### PR TITLE
Exclude revoked denials already in ES

### DIFF
--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -18,6 +18,7 @@ class DenialDocumentType(Document):
     address = fields.TextField()
     reference = fields.KeywordField()
     data = DataField()
+    is_revoked = fields.BooleanField()
 
     class Index:
         name = settings.ELASTICSEARCH_DENIALS_INDEX_ALIAS
@@ -32,6 +33,3 @@ class DenialDocumentType(Document):
 
     class Django:
         model = models.Denial
-
-    def get_indexing_queryset(self):
-        return self.get_queryset().exclude(is_revoked=True)

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -2,8 +2,9 @@ import os
 
 from test_helpers.clients import DataTestClient
 
+from django.core.management import call_command
 from django.conf import settings
-
+from django.test import override_settings
 from django.urls import reverse
 
 from api.external_data import models
@@ -87,3 +88,31 @@ class DenialViewSetTests(DataTestClient):
                 }
             },
         )
+
+
+class DenialSearchView(DataTestClient):
+    @override_settings(ELASTICSEARCH_DENIALS_INDEX_ALIAS="denials-alias-test")
+    def test_search(self):
+        call_command("search_index", models=["external_data.denial"], action="rebuild", force=True)
+        # given some denials exist
+        url = reverse("external_data:denial-list")
+        file_path = os.path.join(settings.BASE_DIR, "external_data/tests/denial_valid.csv")
+        with open(file_path, "rb") as f:
+            content = f.read()
+        response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(models.Denial.objects.count(), 3)
+
+        # and one of them is revoked
+
+        denial = models.Denial.objects.first()
+        denial.is_revoked = True
+        denial.save()
+
+        # then only 2 denials will be returned when searching
+        url = reverse("external_data:denial_search-list")
+
+        response = self.client.get(url, {"search": "Example"}, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["hits"]["hits"]), 2)

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -35,3 +35,7 @@ class DenialSearchView(DocumentViewSet):
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         return Response(queryset.execute().to_dict())
+
+    def filter_queryset(self, queryset):
+        queryset = queryset.filter("term", is_revoked=False)
+        return super().filter_queryset(queryset)


### PR DESCRIPTION
Currently we only filter out revoked denials on index create, but do not handle when denials have been revoked after tehy area already indexed.

![denials-filtered](https://user-images.githubusercontent.com/5485798/104907853-9e817380-597d-11eb-8714-83bf567297b6.gif)
