### PR TITLE
Fix goods on application data migration

### DIFF
--- a/licences/migrations/0011_map_goodonapplication_to_goodonlicence.py
+++ b/licences/migrations/0011_map_goodonapplication_to_goodonlicence.py
@@ -11,12 +11,9 @@ def convert_good_on_application_to_good_on_licence(apps, schema_editor):
     Licence = apps.get_model("licences", "Licence")
 
     for good_on_application in GoodOnApplication.objects.filter(licenced_quantity__isnull=False):
-        licence = Licence.objects.filter(
-            application=good_on_application.application, status=LicenceStatus.ISSUED
-        ).first()
         GoodOnLicence.objects.create(
             good=good_on_application,
-            licence=licence,
+            licence=good_on_application.application.licence.first(),
             usage=good_on_application.usage,
             quantity=good_on_application.licenced_quantity,
             value=good_on_application.licenced_value,


### PR DESCRIPTION
Removing the `status=LicenceStatus.ISSUED`  from the filter so that draft licenced goods are also converted, otherwise the migration fails for draft licences (and we lose data on goods from draft licences)