### PR TITLE
LTD-392 Make sure invalid/null validation works

### DIFF
--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -82,8 +82,17 @@ class FirearmDetailsSerializer(serializers.ModelSerializer):
         error_messages={"null": strings.Goods.FIREARM_GOOD_NO_TYPE},
         required=False,
     )
-    year_of_manufacture = serializers.IntegerField(allow_null=True, required=False)
-    calibre = serializers.CharField(allow_blank=True, required=False)
+    year_of_manufacture = serializers.IntegerField(
+        allow_null=False,
+        required=False,
+        error_messages={
+            "null": strings.Goods.FIREARM_GOOD_NO_YEAR_OF_MANUFACTURE,
+            "invalid": strings.Goods.FIREARM_GOOD_YEAR_MUST_BE_VALID,
+        },
+    )
+    calibre = serializers.CharField(
+        allow_blank=True, required=False, error_messages={"null": strings.Goods.FIREARM_GOOD_NO_CALIBRE,}
+    )
     is_sporting_shotgun = serializers.BooleanField(allow_null=True, required=False)
     is_replica = serializers.BooleanField(allow_null=True, required=False)
     replica_description = serializers.CharField(allow_blank=True, required=False)


### PR DESCRIPTION
Firearms calibre and year of manufacture should error if provided but null,
this doesn't make them required and is just on the serializer so they can be
null if the model is created directly using the model.

corresponding lite-frontend PR: https://github.com/uktrade/lite-frontend/pull/91/files