### PR TITLE
Some tests misusing assertTrue for comparisons fix

### DIFF
--- a/api/goods/tests/test_edit.py
+++ b/api/goods/tests/test_edit.py
@@ -471,7 +471,7 @@ class GoodsEditDraftGoodTests(DataTestClient):
         errors = response.json()["errors"]
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue(errors["section_certificate_number"], ["Enter the certificate number"])
+        self.assertEqual(errors["section_certificate_number"], ["Enter the certificate number"])
 
     def test_edit_category_two_section_question_and_invalid_expiry_date_failure(self):
         """Test editing section of firearms question failure by providing an expiry date not in the future."""

--- a/api/organisations/tests/test_users.py
+++ b/api/organisations/tests/test_users.py
@@ -135,7 +135,7 @@ class OrganisationUsersCreateTests(DataTestClient):
         response = self.client.post(self.url, data, **self.exporter_headers)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(len(UserOrganisationRelationship.objects.all()), 2)
+        self.assertEqual(len(UserOrganisationRelationship.objects.all()), 2)
 
     def test_add_user_to_another_organisation_success(self):
         """
@@ -176,7 +176,7 @@ class OrganisationUsersCreateTests(DataTestClient):
             response_data["errors"]["email"][0],
             data["email"] + " isn't valid",
         )
-        self.assertTrue(len(UserOrganisationRelationship.objects.all()), 1)
+        self.assertEqual(len(UserOrganisationRelationship.objects.all()), 1)
 
     def test_cannot_add_user_without_permission(self):
         self.exporter_user.set_role(self.organisation, self.exporter_default_role)


### PR DESCRIPTION
`assertTrue` is not for comparing arguments, should use `assertEqual` for that.

The developer's intent of the test was to compare argument 1 with argument 2, which is not happening. Really what is happening is the test is passing because first argument is truthy. The correct method to use is assertEqual. [more details](https://codereview.doctor/features/python/best-practice/avoid-misusing-unittest-assert-true)