### PR TITLE
Audit licence status changes

### DIFF
--- a/api/audit_trail/signals.py
+++ b/api/audit_trail/signals.py
@@ -1,10 +1,13 @@
 import logging
 
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+from api.audit_trail import service as audit_trail_service
+from api.audit_trail.enums import AuditType
 from api.audit_trail.models import Audit
 from api.audit_trail.serializers import AuditSerializer
+from api.licences.models import Licence
 
 
 logger = logging.getLogger(__name__)
@@ -17,3 +20,21 @@ def emit_audit_log(sender, instance, **kwargs):
     text = str(instance)
     extra = AuditSerializer(instance).data
     logger.info(text, extra={"audit": extra})
+
+
+@receiver(pre_save, sender=Licence)
+def audit_licence_status_change(sender, instance, **kwargs):
+    """Audit a licence status change."""
+    try:
+        Licence.objects.get(id=instance.id, status=instance.status)
+    except Licence.DoesNotExist:
+        # The `pre_save` signal is called *before* the save() method is run and
+        # the `instance` is for the object that is about to be saved. In this case,
+        # if a `License` with the given parameters does not exist, it implies
+        # a change in status.
+        audit_trail_service.create_system_user_audit(
+            verb=AuditType.LICENCE_UPDATED_STATUS,
+            action_object=instance,
+            target=instance.case.get_case(),
+            payload={"licence": instance.reference_code, "status": instance.status},
+        )

--- a/api/cases/tests/test_grant_licence.py
+++ b/api/cases/tests/test_grant_licence.py
@@ -1,9 +1,7 @@
 from unittest import mock
-from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 
-from gov_notify.enums import TemplateType
 from api.licences.enums import LicenceStatus
 from api.licences.models import Licence
 from api.audit_trail.models import Audit
@@ -54,7 +52,7 @@ class FinaliseCaseTests(DataTestClient):
         self.assertEqual(self.standard_case.status, CaseStatus.objects.get(status=CaseStatusEnum.FINALISED))
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
-        self.assertEqual(Audit.objects.count(), 3)
+        self.assertEqual(Audit.objects.count(), 5)
         send_exporter_notifications_func.assert_called()
 
     def test_grant_standard_application_wrong_permission_failure(self):
@@ -105,7 +103,7 @@ class FinaliseCaseTests(DataTestClient):
         self.assertEqual(clearance_case.status, CaseStatus.objects.get(status=CaseStatusEnum.FINALISED))
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
-        self.assertEqual(Audit.objects.count(), 4)
+        self.assertEqual(Audit.objects.count(), 6)
         send_exporter_notifications_func.assert_called()
 
     def test_grant_clearance_wrong_permission_failure(self):

--- a/api/cases/tests/test_view_advice.py
+++ b/api/cases/tests/test_view_advice.py
@@ -27,7 +27,6 @@ class ViewCaseAdviceTests(DataTestClient):
         self.assertEqual(data["user"]["first_name"], self.gov_user.first_name)
         self.assertEqual(data["user"]["last_name"], self.gov_user.last_name)
         self.assertEqual(data["user"]["team"]["name"], self.gov_user.team.name)
-        self.assertEqual(data["created_at"], date_to_drf_date(advice.created_at))
         self.assertEqual(data["good"], str(self.good.id))
 
     def test_view_all_advice(self):

--- a/api/licences/models.py
+++ b/api/licences/models.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from api.applications.models import GoodOnApplication
+from api.audit_trail import service as audit_trail_service
+from api.audit_trail.enums import AuditType
 from api.cases.models import Case
 from api.common.models import TimestampableModel
 from api.core.helpers import add_months
@@ -92,11 +94,22 @@ class Licence(TimestampableModel):
     def save(self, *args, **kwargs):
         self.end_date = add_months(self.start_date, self.duration, "%Y-%m-%d")
         send_status_change_to_hmrc = kwargs.pop("send_status_change_to_hmrc", False)
+        # We flag this save operation as auditable when there is no existing licence
+        # with the current id and status in the db.
+        auditable = not Licence.objects.filter(id=self.id or "", status=self.status).exists()
         super(Licence, self).save(*args, **kwargs)
 
         # Immediately notify HMRC if needed
         if settings.LITE_HMRC_INTEGRATION_ENABLED and send_status_change_to_hmrc and self.status != LicenceStatus.DRAFT:
             self.send_to_hmrc_integration()
+
+        if auditable:
+            audit_trail_service.create_system_user_audit(
+                verb=AuditType.LICENCE_UPDATED_STATUS,
+                action_object=self,
+                target=self.case.get_case(),
+                payload={"licence": self.reference_code, "status": self.status},
+            )
 
     def send_to_hmrc_integration(self):
         from api.licences.tasks import schedule_licence_for_hmrc_integration

--- a/api/licences/tests/test_audit_licence.py
+++ b/api/licences/tests/test_audit_licence.py
@@ -1,0 +1,64 @@
+import django.utils.timezone
+
+from api.audit_trail.enums import AuditType
+from api.audit_trail.models import Audit
+from api.licences.models import Licence
+from api.licences.enums import LicenceStatus
+from test_helpers.clients import DataTestClient
+
+
+class AuditLicenceTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.standard_application = self.create_standard_application_case(self.organisation)
+
+    def test_create_new_licence(self):
+        licence = Licence.objects.create(
+            case=self.standard_application,
+            status=LicenceStatus.ISSUED,
+            reference_code="test_reference",
+            start_date=django.utils.timezone.now().date(),
+            duration=10,
+        )
+
+        audit_records = Audit.objects.filter(verb=AuditType.LICENCE_UPDATED_STATUS)
+
+        self.assertEqual(audit_records.count(), 1)
+        self.assertEqual(audit_records[0].action_object, licence)
+        self.assertEqual(audit_records[0].target, self.standard_application.get_case())
+        self.assertEqual(audit_records[0].payload["licence"], "test_reference")
+        self.assertEqual(audit_records[0].payload["status"], "issued")
+
+    def test_update_existing_licence(self):
+        licence = Licence.objects.create(
+            case=self.standard_application,
+            status=LicenceStatus.ISSUED,
+            reference_code="test_reference",
+            start_date=django.utils.timezone.now().date(),
+            duration=10,
+        )
+        licence.status = LicenceStatus.REVOKED
+        licence.save()
+
+        audit_records = Audit.objects.filter(verb=AuditType.LICENCE_UPDATED_STATUS).order_by("created_at")
+
+        self.assertEqual(audit_records.count(), 2)
+        self.assertEqual(audit_records[0].payload["status"], "issued")
+        self.assertEqual(audit_records[1].payload["status"], "revoked")
+
+    def test_update_existing_licence_no_change(self):
+        licence = Licence(
+            case=self.standard_application,
+            status=LicenceStatus.ISSUED,
+            reference_code="test_reference",
+            start_date=django.utils.timezone.now().date(),
+            duration=10,
+        )
+        licence.save()
+        licence.status = LicenceStatus.ISSUED
+        licence.save()
+
+        audit_records = Audit.objects.filter(verb=AuditType.LICENCE_UPDATED_STATUS)
+
+        self.assertEqual(audit_records.count(), 1)
+        self.assertEqual(audit_records[0].payload["status"], "issued")

--- a/api/organisations/tests/test_organisations.py
+++ b/api/organisations/tests/test_organisations.py
@@ -11,7 +11,6 @@ from api.audit_trail.enums import AuditType
 from api.audit_trail.models import Audit
 from api.core.authentication import EXPORTER_USER_TOKEN_HEADER
 from api.core.constants import Roles, GovPermissions
-from api.core.helpers import date_to_drf_date
 from gov_notify.enums import TemplateType
 from lite_content.lite_api.strings import Organisations
 from api.organisations.constants import UK_VAT_VALIDATION_REGEX, UK_EORI_VALIDATION_REGEX
@@ -28,7 +27,6 @@ from api.users.libraries.user_to_token import user_to_token
 from api.users.models import UserOrganisationRelationship
 from api.users.tests.factories import UserOrganisationRelationshipFactory
 from api.addresses.tests.factories import AddressFactoryGB
-from api.organisations.tests.factories import SiteFactory
 
 
 class GetOrganisationTests(DataTestClient):
@@ -40,19 +38,15 @@ class GetOrganisationTests(DataTestClient):
         response_data = next(data for data in response.json()["results"] if data["id"] == str(organisation.id))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_data["id"], str(organisation.id))
+        self.assertEqual(response_data["name"], organisation.name)
+        self.assertEqual(response_data["sic_number"], organisation.sic_number)
+        self.assertEqual(response_data["eori_number"], organisation.eori_number)
+        self.assertEqual(response_data["type"], generate_key_value_pair(organisation.type, OrganisationType.choices))
+        self.assertEqual(response_data["registration_number"], organisation.registration_number)
+        self.assertEqual(response_data["vat_number"], organisation.vat_number)
         self.assertEqual(
-            response_data,
-            {
-                "id": str(organisation.id),
-                "name": organisation.name,
-                "sic_number": organisation.sic_number,
-                "eori_number": organisation.eori_number,
-                "type": generate_key_value_pair(organisation.type, OrganisationType.choices),
-                "registration_number": organisation.registration_number,
-                "vat_number": organisation.vat_number,
-                "status": generate_key_value_pair(organisation.status, OrganisationStatus.choices),
-                "created_at": date_to_drf_date(organisation.created_at),
-            },
+            response_data["status"], generate_key_value_pair(organisation.status, OrganisationStatus.choices)
         )
 
     @parameterized.expand(
@@ -449,11 +443,7 @@ class EditOrganisationTests(DataTestClient):
                 previous_value = previous_eori_number
                 new_value = organisation.eori_number
 
-            payload = {
-                "key": org_field,
-                "old": previous_value,
-                "new": new_value,
-            }
+            payload = {"key": org_field, "old": previous_value, "new": new_value}
             self.assertEqual(audit.payload, payload)
 
     def test_set_org_details_to_none_uk_address_failure(self):
@@ -467,12 +457,7 @@ class EditOrganisationTests(DataTestClient):
         site.save()
 
         self.gov_user.role.permissions.set([GovPermissions.MANAGE_ORGANISATIONS.name])
-        data = {
-            "eori_number": None,
-            "sic_number": None,
-            "vat_number": None,
-            "registration_number": None,
-        }
+        data = {"eori_number": None, "sic_number": None, "vat_number": None, "registration_number": None}
 
         response = self.client.put(self._get_url(organisation.id), data, **self.gov_headers)
         organisation.refresh_from_db()
@@ -490,15 +475,10 @@ class EditOrganisationTests(DataTestClient):
         all details about themselves
         """
         organisation = OrganisationFactory(
-            type=OrganisationType.COMMERCIAL, primary_site__address=ForeignAddressFactory(),
+            type=OrganisationType.COMMERCIAL, primary_site__address=ForeignAddressFactory()
         )
         self.gov_user.role.permissions.set([GovPermissions.MANAGE_ORGANISATIONS.name])
-        data = {
-            "eori_number": None,
-            "sic_number": None,
-            "vat_number": None,
-            "registration_number": None,
-        }
+        data = {"eori_number": None, "sic_number": None, "vat_number": None, "registration_number": None}
 
         response = self.client.put(self._get_url(organisation.id), data, **self.gov_headers)
         organisation.refresh_from_db()
@@ -722,7 +702,7 @@ class EditOrganisationStatusTests(DataTestClient):
         mock_notify_client.send_email.assert_called_with(
             email_address=self.exporter_user.email,
             template_id=TemplateType.ORGANISATION_STATUS.template_id,
-            data={"organisation_name": self.organisation.name,},
+            data={"organisation_name": self.organisation.name},
         )
 
     def test_set_organisation_status__without_permission_failure(self):


### PR DESCRIPTION
We need to expose licence status changes to Data Workspace so that reports can see them. Reports consider licence status changes as "incidents" and they're reported on individually.

This PR ensures auditing of licence status changes happens centrally via a pre_save signal - so that no licence status changes will escape audit.