### PR TITLE
bug: LT-2200 - Finalising MOD licence throws an API error

### DIFF
--- a/applications/libraries/licence.py
+++ b/applications/libraries/licence.py
@@ -9,7 +9,8 @@ def get_default_duration(application):
 
     Rules defined in: https://uktrade.atlassian.net/browse/LT-1586
     """
-    if application.case_type.sub_type == CaseTypeSubTypeEnum.EXHIBITION:
+    # MOD clearance application do not have an export type
+    if CaseTypeSubTypeEnum.is_mod_clearance(application.case_type.sub_type):
         return DefaultDuration.TEMPORARY.value
 
     elif application.export_type == ApplicationExportType.TEMPORARY:

--- a/cases/enums.py
+++ b/cases/enums.py
@@ -93,6 +93,18 @@ class CaseTypeSubTypeEnum:
             CaseTypeSubTypeEnum.GIFTING,
         ]
 
+    @classmethod
+    def is_mod_clearance(cls, application_type):
+        """
+        Check if the application type does not use an export type
+        Useful for licence duration
+        """
+        return application_type in [
+            CaseTypeSubTypeEnum.F680,
+            CaseTypeSubTypeEnum.EXHIBITION,
+            CaseTypeSubTypeEnum.GIFTING,
+        ]
+
 
 class CaseTypeEnum:
     class OIEL:


### PR DESCRIPTION
- reason for this being MOD clearance applications (F680, Exhibition and Gifting) not having an export type, so no default licence duration was being returned when the advice was finalised
  - added a check for whether the application type does not use an export type - assigning temporary duration if that's the case

_This is to unblock LT-1168._
Forms part of https://uktrade.atlassian.net/browse/LT-2200 
NOTE: this does not address the finalised advice not showing on the exporter's side bug