### PR TITLE
hotfix: Temp AuditType payload fix

### DIFF
--- a/audit_trail/serializers.py
+++ b/audit_trail/serializers.py
@@ -29,7 +29,7 @@ class AuditSerializer(serializers.ModelSerializer):
 
     def get_text(self, instance):
         try:
-            # TODO: Fix payload enum, replace this.
+            # TODO: Fix payload enum, set as choices on model, remove below.
             verb = AuditType(instance.verb)
         except ValueError:
             verb = AuditType(instance.verb.replace(":", ""))

--- a/audit_trail/serializers.py
+++ b/audit_trail/serializers.py
@@ -28,7 +28,12 @@ class AuditSerializer(serializers.ModelSerializer):
         }
 
     def get_text(self, instance):
-        verb = AuditType(instance.verb)
+        try:
+            # TODO: Fix payload enum, replace this.
+            verb = AuditType(instance.verb)
+        except ValueError:
+            verb = AuditType(instance.verb.replace(":", ""))
+
         payload = deepcopy(instance.payload)
 
         for key in payload:


### PR DESCRIPTION
AuditType. MOVE_CASE value was changed from:
```
moved the case to: {queues}
```
to
```
moved the case to {queues}
```
breaking previous Audits with AuditType. MOVE_CASE.value stored in db.

This is a temporary hotfix which will be replaced with a robust solution in LT-2486
