### PR TITLE
Don't delete unused denial reasons

### DIFF
--- a/api/staticdata/management/commands/seeddenialreasons.py
+++ b/api/staticdata/management/commands/seeddenialreasons.py
@@ -22,4 +22,3 @@ class Command(SeedCommand):
             {"id": row["id"], "deprecated": row["deprecated"], "description": row["description"]} for row in csv
         ]
         self.update_or_create(DenialReason, filtered_csv)
-        self.delete_unused_objects(DenialReason, filtered_csv)


### PR DESCRIPTION
This command will also remove any associated advice->denial reason
mappings via the many-to-many through table which is not desired.