### PR TITLE
Create endpoint for retrieving move case audit events

### DIFF
--- a/api/data_workspace/audit_views.py
+++ b/api/data_workspace/audit_views.py
@@ -1,0 +1,46 @@
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
+
+
+from api.audit_trail.enums import AuditType
+from api.audit_trail.models import Audit
+from api.cases.models import Case
+from api.core.authentication import DataWorkspaceOnlyAuthentication
+from api.data_workspace.serializers import AuditMoveCaseSerializer
+
+
+class AuditMoveCaseListView(viewsets.ReadOnlyModelViewSet):
+    """Expose 'move case' audit events to data workspace."""
+
+    authentication_classes = (DataWorkspaceOnlyAuthentication,)
+    serializer_class = AuditMoveCaseSerializer
+    pagination_class = LimitOffsetPagination
+
+    def get_queryset(self):
+        content_type = ContentType.objects.get_for_model(Case)
+
+        # This returns a queryset of audit records for the "move case" audit event.
+        # For each record, it exposes the nested "queues" JSON property as a top
+        # level column called "queue" and splits into multiple rows when "queues"
+        # contains multiple entries.
+        # It also deals with the fact that the value of "queues" is sometimes an
+        # array of queue names but sometimes a single string.
+        return Audit.objects.raw(
+            """
+            with audit_move_case as (
+              select *,
+                case when jsonb_typeof(payload->'queues') = 'array' 
+                then payload->'queues'
+                else jsonb_build_array(payload->'queues')
+                end as queues
+              from audit_trail_audit
+              where verb = %(verb)s
+              and (action_object_content_type_id = %(action_type)s
+                or target_content_type_id = %(target_type)s)
+              order by created_at
+            )
+            select *, value->>0 as "queue" from audit_move_case cross join jsonb_array_elements(queues)
+            """,
+            {"verb": AuditType.MOVE_CASE, "action_type": content_type.pk, "target_type": content_type.pk},
+        )

--- a/api/data_workspace/serializers.py
+++ b/api/data_workspace/serializers.py
@@ -1,4 +1,6 @@
-from api.cases.models import EcjuQuery, CaseAssignment
+from api.audit_trail.models import Audit
+from api.cases.models import CaseAssignment, EcjuQuery
+from api.queues.models import Queue
 
 from rest_framework import serializers
 import api.cases.serializers as cases_serializers
@@ -15,3 +17,29 @@ class CaseAssignmentSerializer(cases_serializers.CaseAssignmentSerializer):
     class Meta:
         model = CaseAssignment
         fields = "__all__"
+
+
+class AuditMoveCaseSerializer(serializers.ModelSerializer):
+    """Serializer for serializing 'move case' audit events."""
+
+    user = serializers.SerializerMethodField()
+    case = serializers.SerializerMethodField()
+    queue = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Audit
+        fields = ("created_at", "user", "case", "queue")
+
+    def get_user(self, instance):
+        if instance.actor:
+            return instance.actor.pk
+        return None
+
+    def get_case(self, instance):
+        return instance.action_object_object_id or instance.target_object_id or None
+
+    def get_queue(self, instance):
+        queue = Queue.objects.filter(name=instance.queue).first()
+        if queue:
+            return queue.pk
+        return None

--- a/api/data_workspace/tests/test_audit_views.py
+++ b/api/data_workspace/tests/test_audit_views.py
@@ -1,0 +1,57 @@
+from django.urls import reverse
+from functools import partial
+from rest_framework import status
+
+from api.audit_trail.enums import AuditType
+from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+from test_helpers.clients import DataTestClient
+
+
+class DataWorkspaceAuditMoveCaseTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("data_workspace:dw-audit-move-case-list")
+        case = self.create_standard_application_case(self.organisation, "Test Application")
+        # Audit events are only created for non-draft cases
+        case.status = get_case_status_by_status(CaseStatusEnum.OPEN)
+        case.save()
+        self.create_audit = partial(
+            super().create_audit, verb=AuditType.MOVE_CASE, actor=self.gov_user, target=case.get_case()
+        )
+
+        self.create_audit(payload={"queues": "Initial Queue"})
+        self.create_audit(verb=AuditType.CREATED_USER_ADVICE)
+
+    def test_audit_move_case(self):
+        expected_fields = ("created_at", "user", "case", "queue")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(tuple(results[0].keys()), expected_fields)
+        self.assertEqual(results[0]["queue"], str(self.queue.pk))
+
+        response = self.client.options(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        options = response.json()["actions"]["OPTIONS"]
+        self.assertEqual(tuple(options.keys()), expected_fields)
+
+    def test_payload_multiple_queues(self):
+        queue1 = self.create_queue("MOD - DSR Cases to Review", self.team)
+        queue2 = self.create_queue("MOD - WECA Cases to Review", self.team)
+        # Create a single audit record with multiple queues in the payload
+        self.create_audit(payload={"queues": ["MOD - DSR Cases to Review", "MOD - WECA Cases to Review"]})
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0]["queue"], str(self.queue.pk))
+        # The record with multiple queues should have been split into separate entries.
+        self.assertEqual(results[1]["queue"], str(queue1.pk))
+        self.assertEqual(results[2]["queue"], str(queue2.pk))

--- a/api/data_workspace/tests/test_serializers.py
+++ b/api/data_workspace/tests/test_serializers.py
@@ -1,4 +1,6 @@
-from api.data_workspace.serializers import EcjuQuerySerializer, CaseAssignmentSerializer
+from api.audit_trail.models import AuditType
+from api.audit_trail.tests.factories import AuditFactory
+from api.data_workspace.serializers import AuditMoveCaseSerializer, CaseAssignmentSerializer, EcjuQuerySerializer
 from api.cases.tests.factories import EcjuQueryFactory, CaseAssignmentFactory
 
 
@@ -14,4 +16,12 @@ def test_CaseAssignmentSerializer(db):
     case_assignment = CaseAssignmentFactory()
     serialized = CaseAssignmentSerializer(case_assignment)
     expected_fields = {"case", "user", "id", "queue", "created_at", "updated_at"}
+    assert set(serialized.data.keys()) == expected_fields
+
+
+def test_AuditMoveCaseSerializer(db):
+    audit = AuditFactory(verb=AuditType.MOVE_CASE, payload={"queues": ["test_queue_1", "test_queue_2"]})
+    audit.queue = "test_queue_1"
+    serialized = AuditMoveCaseSerializer(audit)
+    expected_fields = {"created_at", "user", "case", "queue"}
     assert set(serialized.data.keys()) == expected_fields

--- a/api/data_workspace/urls.py
+++ b/api/data_workspace/urls.py
@@ -3,6 +3,7 @@ from rest_framework.routers import DefaultRouter
 
 from api.data_workspace import (
     application_views,
+    audit_views,
     case_views,
     good_views,
     license_views,
@@ -63,8 +64,6 @@ router_v1.register(
 )
 router_v1.register("users-base-users", users_views.BaseUserListView, basename="dw-users-base-users")
 router_v1.register("users-gov-users", users_views.GovUserListView, basename="dw-users-gov-users")
+router_v1.register("audit-move-case", audit_views.AuditMoveCaseListView, basename="dw-audit-move-case")
 
-urlpatterns = [
-    path("v0/", include(router_v0.urls)),
-    path("v1/", include(router_v1.urls)),
-]
+urlpatterns = [path("v0/", include(router_v0.urls)), path("v1/", include(router_v1.urls))]


### PR DESCRIPTION
This endpoint exposes 'move case' audit events in the following format:
```
        {
            "created_at": "2021-06-08T17:31:15.520183+01:00",
            "user": "00000000-0000-0000-0000-000000000001",
            "case": "b878c4f8-8f7c-45f9-ab06-143de04de3b5",
            "queue": "4dfc0d0b-c0c0-4f59-897b-b7d596bed930"
        },
```