### PR TITLE
LTD-776: Include good name in the data sent to lite-hmrc service

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -343,6 +343,10 @@ class GoodOnApplication(AbstractGoodOnApplication):
         ordering = ["created_at"]
 
     @property
+    def name(self):
+        return self.good.name
+
+    @property
     def description(self):
         return self.good.description
 

--- a/api/licences/serializers/hmrc_integration.py
+++ b/api/licences/serializers/hmrc_integration.py
@@ -49,6 +49,7 @@ class HMRCIntegrationEndUserSerializer(serializers.Serializer):
 class HMRCIntegrationGoodOnLicenceSerializer(serializers.Serializer):
     id = serializers.UUIDField(source="good.good.id")
     usage = serializers.FloatField()
+    name = serializers.CharField(source="good.good.name")
     description = serializers.CharField(source="good.good.description")
     unit = serializers.CharField(source="good.unit")
     quantity = serializers.FloatField()


### PR DESCRIPTION
## Change description

Currently we use description in the licence line in edifact file sent to HMRC but it is made optional so it can be empty however
this is a mandatory field in the edifact file so use mandatory field "name" instead.