### PR TITLE
Replace direct settings import with django settings import

### DIFF
--- a/cases/tests/tests_is_recently_updated.py
+++ b/cases/tests/tests_is_recently_updated.py
@@ -4,7 +4,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from conf import settings
+from django.conf import settings
 from static.statuses.enums import CaseStatusEnum
 from test_helpers.clients import DataTestClient
 

--- a/conf/authentication.py
+++ b/conf/authentication.py
@@ -6,7 +6,7 @@ from mohawk import Receiver
 from mohawk.exc import HawkFail, AlreadyProcessed
 from rest_framework import authentication
 
-from conf import settings
+from django.conf import settings
 from conf.exceptions import PermissionDeniedError
 from conf.settings import HAWK_AUTHENTICATION_ENABLED
 from gov_users.enums import GovUserStatuses

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -5,7 +5,7 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
-from conf import settings
+from django.conf import settings
 from conf.settings import ADMIN_ENABLED
 
 api_info = openapi.Info(

--- a/letter_templates/helpers.py
+++ b/letter_templates/helpers.py
@@ -4,7 +4,7 @@ from django.template import Context, Engine, TemplateDoesNotExist
 from django.utils.html import escape
 from markdown import markdown
 
-from conf import settings
+from django.conf import settings
 from conf.exceptions import NotFoundError
 from conf.settings import CSS_ROOT
 from letter_templates.context_generator import get_document_context

--- a/organisations/tests/tests_users.py
+++ b/organisations/tests/tests_users.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from conf import settings
+from django.conf import settings
 from conf.constants import ExporterPermissions
 from test_helpers.clients import DataTestClient
 from users.enums import UserStatuses

--- a/static/control_list_entries/parser.py
+++ b/static/control_list_entries/parser.py
@@ -1,4 +1,4 @@
-from conf import settings
+from django.conf import settings
 from static.control_list_entries.models import ControlListEntry
 
 

--- a/static/management/SeedCommand.py
+++ b/static/management/SeedCommand.py
@@ -7,7 +7,7 @@ from django.db import transaction, models, IntegrityError
 from django.db.models import QuerySet
 from django.test import TestCase
 
-from conf import settings
+from django.conf import settings
 
 
 class SeedCommand(ABC, BaseCommand):

--- a/static/management/commands/seedall.py
+++ b/static/management/commands/seedall.py
@@ -1,6 +1,6 @@
 from django.core.management import call_command
 
-from conf import settings
+from django.conf import settings
 from static.management.SeedCommand import SeedCommand
 
 SEED_COMMANDS = {

--- a/static/management/commands/seedcountries.py
+++ b/static/management/commands/seedcountries.py
@@ -1,6 +1,6 @@
 from django.db import transaction, IntegrityError
 
-from conf import settings
+from django.conf import settings
 from static.countries.models import Country
 from static.management.SeedCommand import SeedCommand
 

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -38,7 +38,7 @@ from cases.enums import AdviceType, CaseDocumentState, CaseTypeEnum, CaseTypeSub
 from cases.generated_documents.models import GeneratedCaseDocument
 from cases.models import CaseNote, Case, CaseDocument, CaseAssignment, GoodCountryDecision, EcjuQuery, CaseType, Advice
 from cases.sla import get_application_target_sla
-from conf import settings
+from django.conf import settings
 from conf.constants import Roles
 from conf.urls import urlpatterns
 from flags.enums import SystemFlags, FlagStatuses, FlagLevels


### PR DESCRIPTION
`from django.conf import settings` is not a file but a class making an abstraction of the concepts, default settings and your site-specific settings.

Django also does other checks when you use from django.conf import settings.

https://docs.djangoproject.com/en/2.2/topics/settings/#using-settings-in-python-code