### PR TITLE
Mark user text as safe to fix underlining

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -49,6 +49,7 @@ django-elasticsearch-dsl-drf = "~=0.20"
 django-elasticsearch-dsl = "~=7.1"
 gunicorn = "~=20.0"
 gevent = "~=20.6"
+bleach = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "bleach": {
+            "hashes": [
+                "sha256:52b5919b81842b1854196eaae5ca29679a2f2e378905c346d3ca8227c2c66080",
+                "sha256:9f8ccbeb6183c6e6cddea37592dfb0167485c1e3b13b3363bc325aa8bda3adbd"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
+        },
         "boto3": {
             "hashes": [
                 "sha256:2bead722a2b91d11faad0479eadf57283c864a40687100d0f5829e6a4242ccb1",

--- a/api/letter_templates/helpers.py
+++ b/api/letter_templates/helpers.py
@@ -1,7 +1,7 @@
 import os
 
 from django.template import Context, Engine, TemplateDoesNotExist
-from django.utils.html import escape
+from django.utils.html import mark_safe
 from markdown import markdown
 
 from django.conf import settings
@@ -62,7 +62,7 @@ def load_css(filename):
 
 
 def format_user_text(user_text):
-    return markdown_to_html(escape(user_text))
+    return markdown_to_html(mark_safe(user_text))
 
 
 def generate_preview(layout: str, text: str, case=None, additional_contact=None, allow_missing_variables=True):

--- a/api/letter_templates/helpers.py
+++ b/api/letter_templates/helpers.py
@@ -1,3 +1,4 @@
+import bleach
 import os
 
 from django.template import Context, Engine, TemplateDoesNotExist
@@ -14,6 +15,7 @@ from lite_content.lite_api import strings
 
 
 CONTENT_PLACEHOLDER = "$USER_CONTENT$"
+ALLOWED_TAGS = ["b", "strong", "em", "u", "h1", "h2", "h3", "h4", "h5", "h6"]
 
 
 def get_letter_template(pk):
@@ -62,7 +64,8 @@ def load_css(filename):
 
 
 def format_user_text(user_text):
-    return markdown_to_html(mark_safe(user_text))
+    cleaned_text = bleach.clean(user_text, tags=ALLOWED_TAGS)
+    return markdown_to_html(mark_safe(cleaned_text))
 
 
 def generate_preview(layout: str, text: str, case=None, additional_contact=None, allow_missing_variables=True):

--- a/api/letter_templates/tests/tests_view.py
+++ b/api/letter_templates/tests/tests_view.py
@@ -1,9 +1,11 @@
+from api.letter_templates.helpers import format_user_text
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from api.cases.enums import AdviceType, CaseTypeReferenceEnum
 from api.cases.enums import CaseTypeSubTypeEnum, CaseTypeEnum
 from api.staticdata.decisions.models import Decision
+from parameterized import parameterized
 from test_helpers.clients import DataTestClient
 
 
@@ -122,3 +124,18 @@ class LetterTemplatesListTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue("text" in response_data)
         self.assertTrue(self.letter_template.letter_paragraphs.first().text in response_data["text"])
+
+    @parameterized.expand(
+        [
+            ("**bold text**", "<p><strong>bold text</strong></p>"),
+            ("_italic text_", "<p><em>italic text</em></p>"),
+            ("<u>underlined text</u>", "<p><u>underlined text</u></p>"),
+            ("<u>**bold** _italic_</u>", "<p><u><strong>bold</strong> <em>italic</em></u></p>"),
+            (
+                "# Heading1\r\n**{{organisation.name}}** {{address}} <u>NOTE:</u>",
+                "<h1>Heading1</h1>\n<p><strong>{{organisation.name}}</strong> {{address}} <u>NOTE:</u></p>",
+            ),
+        ]
+    )
+    def test_format_user_text_in_preview(self, raw_text, formatted):
+        self.assertEqual(format_user_text(raw_text), formatted)

--- a/api/letter_templates/tests/tests_view.py
+++ b/api/letter_templates/tests/tests_view.py
@@ -135,6 +135,7 @@ class LetterTemplatesListTests(DataTestClient):
                 "# Heading1\r\n**{{organisation.name}}** {{address}} <u>NOTE:</u>",
                 "<h1>Heading1</h1>\n<p><strong>{{organisation.name}}</strong> {{address}} <u>NOTE:</u></p>",
             ),
+            ("<script>malicious code</script>", "<p>&lt;script&gt;malicious code&lt;/script&gt;</p>"),
         ]
     )
     def test_format_user_text_in_preview(self, raw_text, formatted):


### PR DESCRIPTION
We are using markdown to render user content in bold, italic and underline but
markdown doesn't support underline so inline html is used in markdown.

The current code escaping html tags, marking it as safe to avoid escaping
underline html tags.