### PR TITLE
LTD-1643-Enable the ability to export to Great Britain

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: /vendor,/.venv,/staticdata/management,**/test_*.py
+exclude: /vendor,/.venv,/staticdata/management,**/test_*.py,/staticdata/countries/test.py

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,3 +1,7 @@
+from django.core.management import call_command
+from django.db.migrations.executor import MigrationExecutor
+from django import db
+
 import re
 import glob
 from importlib import import_module
@@ -62,3 +66,50 @@ def {fixture_name}(db):
 if settings.DEBUG:
     for fixture_name in sorted(fixture_names):
         print(f"pytest.fixture: {fixture_name}")
+
+
+@pytest.fixture()
+def migration(transactional_db):
+    """
+    This fixture returns a helper object to test Django data migrations.
+    The fixture returns an object with two methods;
+     - `before` to initialize db to the state before the migration under test
+     - `after` to execute the migration and bring db to the state after the
+    migration. The methods return `old_apps` and `new_apps` respectively; these
+    can be used to initiate the ORM models as in the migrations themselves.
+    For example:
+        def test_foo_set_to_bar(migration):
+            old_apps = migration.before([('my_app', '0001_inital')])
+            Foo = old_apps.get_model('my_app', 'foo')
+            Foo.objects.create(bar=False)
+            assert Foo.objects.count() == 1
+            assert Foo.objects.filter(bar=False).count() == Foo.objects.count()
+            # executing migration
+            new_apps = migration.apply('my_app', '0002_set_foo_bar')
+            Foo = new_apps.get_model('my_app', 'foo')
+            assert Foo.objects.filter(bar=False).count() == 0
+            assert Foo.objects.filter(bar=True).count() == Foo.objects.count()
+    From: https://gist.github.com/asfaltboy/b3e6f9b5d95af8ba2cc46f2ba6eae5e2
+    """
+
+    class Migrator:
+        def before(self, migrate_from):
+            """Specify app and starting migration name as in:
+            before(['app', '0001_before']) => app/migrations/0001_before.py
+            """
+            self.migrate_from = migrate_from
+            self.executor = MigrationExecutor(db.connection)
+            self.executor.migrate(self.migrate_from)
+            self._old_apps = self.executor.loader.project_state(self.migrate_from).apps
+            return self._old_apps
+
+        def apply(self, app, migrate_to):
+            """Migrate forwards to the "migrate_to" migration"""
+            self.migrate_to = [(app, migrate_to)]
+            self.executor.loader.build_graph()  # reload.
+            self.executor.migrate(self.migrate_to)
+            self._new_apps = self.executor.loader.project_state(self.migrate_to).apps
+            return self._new_apps
+
+    yield Migrator()
+    call_command("migrate")

--- a/api/staticdata/countries/migrations/0002_rename_countries.py
+++ b/api/staticdata/countries/migrations/0002_rename_countries.py
@@ -1,0 +1,42 @@
+import logging
+
+from django.db import migrations
+
+from api.staticdata.countries.models import Country
+
+logger = logging.getLogger(__name__)
+
+
+def rename_countries(apps, schema_editor):
+    change_needed = {"United Kingdom": "Great Britain", "St Vincent": "St Vincent and the Grenadines"}
+
+    for key in change_needed:
+      country_query = Country.objects.filter(name__iexact=key)
+
+      if country_query.exists():
+        country = country_query.first()
+        country.name = change_needed[key]
+        country.save()
+
+def rename_reverse_countries(apps, schema_editor):
+    change_needed = {"Great Britain": "United Kingdom", "St Vincent and the Grenadines": "St Vincent"}
+
+    for key in change_needed:
+      country_query = Country.objects.filter(name__iexact=key)
+
+      if country_query.exists():
+        country = country_query.first()
+        country.name = change_needed[key]
+        country.save()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('countries', '0001_squashed_0003_auto_20210105_1058'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_countries,
+            rename_reverse_countries
+        ),
+    ]

--- a/api/staticdata/countries/migrations/0002_rename_countries.py
+++ b/api/staticdata/countries/migrations/0002_rename_countries.py
@@ -1,29 +1,27 @@
 from django.db import migrations
 
-from api.staticdata.countries.models import Country
+change_needed = [("United Kingdom", "Great Britain"), ("St Vincent", "St Vincent and the Grenadines")]
 
 
 def rename_countries(apps, schema_editor):
-    change_needed = {"United Kingdom": "Great Britain", "St Vincent": "St Vincent and the Grenadines"}
-
-    for key in change_needed:
-        country_query = Country.objects.filter(name__iexact=key)
+    Country = apps.get_model("countries", "Country")
+    for old_name, new_name in change_needed:
+        country_query = Country.objects.filter(name__iexact=old_name)
 
         if country_query.exists():
             country = country_query.first()
-            country.name = change_needed[key]
+            country.name = new_name
             country.save()
 
 
 def rename_reverse_countries(apps, schema_editor):
-    change_needed = {"Great Britain": "United Kingdom", "St Vincent and the Grenadines": "St Vincent"}
-
-    for key in change_needed:
-        country_query = Country.objects.filter(name__iexact=key)
+    Country = apps.get_model("countries", "Country")
+    for old_name, new_name in change_needed:
+        country_query = Country.objects.filter(name__iexact=new_name)
 
         if country_query.exists():
             country = country_query.first()
-            country.name = change_needed[key]
+            country.name = old_name
             country.save()
 
 

--- a/api/staticdata/countries/migrations/0002_rename_countries.py
+++ b/api/staticdata/countries/migrations/0002_rename_countries.py
@@ -1,42 +1,37 @@
-import logging
-
 from django.db import migrations
 
 from api.staticdata.countries.models import Country
-
-logger = logging.getLogger(__name__)
 
 
 def rename_countries(apps, schema_editor):
     change_needed = {"United Kingdom": "Great Britain", "St Vincent": "St Vincent and the Grenadines"}
 
     for key in change_needed:
-      country_query = Country.objects.filter(name__iexact=key)
+        country_query = Country.objects.filter(name__iexact=key)
 
-      if country_query.exists():
-        country = country_query.first()
-        country.name = change_needed[key]
-        country.save()
+        if country_query.exists():
+            country = country_query.first()
+            country.name = change_needed[key]
+            country.save()
+
 
 def rename_reverse_countries(apps, schema_editor):
     change_needed = {"Great Britain": "United Kingdom", "St Vincent and the Grenadines": "St Vincent"}
 
     for key in change_needed:
-      country_query = Country.objects.filter(name__iexact=key)
+        country_query = Country.objects.filter(name__iexact=key)
 
-      if country_query.exists():
-        country = country_query.first()
-        country.name = change_needed[key]
-        country.save()
+        if country_query.exists():
+            country = country_query.first()
+            country.name = change_needed[key]
+            country.save()
+
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('countries', '0001_squashed_0003_auto_20210105_1058'),
+        ("countries", "0001_squashed_0003_auto_20210105_1058"),
     ]
 
     operations = [
-        migrations.RunPython(
-            rename_countries,
-            rename_reverse_countries
-        ),
+        migrations.RunPython(rename_countries, rename_reverse_countries),
     ]

--- a/api/staticdata/countries/test.py
+++ b/api/staticdata/countries/test.py
@@ -1,5 +1,8 @@
+from django.apps import apps
+
 from rest_framework import status
 from rest_framework.reverse import reverse
+import pytest
 
 from api.staticdata.countries.models import Country
 from test_helpers.clients import DataTestClient
@@ -52,3 +55,13 @@ class CountriesResponseTests(EndPointTests):
 
     def test_countries(self):
         self.call_endpoint(self.get_exporter_headers(), self.url)
+
+
+@pytest.mark.django_db
+def test_rename_countries_migration(migration):
+    old_apps = migration.before([("countries", "0001_squashed_0003_auto_20210105_1058")])
+    Country = apps.get_model("countries", "Country")
+    assert Country.objects.filter(name="United Kingdom").first().name == "United Kingdom"
+    # executing migration
+    new_apps = migration.apply("countries", "0002_rename_countries")
+    assert Country.objects.filter(name="Great Britain").first().name == "Great Britain"


### PR DESCRIPTION
This ticket change names from United Kingdom to Great Britain. Essentially it is what being asked in the story by adding Great Britain and removing United Kingdom from the list. 

From database point of view it does not make any difference.

In the same migration I also changed the name for St Vincent → St Vincent and the Grenadines from the ticket:
https://uktrade.atlassian.net/browse/LTD-1467

since it is related and both report and end user address are being pulled from the same source of countries in database.

SS with GB:
<img width="974" alt="Screenshot 2022-02-14 at 13 46 26" src="https://user-images.githubusercontent.com/24960282/153881408-a0245690-98aa-4949-b3a3-fdc4c3b40358.png">

SS with Untied Kingdom removed:
<img width="1052" alt="Screenshot 2022-02-14 at 13 46 19" src="https://user-images.githubusercontent.com/24960282/153881449-65c9cf60-9400-4c04-b938-1d9d7e6d383c.png">


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-1643
- [x] Jira ticket has the correct status.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
