### PR TITLE
LTD-319: Digital signature text in licence template mismatch

### DIFF
--- a/api/cases/generated_documents/helpers.py
+++ b/api/cases/generated_documents/helpers.py
@@ -60,7 +60,11 @@ def get_generated_document_data(request_params, pk):
     except LetterTemplate.DoesNotExist:
         raise NotFoundError({"letter_template": strings.Cases.GeneratedDocuments.LETTER_TEMPLATE_NOT_FOUND})
     document_html = generate_preview(
-        layout=template.layout.filename, text=text, case=case, additional_contact=additional_contact
+        layout=template.layout.filename,
+        text=text,
+        case=case,
+        additional_contact=additional_contact,
+        include_digital_signature=template.include_digital_signature,
     )
 
     if "error" in document_html:

--- a/api/goods/tests/tests_edit.py
+++ b/api/goods/tests/tests_edit.py
@@ -1,3 +1,6 @@
+from datetime import timedelta
+
+from django.utils.timezone import now
 from parameterized import parameterized
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -405,11 +408,12 @@ class GoodsEditDraftGoodTests(DataTestClient):
         )
 
         url = reverse("goods:good_details", kwargs={"pk": str(good.id)})
+        future_expiry_date = (now() + timedelta(days=365)).date().isoformat()
         request_data = {
             "firearm_details": {
                 "is_covered_by_firearm_act_section_one_two_or_five": "True",
                 "section_certificate_number": "ABC123",
-                "section_certificate_date_of_expiry": "2020-12-12",
+                "section_certificate_date_of_expiry": future_expiry_date,
             }
         }
 
@@ -420,7 +424,7 @@ class GoodsEditDraftGoodTests(DataTestClient):
         # created good is set as 'ammunition' type
         self.assertTrue(good["firearm_details"]["is_covered_by_firearm_act_section_one_two_or_five"])
         self.assertEquals(good["firearm_details"]["section_certificate_number"], "ABC123")
-        self.assertEquals(good["firearm_details"]["section_certificate_date_of_expiry"], "2020-12-12")
+        self.assertEquals(good["firearm_details"]["section_certificate_date_of_expiry"], future_expiry_date)
         # 2 due to creating a new good for this test
         self.assertEquals(Good.objects.all().count(), 2)
 

--- a/api/letter_templates/helpers.py
+++ b/api/letter_templates/helpers.py
@@ -68,7 +68,14 @@ def format_user_text(user_text):
     return markdown_to_html(mark_safe(cleaned_text))
 
 
-def generate_preview(layout: str, text: str, case=None, additional_contact=None, allow_missing_variables=True):
+def generate_preview(
+    layout: str,
+    text: str,
+    case=None,
+    additional_contact=None,
+    allow_missing_variables=True,
+    include_digital_signature=False,
+):
     try:
         django_engine = template_engine_factory(allow_missing_variables)
         template = django_engine.get_template(f"{layout}.html")
@@ -80,9 +87,9 @@ def generate_preview(layout: str, text: str, case=None, additional_contact=None,
             template = template_text.replace(CONTENT_PLACEHOLDER, text)
             template = django_engine.from_string(template)
 
-        context = {}
+        context = {"include_digital_signature": include_digital_signature}
         if case:
-            context = get_document_context(case, additional_contact)
+            context = {**context, **get_document_context(case, additional_contact)}
 
         return load_css(layout) + template.render(Context(context))
     except (FileNotFoundError, TemplateDoesNotExist):

--- a/api/letter_templates/layouts/siel.html
+++ b/api/letter_templates/layouts/siel.html
@@ -194,7 +194,7 @@
       <tr class="page-break-after">
         <td class="border-black" colspan="11">
           <span class="cell__heading">Digital Signature</span>
-          <span class="cell__uppercase">This document does not have a digital signature</span>
+          <span class="cell__uppercase">This document {{ include_digital_signature|yesno:"does,does not" }} have a digital signature</span>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
The text in the licence template was hard coded and therefore wouldn't match the
"include_digital_signature" boolean set by the user when creating the template.

This change passes the value to the part where the template is generated so it
can be correctly displayed.