### PR TITLE
[LTD-699] SIEL cover letter

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -227,6 +227,13 @@ class Case(TimestampableModel):
                 verb=AuditType.REMOVE_CASE_FROM_ALL_USER_ASSIGNMENTS, action_object=case,
             )
 
+    def get_case_officer_name(self):
+        """
+        Returns the name of the case officer
+        """
+        if self.case_officer:
+            return self.case_officer.baseuser_ptr.get_full_name()
+
 
 class CaseAssignmentSla(models.Model):
     sla_days = models.IntegerField()

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -898,6 +898,7 @@ def get_document_context(case, addressee=None):
 
     return {
         "case_reference": case.reference_code,
+        "case_officer_name": case.get_case_officer_name(),
         "case_type": CaseTypeSerializer(case.case_type).data,
         "current_date": date,
         "current_time": time,

--- a/api/letter_templates/templates/letter_templates/ecju.html
+++ b/api/letter_templates/templates/letter_templates/ecju.html
@@ -2,8 +2,8 @@
 
 <div class="document">
   <p id="references">
-    Our Ref: TBC<br>
-    Your Ref: TBC<br>
+    Our Ref: {{ case_reference }}<br>
+    Your Ref: {{ details.user_reference }}<br>
     SPIRE Doc Ref:PREVIEW
   </p>
   <img src="{% static 'images/dit.png' %}">

--- a/api/letter_templates/templates/letter_templates/ecju.html
+++ b/api/letter_templates/templates/letter_templates/ecju.html
@@ -22,6 +22,7 @@
       <p>Date: {% now "jS F Y" %}</p>
     </div>
     <div id="sender-address">
+      <p>{{ case_officer_name }}</p>
       <p>Export Control Organisation</p>
       <p>
         3 Whitehall Place<br>

--- a/api/letter_templates/tests/tests_context_generation.py
+++ b/api/letter_templates/tests/tests_context_generation.py
@@ -389,6 +389,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self.assertIsNotNone(context["current_date"])
         self.assertIsNotNone(context["current_time"])
         self._assert_applicant(context["addressee"], case)
@@ -415,6 +416,7 @@ class DocumentContextGenerationTests(DataTestClient):
         context = get_document_context(case, addressee=addressee)
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_addressee(context["addressee"], addressee)
 
     def test_generate_context_with_goods(self):
@@ -424,6 +426,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_good(context["goods"]["all"][0], case.goods.all()[0])
 
     def test_generate_context_with_advice_on_goods(self):
@@ -440,6 +443,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_good_with_advice(context["goods"], final_advice, case.goods.all()[0])
 
     def test_generate_context_with_proviso_advice_on_goods(self):
@@ -456,6 +460,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_good_with_advice(context["goods"], final_advice, case.goods.all()[0])
         self.assertEqual(context["goods"][AdviceType.APPROVE][0]["proviso_reason"], final_advice.proviso)
 
@@ -496,6 +501,7 @@ class DocumentContextGenerationTests(DataTestClient):
         context = get_document_context(case)
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
 
         # All goods types should be in all
         self.assertEqual(len(context["goods"]["all"]), 3)
@@ -539,6 +545,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_licence(context["licence"], licence)
         self._assert_good_on_licence(context["goods"]["approve"][0], good_on_licence)
 
@@ -553,6 +560,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_ecju_query(context["ecju_queries"][0], ecju_query)
 
     def test_generate_context_with_case_note(self):
@@ -563,6 +571,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_note(context["notes"][0], note)
 
     def test_generate_context_with_site(self):
@@ -573,6 +582,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_site(context["sites"][0], site)
 
     def test_generate_context_with_external_locations(self):
@@ -584,6 +594,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_external_location(context["external_locations"][0], location)
 
     def test_generate_context_with_document(self):
@@ -593,6 +604,7 @@ class DocumentContextGenerationTests(DataTestClient):
         context = get_document_context(case)
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_document(context["documents"][0], document)
 
     def test_generate_context_with_application_details(self):
@@ -615,6 +627,7 @@ class DocumentContextGenerationTests(DataTestClient):
         context = get_document_context(case)
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_base_application_details(context["details"], case)
 
     def test_generate_context_with_standard_application_details(self):
@@ -634,6 +647,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
         self._assert_base_application_details(context["details"], case)
         self._assert_standard_application_details(context["details"], case)
@@ -658,6 +672,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
         self._assert_base_application_details(context["details"], case)
         self._assert_open_application_details(context["details"], case)
@@ -670,6 +685,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
         self._assert_hmrc_query_details(context["details"], case)
 
@@ -686,6 +702,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
         self._assert_exhibition_clearance_details(context["details"], case)
         self._assert_good(context["goods"]["all"][0], good)
@@ -710,6 +727,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
         self._assert_f680_clearance_details(context["details"], case)
 
@@ -720,6 +738,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_case_type_details(context["case_type"], case)
 
     def test_generate_context_with_end_user_advisory_query_details(self):
@@ -729,6 +748,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_end_user_advisory_details(context["details"], case)
 
     def test_generate_context_with_goods_query_details(self):
@@ -738,6 +758,7 @@ class DocumentContextGenerationTests(DataTestClient):
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["case_reference"], case.reference_code)
+        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
         self._assert_goods_query_details(context["details"], case)
 
     def test_generate_context_with_compliance_visit_details(self):


### PR DESCRIPTION
## [LTD-699](https://uktrade.atlassian.net/browse/LTD-699) Gov - I want to generate a licence covering letter

There are 2 parts to this -

1. Include references in the letter 8a12422e90f9bdf09e8c06c8f3d53215b6f624a2
2. Include case officer's name in the letter 8a12422e90f9bdf09e8c06c8f3d53215b6f624a2

In order to do (2), I had to do some digging into the models.

After these changes, we should be able to generate the letter specified in the ticket using LITE.

P.S. I have changed the standard ECJU letter template. This should be ok for the references but I am not sure about the case officer's name. LMK if there are any issues with this. 