### PR TITLE
LTD-194: Update version of lite-content subrepo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,6 @@ omit =
     *test*
     .venv/*
 branch = True
+
+plugins =
+    django_coverage_plugin

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ coverage = "~=5.0"
 parameterized = "~=0.7"
 prospector = "==1.1.6.2" #  Our project only works with version 1.1.6.2
 django-extensions = "*"
+django-coverage-plugin = "*"
 
 [packages]
 factory-boy = "~=2.12.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8de513717566c3c62b7243b3e47444d250ee8ec747f480efa3e53263cc1d7dd5"
+            "sha256": "d5b212c2fc97f85cc7df8f502ebc0efca24125244a4be769b9dc017c6b37459d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:8a7aa1da29b7c8039f81798bd27465f29494629c40280a70c2ef0daed5bb7682",
-                "sha256:a2bf58d375ad1b918e6007a46e415721b51dd7bb23703332cc64afa1470b056d"
+                "sha256:b240ac281de363e25a8e1a4c862559d6a056d98dcb9f487fc94d73c6f6599dfc",
+                "sha256:defd1aa0bbc8eb9c3b6aefb5060972447f73a4f1c3ba995ba28d6f0b6b9059dd"
             ],
             "index": "pypi",
-            "version": "==1.14.49"
+            "version": "==1.14.53"
         },
         "botocore": {
             "hashes": [
-                "sha256:4433510d12dc783dd068f39ada942008f5792eea0c569f6b357bb751640c6ab4",
-                "sha256:87326c2d3b68c49a56f2d9237aa47a0476bb9ec6c6bc50d04df8bba66991930c"
+                "sha256:7e0272ceeb7747ed259a392e8d7b624cfd037085a8c59ef2b9f8916e7c556267",
+                "sha256:d37a83ac23257c85c48b74ab81173980234f8fc078e7a9d312d0ee7d057f90e6"
             ],
-            "version": "==1.17.49"
+            "version": "==1.17.53"
         },
         "cairocffi": {
             "hashes": [
@@ -161,11 +161,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:3e2f5d172215862abf2bac3138d8a04229d34dbd2d0dab42c6bf33876cc22323",
-                "sha256:91f540000227eace0504a24f508de26daa756353aa7376c6972d7920bc339a3a"
+                "sha256:62cf45e5ee425c52e411c0742e641a6588b7e8af0d2c274a27940931b2786594",
+                "sha256:83ced795a0f239f41d8ecabf51cc5fad4b97462a6008dc12e5af3cb9288724ec"
             ],
             "index": "pypi",
-            "version": "==2.2.15"
+            "version": "==2.2.16"
         },
         "django-activity-stream": {
             "hashes": [
@@ -778,11 +778,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:09cbc253c827a88064c5ed548d24fb4294568bfe9b1816a857fa5a423d4ce762",
-                "sha256:1d654ac57be9967dae67545fb759f6e7594de07f487c21a276e6466dd52e83f1"
+                "sha256:0af429c221670e602f960fca85ca3f607c85510a91f11e8be8f742a978127f78",
+                "sha256:a088a1054673c6a19ea590045c871c38da029ef743b61a07bfee95e9f3c060f7"
             ],
             "index": "pypi",
-            "version": "==0.17.0"
+            "version": "==0.17.3"
         },
         "six": {
             "hashes": [
@@ -1020,13 +1020,20 @@
             "index": "pypi",
             "version": "==5.2.1"
         },
-        "django-extensions": {
+        "django-coverage-plugin": {
             "hashes": [
-                "sha256:40d4b7aec7bbe66dda8704fbfaf2e1b7e04ec4aea6b10dcbd78d8af7c37bfddb",
-                "sha256:6306175ae8c78c18ea7aff794f5fa3a47de7d128666e6668bd40596895da7f84"
+                "sha256:d53cbf3828fd83d6b89ff7292c6805de5274e36411711692043e67bcde25ae0c"
             ],
             "index": "pypi",
-            "version": "==3.0.5"
+            "version": "==1.8.0"
+        },
+        "django-extensions": {
+            "hashes": [
+                "sha256:0ede618f3d933317737406c979753bb91436c3b3e93a452638a1483b624aa89d",
+                "sha256:b49388a943368417d4c203d51866ca4ffe3011bb240679558521762c4b452b8a"
+            ],
+            "index": "pypi",
+            "version": "==3.0.7"
         },
         "dodgy": {
             "hashes": [
@@ -1119,10 +1126,11 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c",
-                "sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8"
+                "sha256:14bfd98f51c78a3dd22a1ef45cf194ad79eee4a19e8e1a0d5c7f8e81ffe182ea",
+                "sha256:5adc0f9fc64319d8df5ca1e4e06eea674c26b80e6f00c530b18ce6a6592ead15"
             ],
-            "version": "==5.4.5"
+            "markers": "python_version >= '2.6'",
+            "version": "==5.5.0"
         },
         "pep8-naming": {
             "hashes": [
@@ -1148,11 +1156,11 @@
         },
         "pydocstyle": {
             "hashes": [
-                "sha256:08374b9d4d2b7164bae50b71bb24eb0d74a56b309029d5d502264092fa7db0c3",
-                "sha256:4ca3c7736d36f92bb215dd74ef84ac3d6c146edd795c7afc5154c10f1eb1f65a"
+                "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325",
+                "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "pyflakes": {
             "hashes": [
@@ -1274,11 +1282,11 @@
         },
         "stevedore": {
             "hashes": [
-                "sha256:38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5",
-                "sha256:c8f4f0ebbc394e52ddf49de8bcc3cf8ad2b4425ebac494106bbc5e3661ac7633"
+                "sha256:a34086819e2c7a7f86d5635363632829dab8014e5fd7be2454c7cba84ac7514e",
+                "sha256:ddc09a744dc224c84ec8e8efcb70595042d21c97c76df60daee64c9ad53bc7ee"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "toml": {
             "hashes": [

--- a/api/letter_templates/custom_tags.py
+++ b/api/letter_templates/custom_tags.py
@@ -2,7 +2,7 @@ from django import template
 from django.template.defaultfilters import linebreaksbr
 from django.utils.safestring import mark_safe
 
-from lite_content.lite_exporter_frontend import strings as exporter_strings
+from lite_content.lite_api import strings
 
 register = template.Library()
 
@@ -58,7 +58,7 @@ def remove_underscores(value):
     return value.replace("_", " ").title()
 
 
-@register.simple_tag(name="exporter_lcs")
+@register.simple_tag(name="lcs")
 @mark_safe
 def get_exporter_lite_content_string(value):
     """
@@ -87,7 +87,7 @@ def get_exporter_lite_content_string(value):
     path = value.split(".")
     try:
         # Get initial object from strings.py (may return AttributeError)
-        path_object = getattr(exporter_strings, path[0])
+        path_object = getattr(strings, path[0])
         return get(path_object, path[1:]) if len(path) > 1 else path_object
     except AttributeError:
         return STRING_NOT_FOUND_ERROR

--- a/api/letter_templates/layouts/application_form.html
+++ b/api/letter_templates/layouts/application_form.html
@@ -220,13 +220,13 @@
 	{% if goods %}
 		<h2 class="govuk-heading-m">Products</h2>
 		{% for good in goods.all %}
-			<h2 class="govuk-heading-m"> {% exporter_lcs 'goods.GoodsDetailSummary.HEADING' %} {{ forloop.counter }} </h2>
+			<h2 class="govuk-heading-m"> {% lcs 'GoodsDetailSummary.HEADING' %} {{ forloop.counter }} </h2>
 			<dl class="govuk-summary-list" id="good-detail-summary{{ forloop.counter }}">
 {#	goods without an item_category are on open applications, and therefore goodstypes, which allows us to split that logic out #}
 				{% if not good.item_category%}
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs "goods.GoodPage.Table.DESCRIPTION" %}
+							{% lcs "GoodPage.Table.DESCRIPTION" %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.description }}
@@ -234,7 +234,7 @@
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.GoodsDetailSummary.CONTROLLED' %}
+							{% lcs 'GoodsDetailSummary.CONTROLLED' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.is_controlled }} - {{ good.control_list_entries|join:", "|default_na }}
@@ -244,7 +244,7 @@
 				{% else %}
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.GoodsDetailSummary.SELECT_CATEGORY' %}
+							{% lcs 'GoodsDetailSummary.SELECT_CATEGORY' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.item_category }}
@@ -252,7 +252,7 @@
 					</div>
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs "goods.GoodPage.Table.DESCRIPTION" %}
+							{% lcs "GoodPage.Table.DESCRIPTION" %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.description }}
@@ -261,7 +261,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.GoodsDetailSummary.PART_NUMBER' %}
+							{% lcs 'GoodsDetailSummary.PART_NUMBER' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.part_number|default_na }}
@@ -270,7 +270,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.GoodsDetailSummary.CONTROLLED' %}
+							{% lcs 'GoodsDetailSummary.CONTROLLED' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.is_controlled }} - {{ good.control_list_entries|join:", "|default_na }}
@@ -280,7 +280,7 @@
 					{% if good.software_or_technology_details %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs "goods.GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
+								{% lcs "GoodsDetailSummary.PURPOSE_SOFTWARE_TECHNOLOGY" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.software_or_technology_details|default_na }}
@@ -291,7 +291,7 @@
 					{% if good.is_military_use %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodsDetailSummary.MILITARY' %}
+								{% lcs 'GoodsDetailSummary.MILITARY' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.is_military_use }}
@@ -306,7 +306,7 @@
 					{% if good.is_component %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodsDetailSummary.COMPONENT' %}
+								{% lcs 'GoodsDetailSummary.COMPONENT' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.is_component|default_na }}
@@ -321,7 +321,7 @@
 					{% if good.uses_information_security %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
+								{% lcs 'GoodsDetailSummary.DESIGNED_FOR_INFORMATION_SECURITY' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.uses_information_security }}
@@ -336,7 +336,7 @@
 					{% if good.firearm_type %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs "goods.GoodsDetailSummary.FirearmDetails.PRODUCT_TYPE" %}
+								{% lcs "GoodsDetailSummary.FirearmDetails.PRODUCT_TYPE" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.firearm_type|default_na }}
@@ -345,7 +345,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs "goods.GoodsDetailSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
+								{% lcs "GoodsDetailSummary.FirearmDetails.YEAR_OF_MANUFACTURE" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.year_of_manufacture|default_na }}
@@ -354,7 +354,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs "goods.GoodsDetailSummary.FirearmDetails.CALIBRE" %}
+								{% lcs "GoodsDetailSummary.FirearmDetails.CALIBRE" %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.calibre|default_na }}
@@ -364,7 +364,7 @@
 						{% if good.is_covered_by_firearm_act_section_one_two_or_five %}
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">
-									{% exporter_lcs "goods.GoodsDetailSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
+									{% lcs "GoodsDetailSummary.FirearmDetails.COVERED_BY_THE_FIREARMS_ACT_1968" %}
 								</dt>
 								<dd class="govuk-summary-list__value">
 									{% if good.is_covered_by_firearm_act_section_one_two_or_five %}
@@ -381,7 +381,7 @@
 						{% if good.has_identification_markings is not None %}
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">
-									{% exporter_lcs "goods.GoodsDetailSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
+									{% lcs "GoodsDetailSummary.FirearmDetails.IDENTIFICATION_MARKINGS" %}
 								</dt>
 								<dd class="govuk-summary-list__value">
 										{{ good.has_identification_markings }}
@@ -400,7 +400,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.CreateGoodForm.IsGraded.TITLE' %}
+							{% lcs 'CreateGoodForm.IsGraded.TITLE' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.is_pv_graded }}
@@ -410,7 +410,7 @@
 					{% if good.pv_grading.grading %}
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.PREFIX' %}
+								{% lcs 'GoodGradingForm.PREFIX' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.prefix|default_na }}
@@ -419,7 +419,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.GRADING' %}
+								{% lcs 'GoodGradingForm.GRADING' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.grading }}
@@ -428,7 +428,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.SUFFIX' %}
+								{% lcs 'GoodGradingForm.SUFFIX' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.suffix|default_na }}
@@ -437,7 +437,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.ISSUING_AUTHORITY' %}
+								{% lcs 'GoodGradingForm.ISSUING_AUTHORITY' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.issuing_authority }}
@@ -446,7 +446,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.REFERENCE' %}
+								{% lcs 'GoodGradingForm.REFERENCE' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.reference }}
@@ -455,7 +455,7 @@
 
 						<div class="govuk-summary-list__row">
 							<dt class="govuk-summary-list__key">
-								{% exporter_lcs 'goods.GoodGradingForm.DATE_OF_ISSUE' %}
+								{% lcs 'GoodGradingForm.DATE_OF_ISSUE' %}
 							</dt>
 							<dd class="govuk-summary-list__value">
 								{{ good.pv_grading.date_of_issue }}
@@ -465,7 +465,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.GoodsDetailSummary.INCORPORATED' %}
+							{% lcs 'GoodsDetailSummary.INCORPORATED' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.is_incorporated|default_na }}
@@ -474,7 +474,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.AddGoodToApplicationForm.Quantity.TITLE' %}
+							{% lcs 'AddGoodToApplicationForm.Quantity.TITLE' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.applied_for_quantity }}
@@ -483,7 +483,7 @@
 
 					<div class="govuk-summary-list__row">
 						<dt class="govuk-summary-list__key">
-							{% exporter_lcs 'goods.AddGoodToApplicationForm.Value.TITLE' %}
+							{% lcs 'AddGoodToApplicationForm.Value.TITLE' %}
 						</dt>
 						<dd class="govuk-summary-list__value">
 							{{ good.applied_for_value|default_na }}


### PR DESCRIPTION
This commit removes the content for lite-internal and lite-exporter that has
been moved to lite-frontend.

This content is no longer maintained in `lite-content` so to avoid confusion it
has been removed.

Update:
lite-api still relies on lite_exporter_content so I've moved those strings to `lite_api/strings.py` to make sure it continues to work