### PR TITLE
Emit audit logs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -62,7 +62,7 @@ pyexcel-ods3 = "*"
 Pillow = ">8.1.0,<8.2"
 django-phonenumber-field = "==5.0.0"
 phonenumbers = "~=8.12"
-django-log-formatter-ecs = "*"
+django-log-formatter-ecs = "==0.0.5"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -62,6 +62,7 @@ pyexcel-ods3 = "*"
 Pillow = ">8.1.0,<8.2"
 django-phonenumber-field = "==5.0.0"
 phonenumbers = "~=8.12"
+django-log-formatter-ecs = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "37d5c0f59fa37ea9f839eda9c3dd9e0b1d50a7e7fa140e84918007cc0fa01a41"
+            "sha256": "65e9b0453259dce60f512e684f83dd6507d1a4bc4c883a58d46d89a251d07613"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:5d62261ceb8e5b8fd4df1b91464a9000550d4caa454241794fa126c6e04d5b69",
-                "sha256:f7447d84c3e1381bb3cc61ceb360dab47e91ebd133725dbd6d98946f11e234d3"
+                "sha256:2783947ec34dd84fc36093e8fc8a9a24679cf912a97bc9a0c47f4966ed059a29",
+                "sha256:6b4a79691a48740816f03c4cb1e8ef46f8335ad2019d9c4a95da73eb5cb98f05"
             ],
             "index": "pypi",
-            "version": "==1.17.50"
+            "version": "==1.17.57"
         },
         "botocore": {
             "hashes": [
-                "sha256:a621a4bf60a1197c7ebd8ed0badac8282e36e0cee7241831a099200983ff7c49",
-                "sha256:f6c2bfae21eaa4e4f75fc5f48b22b16831356755bfb58516219ee11d74070220"
+                "sha256:ae4ac72921f23d35ad54a5fb0989fc00c6fff8a39e24f26128b9315cc6209fec",
+                "sha256:fa430bc773363a3d332c11c55bd8c0c0a5819d576121eb6990528a1bdaa89bcd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.50"
+            "version": "==1.20.57"
         },
         "cairocffi": {
             "hashes": [
@@ -201,11 +201,11 @@
         },
         "django-elasticsearch-dsl": {
             "hashes": [
-                "sha256:5bbd49a9acb51c08fbbb7fba9beee7c9ce73b481af718cc57e4c8ac3d561888f",
-                "sha256:e733ccfd0e8b83ad6896d812a2c15ccbd563caf4ebf30fd31640538ad2de8e26"
+                "sha256:865f9f0d6aa24c923c2cc791b35f608c85cfe766edc8920d00854ced452c326a",
+                "sha256:f9163ffe314a0562f00789d34cc923332e1d51236bf7d5a38bfa8ea72399ceac"
             ],
             "index": "pypi",
-            "version": "==7.1.4"
+            "version": "==7.2.0"
         },
         "django-elasticsearch-dsl-drf": {
             "hashes": [
@@ -225,11 +225,17 @@
         },
         "django-health-check": {
             "hashes": [
-                "sha256:a6aa6ea423eae4fd0665f6372b826af1ed20dfc3e88cf52789d0b49cfb64969c",
-                "sha256:d0628ffc11aee7e62e73b58ff39179ea2a9ca5abfbc92cb345ceca268593dd71"
+                "sha256:334bcbbb9273a6dbd9c928e78474306e623dfb38cc442281cb9fd230a20a7fdb",
+                "sha256:86a8869d67e72394a1dd73e37819a7d2cfd915588b96927fda611d7451fd4735"
             ],
             "index": "pypi",
-            "version": "==3.16.3"
+            "version": "==3.16.4"
+        },
+        "django-ipware": {
+            "hashes": [
+                "sha256:c7df8e1410a8e5d6b1fbae58728402ea59950f043c3582e033e866f0f0cf5e94"
+            ],
+            "version": "==3.0.2"
         },
         "django-jsonfield": {
             "hashes": [
@@ -238,6 +244,14 @@
             ],
             "index": "pypi",
             "version": "==1.4.1"
+        },
+        "django-log-formatter-ecs": {
+            "hashes": [
+                "sha256:1e8731dd25a11ac64e789f19931e12fe7ef8ad1a172b7bceb2ea5cab185a583e",
+                "sha256:6b9784fe31eb1bd6598dc7db0f7f647e03ea6c3926c73cd1c9221adefee289ad"
+            ],
+            "index": "pypi",
+            "version": "==0.0.5"
         },
         "django-model-utils": {
             "hashes": [
@@ -352,9 +366,11 @@
         },
         "et-xmlfile": {
             "hashes": [
-                "sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b"
+                "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c",
+                "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"
             ],
-            "version": "==1.0.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.0"
         },
         "factory-boy": {
             "hashes": [
@@ -483,11 +499,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6",
-                "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"
+                "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581",
+                "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.1"
+            "version": "==4.0.1"
         },
         "jdcal": {
             "hashes": [
@@ -503,6 +519,13 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
+        },
+        "kubi-ecs-logger": {
+            "hashes": [
+                "sha256:284d98b10b9dda68e6e6e23bc39758417a55430f5696422216ed3ac640242a94"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==0.1.0"
         },
         "lml": {
             "hashes": [
@@ -560,6 +583,14 @@
             ],
             "index": "pypi",
             "version": "==3.3.4"
+        },
+        "marshmallow": {
+            "hashes": [
+                "sha256:35ee2fb188f0bd9fc1cf9ac35e45fd394bd1c153cee430745a465ea435514bd5",
+                "sha256:9aa20f9b71c992b4782dad07c51d92884fd0f7c5cb9d3c737bea17ec1bad765f"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.6.1"
         },
         "mohawk": {
             "hashes": [
@@ -806,10 +837,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:5d48b1fd2232141a9d5fb279709117aaba506cacea7f86f11bc392f06bfa8fc2",
-                "sha256:c5dadf598762899d8cfaecf68eba649cd25b0ce93b6c954b156aaa3eed160547"
+                "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc",
+                "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"
             ],
-            "version": "==0.3.6"
+            "version": "==0.4.2"
         },
         "sentry-sdk": {
             "hashes": [
@@ -938,60 +969,60 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:02d3535aa18e34ce97c58d241120b7554f7d1cf4f8002fc9675cc7e7745d20e8",
-                "sha256:0378a42ec284b65706d9ef867600a4a31701a0d6773434e6537cfc744e3343f4",
-                "sha256:07d289358a8c565ea09e426590dd1179f93cf5ac3dd17d43fcc4fc63c1a9d275",
-                "sha256:0e6cdbdd94ae94d1433ab51f46a76df0f2cd041747c31baec1c1ffa4e76bd0c1",
-                "sha256:11354fb8b8bdc5cdd66358ed4f1f0ce739d78ff6d215d33b8f3ae282258c0f11",
-                "sha256:12588a46ae0a99f172c4524cbbc3bb870f32e0f8405e9fa11a5ef3fa3a808ad7",
-                "sha256:16caa44a06f6b0b2f7626ced4b193c1ae5d09c1b49c9b4962c93ae8aa2134f55",
-                "sha256:18c478b89b6505756f007dcf76a67224a23dcf0f365427742ed0c0473099caa4",
-                "sha256:221b41442cf4428fcda7fc958c9721c916709e2a3a9f584edd70f1493a09a762",
-                "sha256:26109c50ccbcc10f651f76277cfc05fba8418a907daccc300c9247f24b3158a2",
-                "sha256:28d8157f8c77662a1e0796a7d3cfa8910289131d4b4dd4e10b2686ab1309b67b",
-                "sha256:2c51689b7b40c7d9c7e8a678350e73dc647945a13b4e416e7a02bbf0c37bdb01",
-                "sha256:2ec58e1e1691dde4fbbd97f8610de0f8f1b1a38593653f7d3b8e931b9cd6d67f",
-                "sha256:416feb6500f7b6fc00d32271f6b8495e67188cb5eb51fc8e289b81fdf465a9cb",
-                "sha256:520352b18adea5478bbf387e9c77910a914985671fe36bc5ef19fdcb67a854bc",
-                "sha256:527415b5ca201b4add44026f70278fbc0b942cf0801a26ca5527cb0389b6151e",
-                "sha256:54243053316b5eec92affe43bbace7c8cd946bc0974a4aa39ff1371df0677b22",
-                "sha256:61b8454190b9cc87279232b6de28dee0bad040df879064bb2f0e505cda907918",
-                "sha256:672668729edcba0f2ee522ab177fcad91c81cfce991c24d8767765e2637d3515",
-                "sha256:67aa26097e194947d29f2b5a123830e03da1519bcce10cac034a51fcdb99c34f",
-                "sha256:6e7305e42b5f54e5ccf51820de46f0a7c951ba7cb9e3f519e908545b0f5628d0",
-                "sha256:7234ac6782ca43617de803735949f79b894f0c5d353fbc001d745503c69e6d1d",
-                "sha256:7426bea25bdf92f00fa52c7b30fcd2a2f71c21cf007178971b1f248b6c2d3145",
-                "sha256:74b331c5d5efdddf5bbd9e1f7d8cb91a0d6b9c4ba45ca3e9003047a84dca1a3b",
-                "sha256:79b6db1a18253db86e9bf1e99fa829d60fd3fc7ac04f4451c44e4bdcf6756a42",
-                "sha256:7d79cd354ae0a033ac7b86a2889c9e8bb0bb48243a6ed27fc5064ce49b842ada",
-                "sha256:823d1b4a6a028b8327e64865e2c81a8959ae9f4e7c9c8e0eec814f4f9b36b362",
-                "sha256:8715717a5861932b7fe7f3cbd498c82ff4132763e2fea182cc95e53850394ec1",
-                "sha256:89a6091f2d07936c8a96ce56f2000ecbef20fb420a94845e7d53913c558a6378",
-                "sha256:8af4b3116e4a37059bc8c7fe36d4a73d7c1d8802a1d8b6e549f1380d13a40160",
-                "sha256:8b4b0034e6c7f30133fa64a1cc276f8f1a155ef9529e7eb93a3c1728b40c0f5c",
-                "sha256:92195df3913c1de80062635bf64cd7bd0d0934a7fa1689b6d287d1cbbd16922c",
-                "sha256:96c2e68385f3848d58f19b2975a675532abdb65c8fa5f04d94b95b27b6b1ffa7",
-                "sha256:9c7044dbbf8c58420a9ef4ed6901f5a8b7698d90cd984d7f57a18c78474686f6",
-                "sha256:a1937efed7e3fe0ee74630e1960df887d8aa83c571e1cf4db9d15b9c181d457d",
-                "sha256:a38c10423a475a1658e2cb8f52cf84ec20a4c0adff724dd43a6b45183f499bc1",
-                "sha256:a413c424199bcbab71bf5fa7538246f27177fbd6dd74b2d9c5f34878658807f8",
-                "sha256:b18a855f8504743e0a2d8b75d008c7720d44e4c76687e13f959e35d9a13eb397",
-                "sha256:b4d59ab3608538e550a72cea13d3c209dd72b6e19e832688da7884081c01594e",
-                "sha256:b51d3f1cd87f488455f43046d72003689024b0fa9b2d53635db7523033b19996",
-                "sha256:c02105deda867d09cdd5088d08708f06d75759df6f83d8f7007b06f422908a30",
-                "sha256:c7b6032dc4490b0dcaf078f09f5b382dc35493cb7f473840368bf0de3196c2b6",
-                "sha256:c95b355dba2aaf5177dff943b25ded0529a7feb80021d5fdb114a99f0a1ef508",
-                "sha256:c980ae87863d76b1ea9a073d6d95554b4135032d34bc541be50c07d4a085821b",
-                "sha256:d12895cd083e35e9e032eb4b57645b91116f8979527381a8d864d1f6b8cb4a2e",
-                "sha256:d3cd9bad547a8e5fbe712a1dc1413aff1b917e8d39a2cd1389a6f933b7a21460",
-                "sha256:e8809b01f27f679e3023b9e2013051e0a3f17abff4228cb5197663afd8a0f2c7",
-                "sha256:f3c37b0dc1898e305aad4f7a1d75f6da83036588c28a9ce0afc681ff5245a601",
-                "sha256:f966765f54b536e791541458de84a737a6adba8467190f17a8fe7f85354ba908",
-                "sha256:fa939c2e2468142c9773443d4038e7c915b0cc1b670d3c9192bdc503f7ea73e9",
-                "sha256:fcc5c1f95102989d2e116ffc8467963554ce89f30a65a3ea86a4d06849c498d8"
+                "sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192",
+                "sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702",
+                "sha256:0cba8477e300d64a11a9789ed40ee8932b59f9ee05f85276dbb4b59acee5dd09",
+                "sha256:0cee5187b60ed26d56eb2960136288ce91bcf61e2a9405660d271d1f122a69a4",
+                "sha256:0ea1d73b7c9dcbc5080bb8aaffb776f1c68e807767069b9ccdd06f27a161914a",
+                "sha256:0f91b5b948686659a8e28b728ff5e74b1be6bf40cb04704453617e5f1e945ef3",
+                "sha256:15e7d1f7a6ee16572e21e3576d2012b2778cbacf75eb4b7400be37455f5ca8bf",
+                "sha256:17776ecd3a1fdd2b2cd5373e5ef8b307162f581c693575ec62e7c5399d80794c",
+                "sha256:194d0bcb1374ac3e1e023961610dc8f2c78a0f5f634d0c737691e215569e640d",
+                "sha256:1c0e316c9add0db48a5b703833881351444398b04111188069a26a61cfb4df78",
+                "sha256:205e40ccde0f37496904572035deea747390a8b7dc65146d30b96e2dd1359a83",
+                "sha256:273f158fabc5ea33cbc936da0ab3d4ba80ede5351babc4f577d768e057651531",
+                "sha256:2876246527c91e101184f63ccd1d716ec9c46519cc5f3d5375a3351c46467c46",
+                "sha256:2c98384b254b37ce50eddd55db8d381a5c53b4c10ee66e1e7fe749824f894021",
+                "sha256:2e5a26f16503be6c826abca904e45f1a44ff275fdb7e9d1b75c10671c26f8b94",
+                "sha256:334701327f37c47fa628fc8b8d28c7d7730ce7daaf4bda1efb741679c2b087fc",
+                "sha256:3748fac0d0f6a304e674955ab1365d515993b3a0a865e16a11ec9d86fb307f63",
+                "sha256:3c02411a3b62668200910090a0dff17c0b25aaa36145082a5a6adf08fa281e54",
+                "sha256:3dd4952748521205697bc2802e4afac5ed4b02909bb799ba1fe239f77fd4e117",
+                "sha256:3f24df7124c323fceb53ff6168da70dbfbae1442b4f3da439cd441681f54fe25",
+                "sha256:469e2407e0fe9880ac690a3666f03eb4c3c444411a5a5fddfdabc5d184a79f05",
+                "sha256:4de4bc9b6d35c5af65b454d3e9bc98c50eb3960d5a3762c9438df57427134b8e",
+                "sha256:5208ebd5152e040640518a77827bdfcc73773a15a33d6644015b763b9c9febc1",
+                "sha256:52de7fc6c21b419078008f697fd4103dbc763288b1406b4562554bd47514c004",
+                "sha256:5bb3489b4558e49ad2c5118137cfeaf59434f9737fa9c5deefc72d22c23822e2",
+                "sha256:5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e",
+                "sha256:5dd9ca406499444f4c8299f803d4a14edf7890ecc595c8b1c7115c2342cadc5f",
+                "sha256:5f931a1c21dfa7a9c573ec1f50a31135ccce84e32507c54e1ea404894c5eb96f",
+                "sha256:63b82bb63de7c821428d513607e84c6d97d58afd1fe2eb645030bdc185440120",
+                "sha256:66c0061c91b3b9cf542131148ef7ecbecb2690d48d1612ec386de9d36766058f",
+                "sha256:6f0c02cbb9691b7c91d5009108f975f8ffeab5dff8f26d62e21c493060eff2a1",
+                "sha256:71aace0c42d53abe6fc7f726c5d3b60d90f3c5c055a447950ad6ea9cec2e37d9",
+                "sha256:7d97a4306898b05404a0dcdc32d9709b7d8832c0c542b861d9a826301719794e",
+                "sha256:7df1e1c05304f26faa49fa752a8c690126cf98b40b91d54e6e9cc3b7d6ffe8b7",
+                "sha256:8270252effc60b9642b423189a2fe90eb6b59e87cbee54549db3f5562ff8d1b8",
+                "sha256:867a5ad16892bf20e6c4ea2aab1971f45645ff3102ad29bd84c86027fa99997b",
+                "sha256:877473e675fdcc113c138813a5dd440da0769a2d81f4d86614e5d62b69497155",
+                "sha256:8892f89999ffd992208754851e5a052f6b5db70a1e3f7d54b17c5211e37a98c7",
+                "sha256:9a9845c4c6bb56e508651f005c4aeb0404e518c6f000d5a1123ab077ab769f5c",
+                "sha256:a1e6e96217a0f72e2b8629e271e1b280c6fa3fe6e59fa8f6701bec14e3354325",
+                "sha256:a8156e6a7f5e2a0ff0c5b21d6bcb45145efece1909efcbbbf48c56f8da68221d",
+                "sha256:a9506a7e80bcf6eacfff7f804c0ad5350c8c95b9010e4356a4b36f5322f09abb",
+                "sha256:af310ec8335016b5e52cae60cda4a4f2a60a788cbb949a4fbea13d441aa5a09e",
+                "sha256:b0297b1e05fd128d26cc2460c810d42e205d16d76799526dfa8c8ccd50e74959",
+                "sha256:bf68f4b2b6683e52bec69273562df15af352e5ed25d1b6641e7efddc5951d1a7",
+                "sha256:d0c1bc2fa9a7285719e5678584f6b92572a5b639d0e471bb8d4b650a1a910920",
+                "sha256:d4d9d6c1a455d4babd320203b918ccc7fcbefe308615c521062bc2ba1aa4d26e",
+                "sha256:db1fa631737dab9fa0b37f3979d8d2631e348c3b4e8325d6873c2541d0ae5a48",
+                "sha256:dd93ea5c0c7f3e25335ab7d22a507b1dc43976e1345508f845efc573d3d779d8",
+                "sha256:f44e517131a98f7a76696a7b21b164bcb85291cee106a23beccce454e1f433a4",
+                "sha256:f7ee479e96f7ee350db1cf24afa5685a5899e2b34992fb99e1f7c1b0b758d263"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.3.0"
+            "version": "==5.4.0"
         }
     },
     "develop": {
@@ -1140,11 +1171,11 @@
         },
         "django-extensions": {
             "hashes": [
-                "sha256:081828e985485662f62a22340c1506e37989d14b927652079a5b7cd84a82368b",
-                "sha256:17f85f4dcdd5eea09b8c4f0bad8f0370bf2db6d03e61b431fa7103fee29888de"
+                "sha256:50de8977794a66a91575dd40f87d5053608f679561731845edbd325ceeb387e3",
+                "sha256:5f0fea7bf131ca303090352577a9e7f8bfbf5489bd9d9c8aea9401db28db34a0"
             ],
             "index": "pypi",
-            "version": "==3.1.2"
+            "version": "==3.1.3"
         },
         "dodgy": {
             "hashes": [
@@ -1187,11 +1218,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6",
-                "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"
+                "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581",
+                "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.1"
+            "version": "==4.0.1"
         },
         "iniconfig": {
             "hashes": [
@@ -1205,7 +1236,7 @@
                 "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6",
                 "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==5.8.0"
         },
         "lazy-object-proxy": {

--- a/api/applications/libraries/document_helpers.py
+++ b/api/applications/libraries/document_helpers.py
@@ -59,7 +59,7 @@ def upload_application_document(application, data, user):
             actor=user.exporteruser,
             verb=AuditType.DOCUMENT_ON_ORGANISATION_CREATE,
             target=document.application.organisation,
-            payload={"file_name": data.get("name")},
+            payload={"file_name": data.get("name"), "document_type": doa_serializer.data.get("document_type")},
         )
 
     audit_trail_service.create(

--- a/api/applications/tests/test_documents.py
+++ b/api/applications/tests/test_documents.py
@@ -37,4 +37,4 @@ class ApplicationDocumentViewTests(DataTestClient):
         self.assertEqual(audit.actor, self.exporter_user)
         self.assertEqual(audit.target.id, self.organisation.id)
         self.assertEqual(audit.verb, AuditType.DOCUMENT_ON_ORGANISATION_CREATE)
-        self.assertEqual(audit.payload, {"file_name": "section5.png"})
+        self.assertEqual(audit.payload, {"file_name": "section5.png", "document_type": "section-five-certificate"})

--- a/api/audit_trail/apps.py
+++ b/api/audit_trail/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ApplicationsConfig(AppConfig):
+    name = "api.audit_trail"
+
+    def ready(self):
+        import api.audit_trail.signals  # noqa

--- a/api/audit_trail/signals.py
+++ b/api/audit_trail/signals.py
@@ -1,0 +1,19 @@
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from api.audit_trail.models import Audit
+from api.audit_trail.serializers import AuditSerializer
+
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=Audit)
+def emit_audit_log(sender, instance, **kwargs):
+    """Emit log entry when an Audit instance is saved to the DB.
+    """
+    text = str(instance)
+    extra = AuditSerializer(instance).data
+    logger.info(text, extra={"audit": extra})

--- a/api/audit_trail/tests/factories.py
+++ b/api/audit_trail/tests/factories.py
@@ -5,7 +5,7 @@ from api.audit_trail.models import Audit
 
 
 class AuditFactory(factory.django.DjangoModelFactory):
-    verb = AuditType.UPDATED_STATUS
+    verb = AuditType.CREATED
 
     class Meta:
         model = Audit

--- a/api/audit_trail/tests/test_audit_trail.py
+++ b/api/audit_trail/tests/test_audit_trail.py
@@ -26,7 +26,7 @@ class CasesAuditTrail(DataTestClient):
 
         self.assertEqual(audit_qs.count(), 1)
 
-        service.create(actor=self.exporter_user, verb=AuditType.ADD_FLAGS, target=self.case)
+        service.create(actor=self.exporter_user, verb=AuditType.CREATED, target=self.case)
 
         self.assertEqual(audit_qs.count(), 2)
         self.case.delete()

--- a/api/audit_trail/tests/test_audit_trail.py
+++ b/api/audit_trail/tests/test_audit_trail.py
@@ -1,10 +1,18 @@
+from unittest import mock
+
 from rest_framework.exceptions import PermissionDenied
 
 from api.audit_trail import service
 from api.audit_trail.models import Audit
 from api.audit_trail.enums import AuditType
+from api.audit_trail.serializers import AuditSerializer
 from test_helpers.clients import DataTestClient
 from api.users.models import BaseUser
+
+
+class Any(object):
+    def __eq__(a, b):
+        return True
 
 
 class CasesAuditTrail(DataTestClient):
@@ -57,3 +65,8 @@ class CasesAuditTrail(DataTestClient):
 
         self.assertEqual(gov_audit_trail_qs.count(), 1)
         self.assertEqual(exp_audit_trail_qs.count(), 0)
+
+    @mock.patch("api.audit_trail.signals.logger")
+    def test_emit_audit_log(self, mock_logger):
+        audit = service.create(actor=self.exporter_user, verb=AuditType.CREATED_FINAL_ADVICE, target=self.case)
+        mock_logger.info.assert_called_with(Any(), extra={"audit": AuditSerializer(audit).data})

--- a/api/audit_trail/tests/test_case_activity_filter.py
+++ b/api/audit_trail/tests/test_case_activity_filter.py
@@ -64,8 +64,8 @@ class CasesAuditTrailSearchTestCase(DataTestClient):
         self.assertEqual(res.first().actor_object_id, str(self.gov_user.pk))
 
     def test_filter_by_audit_type(self):
-        audit_type = AuditType.UPDATED_STATUS
-        fake_audit_type = AuditType.GOOD_REVIEWED
+        audit_type = AuditType.CREATED
+        fake_audit_type = AuditType.CREATED_CASE_NOTE
         AuditFactory(actor=self.exporter_user, verb=audit_type, target=self.case.get_case())
         AuditFactory(actor=self.gov_user, verb=fake_audit_type, target=self.case.get_case())
 
@@ -73,7 +73,7 @@ class CasesAuditTrailSearchTestCase(DataTestClient):
             object_id=self.case.id, object_content_type=self.content_type, audit_type=audit_type
         )
 
-        self.assertEqual(res.count(), 2)
+        self.assertEqual(res.count(), 1)
         self.assertEqual(res.first().actor_object_id, str(self.exporter_user.pk))
         self.assertEqual(res.first().verb, audit_type)
 

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -307,10 +307,17 @@ if "test" not in sys.argv:
             "json": {
                 "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
                 "format": "(asctime)(levelname)(message)(filename)(lineno)(threadName)(name)(thread)(created)(process)(processName)(relativeCreated)(module)(funcName)(levelno)(msecs)(pathname)",  # noqa
-            }
+            },
+            "ecs_formatter": {"class": "django_log_formatter_ecs.ECSFormatter",},
         },
-        "handlers": {"console": {"class": "logging.StreamHandler", "formatter": "json"}},
-        "loggers": {"": {"handlers": ["console"], "level": env("LOG_LEVEL").upper()}},
+        "handlers": {
+            "console": {"class": "logging.StreamHandler", "formatter": "json"},
+            "ecs": {"class": "logging.StreamHandler", "formatter": "ecs_formatter",},
+        },
+        "loggers": {
+            "": {"handlers": ["console"], "level": env("LOG_LEVEL").upper()},
+            "django": {"handlers": ["ecs"],},
+        },
     }
 else:
     LOGGING = {"version": 1, "disable_existing_loggers": True}

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -53,7 +53,7 @@ ALLOWED_CIDR_NETS = ["10.0.0.0/8"]
 INSTALLED_APPS = [
     "api.addresses",
     "api.applications.apps.ApplicationsConfig",
-    "api.audit_trail",
+    "api.audit_trail.apps.ApplicationsConfig",
     "background_task",
     "api.cases",
     "api.cases.generated_documents",

--- a/api/queries/goods_query/tests/test_goods_queries.py
+++ b/api/queries/goods_query/tests/test_goods_queries.py
@@ -146,6 +146,8 @@ class ControlListClassificationsQueryRespondTests(DataTestClient):
                     "good_name": self.query.good.description,
                     "old_control_list_entry": ["No control code"],
                     "new_control_list_entry": self.data["control_list_entries"],
+                    "new_is_good_controlled": "Yes",
+                    "old_is_good_controlled": "Yes",
                 }
                 self.assertEqual(audit.payload, payload)
 

--- a/api/queries/goods_query/views.py
+++ b/api/queries/goods_query/views.py
@@ -153,6 +153,8 @@ class GoodQueryCLCResponse(APIView):
                             "good_name": query.good.description,
                             "old_control_list_entry": previous_control_list_entries,
                             "new_control_list_entry": new_control_list_entries,
+                            "old_is_good_controlled": "Yes" if query.good.is_good_controlled else "No",
+                            "new_is_good_controlled": "Yes" if query.good.is_good_controlled else "No",
                         },
                     )
 


### PR DESCRIPTION
This does 3 things.

1) It adds `django-log-formatter-ecs`.
2) It adds a signal that emits Audit logs in ECS format.
3) Fixes a bunch of tests (and application logic) that was always broken but only got exposed because we started serializing all the `Audit` instances.

(2) looks like the following:

```
{
    "asctime": "2021-04-26 14:37:40,970",
    "levelname": "INFO",
    "message": "ExporterUser object (f0aaf9d1-1bae-4681-b2e3-318da86e46c8) created_final_advice StandardApplication object (0bc97090-4152-42b2-93c6-1bf9d5eefa6f) 0 minutes ago",
    "filename": "signals.py",
    "lineno": 19,
    "threadName": "MainThread",
    "name": "api.audit_trail.signals",
    "thread": 4626759168,
    "created": 1619444260.970651,
    "process": 33461,
    "processName": "MainProcess",
    "relativeCreated": 29715.826988220215,
    "module": "signals",
    "funcName": "emit_audit_log",
    "levelno": 20,
    "msecs": 970.6509113311768,
    "pathname": "/Users/alixedi/Projects/dit/lite-api/api/audit_trail/signals.py",
    "id": "b7e46ed4-469c-4bdf-9fc8-21235f9aa4aa",
    "created_at": "2021-04-26T14:37:40.967040+01:00",
    "user": {
        "id": "f0aaf9d1-1bae-4681-b2e3-318da86e46c8",
        "first_name": "Tiffany",
        "last_name": "Carlson",
        "type": "exporter"
    },
    "text": "created final advice.",
    "additional_text": ""
}
```

I would recommend a commit-wise review.