### PR TITLE
LTD-1412: Fix products order in generated licence template

### DIFF
--- a/api/goods/tests/factories.py
+++ b/api/goods/tests/factories.py
@@ -7,6 +7,7 @@ from api.staticdata.control_list_entries.helpers import get_control_list_entry
 
 
 class GoodFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker("word")
     description = factory.Faker("word")
     is_good_controlled = False
     part_number = factory.Faker("ean13")

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -996,7 +996,7 @@ def _get_good_on_licence_context(good_on_licence):
 
 
 def _get_goods_context(application, final_advice, licence=None):
-    goods_on_application = application.goods.all().order_by("good__description")
+    goods_on_application = application.goods.all().order_by("created_at")
     final_advice = final_advice.filter(good_id__isnull=False)
     goods_context = {advice_type: [] for advice_type, _ in AdviceType.choices}
 
@@ -1006,7 +1006,7 @@ def _get_goods_context(application, final_advice, licence=None):
     goods_context["all"] = GoodOnApplicationSerializer(goods_on_application, many=True).data
 
     if licence:
-        goods_on_licence = licence.goods.all().order_by("good__good__description")
+        goods_on_licence = licence.goods.all().order_by("created_at")
         if goods_on_licence.exists():
             goods_context[AdviceType.APPROVE] = [
                 _get_good_on_licence_context(good_on_licence) for good_on_licence in goods_on_licence

--- a/api/letter_templates/tests/test_context_generation.py
+++ b/api/letter_templates/tests/test_context_generation.py
@@ -15,6 +15,7 @@ from api.applications.enums import (
 from api.applications.models import ExternalLocationOnApplication, CountryOnApplication, GoodOnApplication
 from api.applications.tests.factories import GoodOnApplicationFactory
 from api.cases.enums import AdviceLevel, AdviceType, CaseTypeEnum
+from api.cases.models import Advice
 from api.letter_templates.context_generator import EcjuQuerySerializer
 from api.cases.tests.factories import GoodCountryDecisionFactory, FinalAdviceFactory
 from api.compliance.enums import ComplianceVisitTypes, ComplianceRiskValues
@@ -426,14 +427,26 @@ class DocumentContextGenerationTests(DataTestClient):
         self._assert_addressee(context["addressee"], addressee)
 
     def test_generate_context_with_goods(self):
-        case = self.create_standard_application_case(self.organisation, user=self.exporter_user)
+        application = self.create_standard_application_case(self.organisation, user=self.exporter_user, num_products=10)
+        for product in application.goods.all():
+            self.create_advice(
+                self.gov_user, application, "good", AdviceType.APPROVE, AdviceLevel.FINAL, good=product.good
+            )
 
-        context = get_document_context(case)
+        licence = self.create_licence(application, status=LicenceStatus.ISSUED)
+        for product in application.goods.all():
+            GoodOnLicenceFactory(
+                good=product, licence=licence, quantity=product.quantity, usage=0.0, value=product.value,
+            )
+
+        context = get_document_context(application)
+        # Ensure products order in generated template matches with the order in application
+        order_in_application = [product.good.name for product in application.goods.all()]
+        order_in_licence_template = [product["good"]["name"] for product in context["goods"]["approve"]]
+        self.assertEqual(order_in_application, order_in_licence_template)
         render_to_string(template_name="letter_templates/case_context_test.html", context=context)
-
-        self.assertEqual(context["case_reference"], case.reference_code)
-        self.assertEqual(context["case_officer_name"], case.get_case_officer_name())
-        self._assert_good(context["goods"]["all"][0], case.goods.all()[0])
+        self.assertEqual(context["case_reference"], application.reference_code)
+        self.assertEqual(context["case_officer_name"], application.get_case_officer_name())
 
     def test_generate_context_with_advice_on_goods(self):
         case = self.create_standard_application_case(self.organisation, user=self.exporter_user)

--- a/api/licences/serializers/hmrc_integration.py
+++ b/api/licences/serializers/hmrc_integration.py
@@ -117,7 +117,11 @@ class HMRCIntegrationLicenceSerializer(serializers.Serializer):
 
     def get_goods(self, instance):
         if instance.goods.exists():
-            return HMRCIntegrationGoodOnLicenceSerializer(instance.goods, many=True).data
+            """The order in which we send to HMRC matters and the line number is the common reference
+            which is used to refer the products when usage data is reported.
+            We also list the products in the same order in licence pdf which is used by exporters
+            when declaring goods at the customs check"""
+            return HMRCIntegrationGoodOnLicenceSerializer(instance.goods.order_by("created_at"), many=True).data
         elif hasattr(instance.case, "baseapplication") and instance.case.baseapplication.goods_type.exists():
             approved_goods_types = get_approved_goods_types(instance.case.baseapplication)
             return HMRCIntegrationGoodsTypeSerializer(approved_goods_types, many=True).data


### PR DESCRIPTION
## Change description
The generated licence document (pdf) contains the list of products in the licence
that require a licence along with their name, quantity etc. Currently these
are being ordered using their description field. Because of this the order in
the licence doesn't match with the order in which they are added to the
application. This has serious implications wrt HMRC integration.

When the licence details are sent to HMRC we send the product details as per
the order they are entered in the application but when products are declared
at the customs they use the order defined in the licence. This can result in
differences in quantities and the customs system may reject the products.
Eg if the quantity shows up as higher than allowed in licence.

Fix this by removing the ordering by description and add a test to ensure
the order as per application is maintained in licence also.