### PR TITLE
Add order.

### DIFF
--- a/api/data_workspace/application_views.py
+++ b/api/data_workspace/application_views.py
@@ -31,4 +31,4 @@ class PartyOnApplicationListView(viewsets.ReadOnlyModelViewSet):
     authentication_classes = (DataWorkspaceOnlyAuthentication,)
     serializer_class = party.PartyOnApplicationViewSerializer
     pagination_class = LimitOffsetPagination
-    queryset = models.PartyOnApplication.objects.all()
+    queryset = models.PartyOnApplication.objects.all().order_by("id")


### PR DESCRIPTION
This was [failing](https://data-flow-staging.london.cloudapps.digital/log?dag_id=LITEPartyOnApplicationPipeline&task_id=insert-into-temp-table-datasets_db&execution_date=2021-08-24T00%3A00%3A00%2B00%3A00) on the data-flow side. 

The working hypothesis was that the lack of order was causing some issues with pagination. 