### PR TITLE
Bug: LT-1468 - Deactivate users

### DIFF
--- a/organisations/models.py
+++ b/organisations/models.py
@@ -4,6 +4,7 @@ import reversion
 from django.db import models
 
 from addresses.models import Address
+from conf.exceptions import NotFoundError
 from static.countries.models import Country
 
 
@@ -20,6 +21,15 @@ class Organisation(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
     last_modified_at = models.DateTimeField(auto_now_add=True, blank=True)
 
+    def has_user(self, user):
+        from users.models import UserOrganisationRelationship
+        try:
+            user_organisation_relationship = UserOrganisationRelationship.objects.get(user=user,
+                                                                                      organisation=self)
+            return user_organisation_relationship
+        except UserOrganisationRelationship.DoesNotExist:
+            raise NotFoundError({'user': 'User does not belong to this organisation'})
+
 
 @reversion.register()
 class Site(models.Model):
@@ -35,4 +45,5 @@ class ExternalLocation(models.Model):
     name = models.TextField(default=None, blank=False)
     address = models.TextField(default=None, blank=False)
     country = models.ForeignKey(Country, blank=False, null=False, on_delete=models.CASCADE)
-    organisation = models.ForeignKey(Organisation, blank=True, null=True, related_name='external_location', on_delete=models.CASCADE)
+    organisation = models.ForeignKey(Organisation, blank=True, null=True, related_name='external_location',
+                                     on_delete=models.CASCADE)

--- a/organisations/models.py
+++ b/organisations/models.py
@@ -21,7 +21,7 @@ class Organisation(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
     last_modified_at = models.DateTimeField(auto_now_add=True, blank=True)
 
-    def has_user(self, user):
+    def get_user_relationship(self, user):
         from users.models import UserOrganisationRelationship
         try:
             user_organisation_relationship = UserOrganisationRelationship.objects.get(user=user,

--- a/organisations/models.py
+++ b/organisations/models.py
@@ -30,6 +30,17 @@ class Organisation(models.Model):
         except UserOrganisationRelationship.DoesNotExist:
             raise NotFoundError({'user': 'User does not belong to this organisation'})
 
+    def get_users(self):
+        from users.models import UserOrganisationRelationship
+        user_organisation_relationships = UserOrganisationRelationship.objects \
+            .filter(organisation=self) \
+            .order_by('user__first_name')
+
+        for relationship in user_organisation_relationships:
+            relationship.user.status = relationship.status
+
+        return [x.user for x in user_organisation_relationships]
+
 
 @reversion.register()
 class Site(models.Model):

--- a/organisations/tests/tests_users.py
+++ b/organisations/tests/tests_users.py
@@ -4,10 +4,11 @@ from rest_framework.reverse import reverse
 from test_helpers.clients import DataTestClient
 from users.enums import UserStatuses
 from users.libraries.get_user import get_users_from_organisation
+from users.libraries.user_to_token import user_to_token
 from users.models import UserOrganisationRelationship, ExporterUser
 
 
-class OrganisationUsersTests(DataTestClient):
+class OrganisationUsersViewTests(DataTestClient):
 
     def setUp(self):
         super().setUp()
@@ -82,3 +83,41 @@ class OrganisationUsersTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('is already a member of this organisation.', response_data['errors']['email'][0])
         self.assertTrue(len(UserOrganisationRelationship.objects.all()), 1)
+
+
+class OrganisationUsersUpdateTests(DataTestClient):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('organisations:user', kwargs={'org_pk': self.organisation.id,
+                                                         'user_pk': self.exporter_user.id})
+
+    def test_can_deactivate_user(self):
+        """
+        Ensure that a user can be deactivated
+        """
+        exporter_user_2 = self.create_exporter_user(self.organisation)
+        url = reverse('organisations:user', kwargs={'org_pk': self.organisation.id,
+                                                    'user_pk': exporter_user_2.id})
+
+        data = {
+            'status': UserStatuses.DEACTIVATED
+        }
+
+        response = self.client.put(url, data, **self.exporter_headers)
+        exporter_user_2 = self.organisation.get_users()[1]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(exporter_user_2.status, data['status'])
+
+    def test_user_cannot_deactivate_themselves(self):
+        """
+        Ensure that a user can be deactivated
+        """
+        data = {
+            'status': UserStatuses.DEACTIVATED
+        }
+
+        response = self.client.put(self.url, data, **self.exporter_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/organisations/tests/tests_users.py
+++ b/organisations/tests/tests_users.py
@@ -4,7 +4,6 @@ from rest_framework.reverse import reverse
 from test_helpers.clients import DataTestClient
 from users.enums import UserStatuses
 from users.libraries.get_user import get_users_from_organisation
-from users.libraries.user_to_token import user_to_token
 from users.models import UserOrganisationRelationship, ExporterUser
 
 
@@ -28,6 +27,27 @@ class OrganisationUsersViewTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response_data), 1)
         self.assertEqual(response_data[0]['status'], UserStatuses.ACTIVE)
+
+    def test_view_user_belonging_to_organisation(self):
+        """
+        Ensure that a user can see an individual user belonging
+        to an organisation
+        """
+        url = reverse('organisations:user', kwargs={'org_pk': self.organisation.id,
+                                                    'user_pk': self.exporter_user.id})
+
+        response = self.client.get(url, **self.exporter_headers)
+        response_data = response.json()['user']
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_data['status'], UserStatuses.ACTIVE)
+
+
+class OrganisationUsersCreateTests(DataTestClient):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('organisations:users', kwargs={'org_pk': self.organisation.id})
 
     def test_add_user_to_organisation_success(self):
         """

--- a/organisations/tests/tests_users.py
+++ b/organisations/tests/tests_users.py
@@ -3,7 +3,7 @@ from rest_framework.reverse import reverse
 
 from test_helpers.clients import DataTestClient
 from users.enums import UserStatuses
-from users.libraries.get_user import get_users_from_organisation
+from users.libraries.get_user import get_users_from_organisation, get_user_organisation_relationship
 from users.models import UserOrganisationRelationship, ExporterUser
 
 
@@ -125,10 +125,10 @@ class OrganisationUsersUpdateTests(DataTestClient):
         }
 
         response = self.client.put(url, data, **self.exporter_headers)
-        exporter_user_2 = self.organisation.get_users()[1]
+        exporter_user_2_relationship = self.organisation.get_user_relationship(exporter_user_2)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(exporter_user_2.status, data['status'])
+        self.assertEqual(exporter_user_2_relationship.status, data['status'])
 
     def test_user_cannot_deactivate_themselves(self):
         """

--- a/organisations/tests/tests_users.py
+++ b/organisations/tests/tests_users.py
@@ -72,13 +72,12 @@ class OrganisationUsersCreateTests(DataTestClient):
         """
         Ensure that a user can be added to multiple organisations
         """
-        organisation_2 = self.create_organisation()
-        user = get_users_from_organisation(organisation_2)[0]
+        exporter_user_2 = self.create_exporter_user()
 
         data = {
-            'first_name': user.first_name,
-            'last_name': user.last_name,
-            'email': user.email,
+            'first_name': exporter_user_2.first_name,
+            'last_name': exporter_user_2.last_name,
+            'email': exporter_user_2.email,
         }
 
         response = self.client.post(self.url, data, **self.exporter_headers)

--- a/organisations/urls.py
+++ b/organisations/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     # ex: /organisations/<uuid:org_pk>/users/ - View all users for that organisation
     path('<uuid:org_pk>/users/', users.UsersList.as_view(), name='users'),
     # ex: /organisations/<uuid:org_pk>/users/<uuid:user_pk> - View all users for that organisation
-    path('<uuid:org_pk>/users/<uuid:user_pk>', users.UserDetail.as_view(), name='user'),
+    path('<uuid:org_pk>/users/<uuid:user_pk>/', users.UserDetail.as_view(), name='user'),
 
     # ex: /organisations/<uuid:pk>/sites/ - View all sites belonging to an organisation
     path('<uuid:org_pk>/sites/', sites.SitesList.as_view(), name='sites'),

--- a/organisations/urls.py
+++ b/organisations/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
 
     # ex: /organisations/<uuid:org_pk>/users/ - View all users for that organisation
     path('<uuid:org_pk>/users/', users.UsersList.as_view(), name='users'),
+    # ex: /organisations/<uuid:org_pk>/users/<uuid:user_pk> - View all users for that organisation
+    path('<uuid:org_pk>/users/<uuid:user_pk>', users.UserDetail.as_view(), name='user'),
 
     # ex: /organisations/<uuid:pk>/sites/ - View all sites belonging to an organisation
     path('<uuid:org_pk>/sites/', sites.SitesList.as_view(), name='sites'),

--- a/organisations/views/users.py
+++ b/organisations/views/users.py
@@ -56,7 +56,7 @@ class UserDetail(APIView):
         organisation = get_organisation_by_pk(kwargs['org_pk'])
 
         # Set the user's status in that org
-        self.user_relationship = organisation.has_user(self.user)
+        self.user_relationship = organisation.get_user_relationship(self.user)
         self.user.status = self.user_relationship.status
 
         return super(UserDetail, self).dispatch(request, *args, **kwargs)

--- a/organisations/views/users.py
+++ b/organisations/views/users.py
@@ -1,4 +1,4 @@
-from django.http import JsonResponse
+from django.http import JsonResponse, Http404
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.parsers import JSONParser
@@ -6,8 +6,9 @@ from rest_framework.views import APIView
 
 from conf.authentication import SharedAuthentication
 from organisations.libraries.get_organisation import get_organisation_by_pk
-from users.libraries.get_user import get_users_from_organisation
-from users.serializers import ExporterUserViewSerializer, ExporterUserCreateUpdateSerializer
+from users.libraries.get_user import get_users_from_organisation, get_user_by_pk
+from users.serializers import ExporterUserViewSerializer, ExporterUserCreateUpdateSerializer, \
+    UserOrganisationRelationshipSerializer
 
 
 class UsersList(APIView):
@@ -42,3 +43,47 @@ class UsersList(APIView):
 
         return JsonResponse(data={'errors': serializer.errors},
                             status=status.HTTP_400_BAD_REQUEST)
+
+
+class UserDetail(APIView):
+    authentication_classes = (SharedAuthentication,)
+
+    user = None
+    user_relationship = None
+
+    def dispatch(self, request, *args, **kwargs):
+        self.user = get_user_by_pk(kwargs['user_pk'])
+        organisation = get_organisation_by_pk(kwargs['org_pk'])
+
+        # Set the user's status in that org
+        self.user_relationship = organisation.has_user(self.user)
+        self.user.status = self.user_relationship.status
+
+        return super(UserDetail, self).dispatch(request, *args, **kwargs)
+
+    def get(self, request, org_pk, user_pk):
+        """
+        List all users from the specified organisation
+        """
+        view_serializer = ExporterUserViewSerializer(self.user)
+        return JsonResponse(data={'user': view_serializer.data})
+
+    def put(self, request, org_pk, user_pk):
+        """
+        Update the status of a user
+        """
+        data = {'status': request.data['status']}
+
+        # Don't allow a user to update their own status
+        if user_pk == request.user.pk:
+            raise Http404
+
+        serializer = UserOrganisationRelationshipSerializer(instance=self.user_relationship,
+                                                            data=data,
+                                                            partial=True)
+
+        if serializer.is_valid():
+            serializer.save()
+            return JsonResponse(data={'user_relationship': serializer.data})
+
+        return JsonResponse(data={'errors': serializer.errors})

--- a/organisations/views/users.py
+++ b/organisations/views/users.py
@@ -63,7 +63,7 @@ class UserDetail(APIView):
 
     def get(self, request, org_pk, user_pk):
         """
-        List all users from the specified organisation
+        Return a user from the specified organisation
         """
         view_serializer = ExporterUserViewSerializer(self.user)
         return JsonResponse(data={'user': view_serializer.data})

--- a/users/libraries/get_user.py
+++ b/users/libraries/get_user.py
@@ -1,4 +1,5 @@
 from conf.exceptions import NotFoundError
+from organisations.models import Organisation
 from users.models import ExporterUser, GovUser, UserOrganisationRelationship
 
 
@@ -55,3 +56,12 @@ def get_users_from_organisation(pk):
         return [x.user for x in user_organisation_relationships]
     except UserOrganisationRelationship.DoesNotExist:
         raise NotFoundError({'organisation': 'Organisation not found - ' + str(pk)})
+
+
+def get_user_organisation_relationship(user: ExporterUser, organisation: Organisation):
+    try:
+        user_organisation_relationship = UserOrganisationRelationship.objects\
+            .get(user=user, organisation=organisation)
+        return user_organisation_relationship
+    except UserOrganisationRelationship.DoesNotExist:
+        raise NotFoundError({'user_organisation_relationship': 'User Organisation Relationship not found'})

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -2,10 +2,12 @@ from rest_framework import serializers
 
 from cases.models import Notification
 from conf.exceptions import NotFoundError
+from conf.serializers import KeyValueChoiceField
 from gov_users.serializers import RoleSerializer
 from organisations.libraries.get_organisation import get_organisation_by_pk
 from organisations.models import Organisation
 from teams.serializers import TeamSerializer
+from users.enums import UserStatuses
 from users.libraries.get_user import get_user_by_pk, get_exporter_user_by_email
 from users.models import ExporterUser, BaseUser, GovUser, UserOrganisationRelationship
 
@@ -166,3 +168,11 @@ class ExporterUserSimpleSerializer(serializers.ModelSerializer):
                   'first_name',
                   'last_name',
                   'email')
+
+
+class UserOrganisationRelationshipSerializer(serializers.ModelSerializer):
+    status = KeyValueChoiceField(choices=UserStatuses.choices)
+
+    class Meta:
+        model = UserOrganisationRelationship
+        fields = ['status']


### PR DESCRIPTION
On Users on exporter, can no longer deactivate them as the button is no longer there

Steps:
Go to exporter homepage
Click manage my organisation
Click Users
Click on a user other than yourself
Notice there is no deactivate button

Changes
Added endpoints for getting and putting an individual user on an organisation
Added tests for viewing an individual user, as well as updating their status (and preventing their status update too!)