### PR TITLE
[LTD-682] Remove address from the ES query & update tests.

### DIFF
--- a/api/applications/helpers.py
+++ b/api/applications/helpers.py
@@ -208,7 +208,7 @@ def auto_match_sanctions(application):
         parties.append(item.party)
 
     for party in parties:
-        query = build_query(name=party.signatory_name_euu, address=party.address)
+        query = build_query(name=party.signatory_name_euu)
         results = (
             Search(index=settings.ELASTICSEARCH_SANCTION_INDEX_ALIAS)
             .query(query)
@@ -237,12 +237,5 @@ def normalize_address(value):
     return value.upper().replace(" ", "")
 
 
-def build_query(name, address):
-    return Q(
-        "bool",
-        should=[
-            Q("function_score", query=Q("match", name=name), min_score=0.5),
-            Q("function_score", query=Q("match", address=address), weight=0.5),
-        ],
-        minimum_should_match=1,
-    )
+def build_query(name):
+    return Q("match", name=name)

--- a/api/applications/tests/test_helpers.py
+++ b/api/applications/tests/test_helpers.py
@@ -66,37 +66,17 @@ class AbstractAutoMatchTests:
         self.assertEquals(str(party_on_application.flags.first().pk), SystemFlags.SANCTION_UK_MATCH)
 
     @pytest.mark.elasticsearch
-    def test_auto_match_sanctions_match_address(self):
-        prepare_index()
-
-        application = self.create_application()
-        party = self.get_party(application)
-        party.address = "123 Fake Street"
-        party.save()
-
-        document = SanctionDocumentType(
-            name="Johnson Woodlington",
-            address="123 fake street",
-            flag_uuid=SystemFlags.SANCTION_UK_MATCH,
-            reference="123",
-        )
-        document.save()
-        SanctionDocumentType._index.refresh()
-
-        helpers.auto_match_sanctions(application)
-
-        party_on_application = application.parties.get(party=party)
-
-        self.assertEquals(party_on_application.sanction_matches.count(), 1)
-        self.assertEquals(party_on_application.sanction_matches.first().elasticsearch_reference, "123")
-        self.assertEquals(str(party_on_application.flags.first().pk), SystemFlags.SANCTION_UK_MATCH)
-
-    @pytest.mark.elasticsearch
-    def test_auto_match_sanctions_match_avoid_false_positive_similar_name_different_address(self):
+    def test_auto_match_sanctions_avoid_false_positives(self):
         names = [
             "Jeremy Thompson",
             "Fred Jackson",
             "Jack Jeremyson",
+            "Jeremy Jacks",
+            "JeremyJackson",
+            "J Jackson",
+            "J. Jackson",
+            "Mr. J Jackson",
+            "Mr. Jackson",
         ]
         for name_variant in names:
             prepare_index()
@@ -109,7 +89,7 @@ class AbstractAutoMatchTests:
 
             document = SanctionDocumentType(
                 name=name_variant,
-                address="456 Fake Street, Berlin",
+                address="123 Plank Street, London, E19 8NX",
                 flag_uuid=SystemFlags.SANCTION_UK_MATCH,
                 reference="123",
             )
@@ -124,51 +104,15 @@ class AbstractAutoMatchTests:
             self.assertEquals(party_on_application.flags.count(), 0)
 
     @pytest.mark.elasticsearch
-    def test_auto_match_sanctions_match_address_similar(self):
-        addresses = [
-            "123 Fake Street, London, E14 9IX",
-            "123 Fake Street, London, E149IX",
-            "123 Fake Street, London, E14 9IX",
-            "123 Fake Street, London, e14 9ix",
-            "123 Fake Street\nLondon\nE14 9IX",
-            "123 Fake Street\nLondon\nUK\nE14 9IX",
-        ]
-
-        for address_variant in addresses:
-            prepare_index()
-
-            application = self.create_application()
-            party = self.get_party(application)
-            party.signatory_name_euu = "Jeremy Jackson"
-            party.address = "123 Fake Street, London, E14 9IX"
-            party.save()
-
-            document = SanctionDocumentType(
-                name="Jeremy Jackson",
-                address=address_variant,
-                flag_uuid=SystemFlags.SANCTION_UK_MATCH,
-                reference="123",
-            )
-            document.save()
-            SanctionDocumentType._index.refresh()
-
-            helpers.auto_match_sanctions(application)
-
-            party_on_application = application.parties.get(party=party)
-
-            self.assertEquals(party_on_application.sanction_matches.count(), 1, msg=f'tried "{address_variant}"')
-            self.assertEquals(str(party_on_application.flags.first().pk), SystemFlags.SANCTION_UK_MATCH)
-
-    @pytest.mark.elasticsearch
     def test_auto_match_sanctions_match_name_similar(self):
+        """ This test exposes the fact that ES tokenization etc. would mean
+        that the following names will be matched to "Jeremy Jackson". There is
+        no simple way around this.
+        """
         names = [
-            "Jeremy Jackson",
             "Jackson, Jeremy",
-            "JeremyJackson",
-            "J Jackson",
-            "J. Jackson",
-            "Mr. J Jackson",
-            "Mr. Jackson",
+            "Jackson Jeremy",
+            "Mr. Jeremy Jackson",
         ]
 
         for name_variant in names:
@@ -195,60 +139,6 @@ class AbstractAutoMatchTests:
             party_on_application = application.parties.get(party=party)
 
             self.assertEquals(party_on_application.sanction_matches.count(), 1, msg=f'tried "{name_variant}"')
-            self.assertEquals(str(party_on_application.flags.first().pk), SystemFlags.SANCTION_UK_MATCH)
-
-    @pytest.mark.elasticsearch
-    def test_auto_match_sanctions_match_name_address_similar(self):
-        names = [
-            "Jeremy Jackson",
-            "Jackson, Jeremy",
-            "JeremyJackson",
-            "J Jackson",
-            "J. Jackson",
-            "Mr. J Jackson",
-            "Mr. Jackson",
-        ]
-
-        addresses = [
-            "123 Fake Street, London",
-            "123 Fake Street, London",
-            "123 Fake Street, London",
-            "123 Fake Street, London",
-            "123 Fake Street\nLondon\n",
-            "123 Fake Street\nLondon\nUK",
-        ]
-
-        postcodes = [
-            "E14 9IX",
-            "e14 9ix",
-            "E149IX",
-        ]
-
-        for name, address, postcode in itertools.product(names, addresses, postcodes):
-            prepare_index()
-
-            application = self.create_application()
-            party = self.get_party(application)
-            party.signatory_name_euu = "Jeremy Jackson"
-            party.address = "123 Fake Street, London, E14 9IX"
-            party.save()
-
-            document = SanctionDocumentType(
-                name=name,
-                address=f"{address} {postcode}",
-                postcode=postcode,
-                flag_uuid=SystemFlags.SANCTION_UK_MATCH,
-                reference="123",
-            )
-            document.save()
-            SanctionDocumentType._index.refresh()
-            helpers.auto_match_sanctions(application)
-
-            party_on_application = application.parties.get(party=party)
-
-            self.assertEquals(
-                party_on_application.sanction_matches.count(), 1, msg=f'tried "{name} + "{address}" "{postcode}"'
-            )
             self.assertEquals(str(party_on_application.flags.first().pk), SystemFlags.SANCTION_UK_MATCH)
 
 


### PR DESCRIPTION
This PR does 2 things -

1. It removes addresses from the ES query for sanctions.
2. It removes the tests that were related to addresses.

It does not -

1. Remove the machinery that ingests addresses for sanctions and generate indices etc.
2. Fix the way tests are written - using weird class inheritance instead of pytest fixtures.
3. Strictly do what the spec says e.g. ATM "Jackson, Jeremy" and "Mr. Jeremy Jackson" will match "Jeremy Jackson". I think that (1) this is how it should be and (2) we can always do a second pass.