### PR TITLE
LTD-1699: Use background task for ES index update

### DIFF
--- a/api/search/signals.py
+++ b/api/search/signals.py
@@ -1,15 +1,16 @@
+from background_task.models import Task
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django_elasticsearch_dsl.registries import registry
 
 from api.applications.models import BaseApplication
+from api.search.tasks import update_search_index
 
 
 @receiver(post_save)
 def update_application_document(sender, **kwargs):
-    if not settings.LITE_API_ENABLE_ES:
+    if not settings.LITE_API_ENABLE_ES or issubclass(sender, Task):
         return
 
     app_label = sender._meta.app_label
@@ -20,26 +21,35 @@ def update_application_document(sender, **kwargs):
     To keep the index fresh we need to update them whenever the underlying data is updated.
     The immediate attributes of the index are handled by django_elasticsearch_dsl but
     additional changes are required to update the related models.
-
     The registry update code requires model corresponding to the index which is BaseApplication
     in our case. We intercept the signals and update the index.
     """
+    to_update = []
+
     if issubclass(sender, BaseApplication):
-        registry.update(instance.baseapplication)
+        to_update.append(instance.baseapplication.pk)
 
     try:
         if app_label == "cases" and model_name == "caseassignment":
-            registry.update(instance.case.baseapplication)
+            to_update.append(instance.case.baseapplication.pk)
         elif app_label == "cases" and model_name == "case":
-            registry.update(instance.baseapplication)
+            to_update.append(instance.baseapplication.pk)
         elif app_label == "goods" and model_name == "good":
             for good in instance.goods_on_application.all():
-                registry.update(good.application)
+                to_update.append(good.application.pk)
         elif app_label == "parties" and model_name == "party":
             for party in instance.parties_on_application.all():
-                registry.update(party.application)
+                to_update.append(party.application.pk)
         elif app_label == "organisations" and model_name == "organisation":
             for case in instance.cases.all():
-                registry.update(case.baseapplication)
+                to_update.append(case.baseapplication.pk)
     except ObjectDoesNotExist:
         pass
+
+    if to_update:
+        update_task = update_search_index
+
+        if not settings.BACKGROUND_TASK_ENABLED:
+            update_task = update_search_index.now
+
+        update_task("applications.BaseApplication", *map(str, to_update))

--- a/api/search/tasks.py
+++ b/api/search/tasks.py
@@ -1,0 +1,17 @@
+from background_task import background
+from django.apps import apps
+from django_elasticsearch_dsl.registries import registry
+
+UPDATE_SEARCH_INDEX_QUEUE = "update_search_index_queue"
+
+
+@background(queue=UPDATE_SEARCH_INDEX_QUEUE, schedule=0)
+def update_search_index(model_name, *ids):
+    """Update the search index with instances of a model as specified by
+    the supplied model_name and ids.
+    """
+    model = apps.get_model(model_name)
+
+    for id_ in ids:
+        instance = model.objects.get(pk=id_)
+        registry.update(instance)

--- a/api/search/tests/test_signals.py
+++ b/api/search/tests/test_signals.py
@@ -1,0 +1,62 @@
+from unittest.mock import call, patch
+
+from django.test import override_settings
+
+from api.parties.models import PartyType
+from test_helpers.clients import DataTestClient
+
+
+class UpdateApplicationDocumentTest(DataTestClient):
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_standard_application(self, mock_task):
+        application = self.create_standard_application_case(self.organisation)
+
+        mock_task.assert_has_calls([call("applications.BaseApplication", str(application.pk))])
+
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_case_assignment(self, mock_task):
+        assignment = self.create_case_assignment(
+            self.queue, self.create_standard_application_case(self.organisation), self.gov_user
+        )
+
+        mock_task.assert_has_calls([call("applications.BaseApplication", str(assignment.case.baseapplication.pk))])
+
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_case(self, mock_task):
+        case = self.create_standard_application_case(self.organisation).get_case()
+
+        mock_task.assert_has_calls([call("applications.BaseApplication", str(case.baseapplication.pk))])
+
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_good(self, mock_task):
+        application = self.create_standard_application_case(self.organisation)
+        good = self.create_good("test good", self.organisation)
+        good_on_app = self.create_good_on_application(application, good)
+        application.goods.add(good_on_app)
+        application.save()
+
+        mock_task.assert_has_calls([call("applications.BaseApplication", str(good_on_app.application.pk))])
+
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_party(self, mock_task):
+        application = self.create_standard_application_case(self.organisation)
+        party = self.create_party("test party", self.organisation, PartyType.END_USER, application=application)
+        party.save()
+
+        mock_task.assert_has_calls(
+            [call("applications.BaseApplication", str(party.parties_on_application.all()[0].application.pk))]
+        )
+
+    @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
+    @patch("api.search.signals.update_search_index")
+    def test_organisation(self, mock_task):
+        self.create_standard_application_case(self.organisation)
+
+        mock_task.assert_has_calls(
+            [call("applications.BaseApplication", str(self.organisation.cases.all()[0].baseapplication.pk))]
+        )

--- a/api/search/tests/test_tasks.py
+++ b/api/search/tests/test_tasks.py
@@ -1,0 +1,15 @@
+from unittest.mock import call, patch
+
+from api.search.tasks import update_search_index
+from test_helpers.clients import DataTestClient
+
+
+class UpdateSearchIndexTests(DataTestClient):
+    @patch("api.search.tasks.registry")
+    def test_update_index(self, mock_registry):
+        app1 = self.create_standard_application_case(self.organisation)
+        app2 = self.create_standard_application_case(self.organisation)
+
+        update_search_index.now("applications.StandardApplication", str(app1.pk), str(app2.pk))
+
+        mock_registry.update.assert_has_calls([call(app1), call(app2)])


### PR DESCRIPTION
Changes to certain models trigger an Elastic Search index update on `save()`. If a model has a large number of related items (e.g. a case with many goods) then the ES update can significantly slow down the `save()` call and cause things to timeout.

This PR makes the ES index update asynchronous by moving the updates to a background task.