### PR TITLE
LTD-1676: Support default values for audit substitution params

### DIFF
--- a/api/audit_trail/payload.py
+++ b/api/audit_trail/payload.py
@@ -19,8 +19,12 @@ class DefaultValueParameterFormatter(Formatter):
                 return kwds[key]
             except KeyError:
                 try:
-                    return key.split("|")[1].strip()
-                except IndexError:
+                    key, val = key.split("|")
+                    try:
+                        return kwds[key.strip()]
+                    except KeyError:
+                        return val.strip()
+                except ValueError:
                     raise KeyError(f"Payload does not contain parameter '{key}' and message specifies no default value")
         else:
             return Formatter.get_value(key, args, kwds)

--- a/api/audit_trail/payload.py
+++ b/api/audit_trail/payload.py
@@ -153,5 +153,5 @@ audit_type_format = {
     AuditType.LICENCE_UPDATED_STATUS: strings.Audit.LICENCE_UPDATED_STATUS,
     AuditType.DOCUMENT_ON_ORGANISATION_CREATE: "added {document_type} '{file_name}' to organization",
     AuditType.REPORT_SUMMARY_UPDATED: "updated ARS for {good_name} from {old_report_summary} to {report_summary}",
-    AuditType.COUNTERSIGN_ADVICE: "countersigned all {department|FCDO} recommendations",
+    AuditType.COUNTERSIGN_ADVICE: "countersigned all {department|} recommendations",
 }

--- a/api/audit_trail/tests/test_audit_payload.py
+++ b/api/audit_trail/tests/test_audit_payload.py
@@ -16,6 +16,8 @@ class TestPayload(DataTestClient):
                 {"file_name": "file.png", "party_type": "Party", "party_name": "Name"},
                 "uploaded the document file.png for Party Name.",
             ],
+            [AuditType.COUNTERSIGN_ADVICE, {"department": "Test Dept"}, "countersigned all Test Dept recommendations."],
+            [AuditType.COUNTERSIGN_ADVICE, {}, "countersigned all  recommendations."],
         ]
     )
     def test_audit_type_formatter_success(self, verb, payload, expected_text):


### PR DESCRIPTION
If a timeline message is changed it potentially no longer matches the payload parameters that are stored for historic audit records. This PR allows a default value to be supplied for parameters so the code has a fallback option.

Also improves error reporting.