### PR TITLE
Settings: Allow DEBUG=True if no django_extensions installed

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -336,7 +336,7 @@ SIGNING_LOCATION = env("SIGNING_LOCATION")
 SIGNING_REASON = env("SIGNING_REASON")
 
 # Django Extensions
-if DEBUG:
+if DEBUG and "django_extensions" in sys.modules:
     INSTALLED_APPS.append("django_extensions")
 
     GRAPH_MODELS = {


### PR DESCRIPTION
The dev environments are run with DEBUG=True but we don't install
django_extensions in those environments so the app fails to start.

This only activates django_extensions if it is installed