### PR TITLE
LTD-1594: Include Flag id in the serializer fields

### DIFF
--- a/api/flags/serializers.py
+++ b/api/flags/serializers.py
@@ -163,6 +163,7 @@ class FlagAssignmentSerializer(serializers.Serializer):
 
 
 class CaseListFlagSerializer(serializers.Serializer):
+    id = serializers.UUIDField(read_only=True)
     name = serializers.CharField()
     label = serializers.CharField()
     colour = serializers.CharField()


### PR DESCRIPTION
id is used to determine if countersigning is required or not