### PR TITLE
LTD-1666: Advice text is optional for NLR

### DIFF
--- a/api/applications/serializers/advice.py
+++ b/api/applications/serializers/advice.py
@@ -130,7 +130,10 @@ class AdviceCreateSerializer(serializers.ModelSerializer):
             self._footnote_fields_setup()
 
             # Only require a reason for the advice decision if it is of type refuse
-            if self.initial_data[0].get("type") != AdviceType.REFUSE:
+            if (
+                self.initial_data[0].get("type") != AdviceType.REFUSE
+                or self.initial_data[0].get("type") != AdviceType.NO_LICENCE_REQUIRED
+            ):
                 self.fields["text"].required = False
                 self.fields["text"].allow_null = True
                 self.fields["text"].allow_blank = True


### PR DESCRIPTION
## Change description

Users don't really submit recommendation for NLR type but to be able
to generate NLR letter we need final advice of NLR type hence make
the advice text optional in this case.