### PR TITLE
LTD-1418: Display product name under licences tab instead of description

### DIFF
--- a/api/licences/service.py
+++ b/api/licences/service.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 class GoodOnLicenceSerializer(serializers.ModelSerializer):
     control_list_entries = serializers.SerializerMethodField()
     is_good_controlled = serializers.SerializerMethodField()
+    name = serializers.CharField(source="good.good.name")
     description = serializers.CharField(source="good.good.description")
 
     # instance.good is good_on_application
@@ -26,6 +27,7 @@ class GoodOnLicenceSerializer(serializers.ModelSerializer):
         fields = (
             "control_list_entries",
             "is_good_controlled",
+            "name",
             "description",
             "quantity",
             "usage",

--- a/api/licences/tests/test_service.py
+++ b/api/licences/tests/test_service.py
@@ -53,6 +53,7 @@ class GetCaseLicenceTests(DataTestClient):
         self.assertEqual(data["reference_code"], self.licence.reference_code)
         self.assertEqual(data["status"], LicenceStatus.to_str(self.licence.status))
         self.assertEqual(data["goods"][0]["control_list_entries"][0]["rating"], "ML1a")
+        self.assertEqual(data["goods"][0]["name"], self.good.name)
         self.assertEqual(data["goods"][0]["description"], self.good.description)
         self.assertEqual(data["goods"][0]["quantity"], self.good_on_licence.quantity)
         self.assertEqual(data["goods"][0]["usage"], self.good_on_licence.usage)


### PR DESCRIPTION
## Change description

Because description is optional and can be empty.