### PR TITLE
Reset firearm replica description if the product is not a replica

### DIFF
--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -211,7 +211,9 @@ class FirearmDetailsSerializer(serializers.ModelSerializer):
         instance.calibre = validated_data.get("calibre", instance.calibre)
 
         instance.is_replica = validated_data.get("is_replica", instance.is_replica)
-        instance.replica_description = validated_data.get("replica_description", instance.replica_description)
+        instance.replica_description = (
+            validated_data.get("replica_description", instance.replica_description) if instance.is_replica else ""
+        )
 
         is_covered_by_firearms_act = validated_data.get("is_covered_by_firearm_act_section_one_two_or_five")
         # if the answer to the firearms act has changed, then set the new value and the certificate and date fields

--- a/api/goods/tests/tests_edit.py
+++ b/api/goods/tests/tests_edit.py
@@ -373,6 +373,32 @@ class GoodsEditDraftGoodTests(DataTestClient):
         # 2 due to creating a new good for this test
         self.assertEquals(Good.objects.all().count(), 2)
 
+    def test_edit_category_two_firearm_replica(self):
+        good = self.create_good(
+            "a good", self.organisation, item_category=ItemCategory.GROUP2_FIREARMS, create_firearm_details=True
+        )
+
+        url = reverse("goods:good_details", kwargs={"pk": str(good.id)})
+        request_data = {
+            "firearm_details": {"type": "firearms", "is_replica": True, "replica_description": "Yes this is a replica"}
+        }
+        response = self.client.put(url, request_data, **self.exporter_headers)
+        good = response.json()["good"]
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(good["firearm_details"]["is_replica"], True)
+        self.assertEquals(good["firearm_details"]["replica_description"], "Yes this is a replica")
+
+        request_data = {"firearm_details": {"type": "firearms", "is_replica": False}}
+        response = self.client.put(url, request_data, **self.exporter_headers)
+        good = response.json()["good"]
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(good["firearm_details"]["is_replica"], False)
+        self.assertEquals(good["firearm_details"]["replica_description"], "")
+        # 2 due to creating a new good for this test
+        self.assertEquals(Good.objects.all().count(), 2)
+
     def test_edit_category_two_section_question_and_details_success(self):
         good = self.create_good(
             "a good", self.organisation, item_category=ItemCategory.GROUP2_FIREARMS, create_firearm_details=True


### PR DESCRIPTION
## Change description

When we specify a firearm product is a replica then we need to provide
description. If we edit and change the status to not a replica then
description was not removed, this change resets this.