### PR TITLE
LTD-765: Ignore case when looking for ExporterUser using email

### DIFF
--- a/api/users/tests/tests_create_exporter.py
+++ b/api/users/tests/tests_create_exporter.py
@@ -49,3 +49,18 @@ class CreateExporterUser(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ExporterUser.objects.count(), previous_user_count)
+
+    def test_create_exporter_uppercase_email(self):
+        previous_user_count = ExporterUser.objects.count()
+        data = {
+            "email": "TESTEXPORTER@email.com",
+            "phone_number": "+447812346820",
+            "sites": [str(self.site.id)],
+            "role": Roles.EXPORTER_DEFAULT_ROLE_ID,
+        }
+
+        response = self.client.post(self.url, data, **self.exporter_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(ExporterUser.objects.count(), previous_user_count + 1)
+        self.assertEqual(ExporterUser.objects.filter(baseuser_ptr__email__iexact=data["email"].lower()).count(), 1)

--- a/api/users/tests/tests_exporter_authentication.py
+++ b/api/users/tests/tests_exporter_authentication.py
@@ -38,3 +38,22 @@ class ExporterUserAuthenticateTests(DataTestClient):
 
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authentication_with_email_in_uppercase(self):
+        data = {
+            "email": self.exporter_user.email.upper(),
+            "user_profile": {"first_name": "Matt", "last_name": "Berninger"},
+        }
+
+        response = self.client.post(self.url, data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = {
+            "HTTP_EXPORTER_USER_TOKEN": response_data["token"],
+            "HTTP_ORGANISATION_ID": str(self.organisation.id),
+        }
+
+        response = self.client.get(reverse("goods:goods"), **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -64,7 +64,7 @@ class AuthenticateExporterUser(APIView):
             )
 
         try:
-            user = ExporterUser.objects.get(baseuser_ptr__email=data.get("email"))
+            user = ExporterUser.objects.get(baseuser_ptr__email__iexact=data.get("email"))
             # Update the user's first and last names
             user.baseuser_ptr.first_name = first_name
             user.baseuser_ptr.last_name = last_name


### PR DESCRIPTION
## Change description

If the user uses email in uppercase when registering an organisation then it
is saved as lower case when saving the BaseUser instance because of this we
fail to authenticate the user when logged in with the email in upper case.
Fix this by ignoring the case when looking for the exporter.

Add a test that ensures user can be authenticated by using email in uppercase.