### PR TITLE
[LTD-1055] Revert changes

### DIFF
--- a/api/flags/views.py
+++ b/api/flags/views.py
@@ -74,7 +74,7 @@ class FlagsListCreateView(ListCreateAPIView):
         if case:
             flags = get_flags(get_case(case))
         else:
-            flags = Flag.objects.exclude(level=FlagLevels.PARTY_ON_APPLICATION, id__in=SystemFlags.list)
+            flags = Flag.objects.exclude(level=FlagLevels.PARTY_ON_APPLICATION)
 
         if name:
             flags = flags.filter(name__icontains=name)

--- a/api/staticdata/management/commands/seedflags.py
+++ b/api/staticdata/management/commands/seedflags.py
@@ -18,5 +18,4 @@ class Command(SeedCommand):
     @transaction.atomic
     def operation(self, *args, **options):
         csv = self.read_csv(FLAGS_FILE)
-        self.delete_unused_objects(Flag, csv)
         self.update_or_create(Flag, csv)


### PR DESCRIPTION
Reverts some changes introduced in #786 and #785. There are a couple of reasons for this -

1) Most important one - we cannot `delete_unused_object` for `Flag` model. The reason is that, unlike other "seeded" models, the `Flag` model comprises seeded (system) flags as well as user-defined flags. In the same model 🤦 

(this was my bad, I should have realised this but didn't)

2) The second one is more insidious. The order in which filters are applied in `FlagsListCreateView.get_queryset` matters. As a result, this doesn't work e.g. if I have `name=UK` and `include_system_flags=True`. The results will include flags that have `UK` in the name as well as ALL the system flags. 
