### PR TITLE
Exclude NLR goods from serialization

### DIFF
--- a/api/licences/helpers.py
+++ b/api/licences/helpers.py
@@ -51,7 +51,7 @@ def serialize_goods_on_licence(licence):
 
     if licence.goods.exists():
         # Standard Application
-        return GoodOnLicenceViewSerializer(licence.goods, many=True).data
+        return GoodOnLicenceViewSerializer(licence.goods.filter(good__is_good_controlled=True), many=True).data
     elif licence.case.baseapplication.goods_type.exists():
         # Open Application
         approved_goods_types = get_approved_goods_types(licence.case.baseapplication)

--- a/api/licences/tests/test_get_licences.py
+++ b/api/licences/tests/test_get_licences.py
@@ -56,6 +56,8 @@ class GetLicencesTests(DataTestClient):
 
         for application, licence in self.licences.items():
             for good in application.goods.all():
+                good.is_good_controlled = True
+                good.save()
                 FinalAdviceFactory(user=self.gov_user, good=good.good, case=application)
                 GoodOnLicenceFactory(licence=licence, good=good, quantity=good.quantity, value=good.value)
             for goods_type in application.goods_type.all():


### PR DESCRIPTION
Filter out any goods that are not controlled (NLR) before attempting to serialize the goods on a licence.