### PR TITLE
[LTD-1028] Stop SLA for cases with terminal status.

### DIFF
--- a/api/cases/tests/test_sla.py
+++ b/api/cases/tests/test_sla.py
@@ -2,6 +2,7 @@ from datetime import time, datetime
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
@@ -20,6 +21,8 @@ from api.cases.tasks import (
     HMRC_QUERY_TARGET_DAYS,
 )
 from api.cases.models import CaseAssignmentSla
+from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from test_helpers.clients import DataTestClient
 
 HOUR_BEFORE_CUTOFF = time(SLA_UPDATE_CUTOFF_TIME.hour - 1, 0, 0)


### PR DESCRIPTION
If you read carefully, we are supposed to only stop the counter for `FINALISED`, `CLOSED`, `WITHDRAWN`.

I am going with `CaseStatusEnum.terminal_statuses()` because that seems like a more exhaustive list, which means it includes `FINALISED`, `CLOSED`, `WITHDRAWN` amongst others.