### PR TITLE
LTD-745 API errors

### DIFF
--- a/api/cases/generated_documents/tests/test_generate_document.py
+++ b/api/cases/generated_documents/tests/test_generate_document.py
@@ -294,6 +294,17 @@ class GenerateDocumentTests(DataTestClient):
         html_to_pdf_func.assert_not_called()
         upload_bytes_file_func.assert_not_called()
 
+    def test_get_document_preview_when_get_html_contains_error_string(self):
+        url = (
+            reverse("cases:generated_documents:preview", kwargs={"pk": str(self.case.pk)})
+            + "?template="
+            + str(self.letter_template.id)
+            + "&text=This text contains the string - error"
+        )
+
+        response = self.client.get(url, **self.gov_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 class GetGeneratedDocumentsTests(DataTestClient):
     def setUp(self):

--- a/api/core/helpers.py
+++ b/api/core/helpers.py
@@ -46,7 +46,7 @@ def date_to_drf_date(date):
     suitable for comparison to rest framework datetimes
     """
     date = timezone.localtime(date)
-    return date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    return date.isoformat()
 
 
 def friendly_boolean(boolean):

--- a/api/letter_templates/helpers.py
+++ b/api/letter_templates/helpers.py
@@ -71,6 +71,10 @@ def format_user_text(user_text):
     return markdown_to_html(mark_safe(cleaned_text))
 
 
+class DocumentPreviewError(Exception):
+    pass
+
+
 def generate_preview(
     layout: str,
     text: str,
@@ -96,4 +100,4 @@ def generate_preview(
 
         return load_css(layout) + template.render(Context(context))
     except (FileNotFoundError, TemplateDoesNotExist):
-        return {"error": strings.LetterTemplates.PREVIEW_ERROR}
+        raise DocumentPreviewError(strings.LetterTemplates.PREVIEW_ERROR)


### PR DESCRIPTION
This bug resulted from a lack of exception handling and was exacerbated by the poor code that looked for `error` in a string. 

In that, if a user puts `error` in the form for customising the text, not only did the API incorrectly thought there was an error in generating the document but in trying to find that (nonexistent) error, ran into a real `KeyError`.