### PR TITLE
no jq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
     working_directory: ~/lite-api
 
     steps:
-      - jq/install
 
       - checkout
       - run:


### PR DESCRIPTION
JQ is getting installed for the circle CI run but i cant see any need for it

I\ve removed it and all the circle ci tests pass
https://github.com/stedolan/jq
