### PR TITLE
Generic Error Views

### DIFF
--- a/api/conf/urls.py
+++ b/api/conf/urls.py
@@ -32,6 +32,9 @@ urlpatterns = [
     path("data-workspace/", include("api.data_workspace.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
+handler500 = "rest_framework.exceptions.server_error"
+handler400 = "rest_framework.exceptions.bad_request"
+
 if settings.LITE_API_ENABLE_ES:
     urlpatterns += (path("search/", include("api.search.urls")),)
 


### PR DESCRIPTION
The API returns a django 500 error page when there is a unhandled error, this
should be a json response instead so this commit tells djagno to use the DRF
provided Generic Error Views https://www.django-rest-framework.org/api-guide/exceptions/#generic-error-views