### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/api/applications/tests/test_duration_view.py
+++ b/api/applications/tests/test_duration_view.py
@@ -25,7 +25,7 @@ class DurationViewTest(DataTestClient):
 
         self.assertEqual(response.json()["licence_duration"], DefaultDuration.PERMANENT_OPEN.value)
 
-    def test_get_open_licence_duration_non_eu(self):
+    def test_get_open_licence_duration_non_eu_two(self):
         url = reverse("applications:duration", kwargs={"pk": self.open_application.pk})
 
         country = CountryOnApplication.objects.get(application=self.open_application).country

--- a/api/applications/tests/test_endpoints_response_applications.py
+++ b/api/applications/tests/test_endpoints_response_applications.py
@@ -107,12 +107,12 @@ class ApplicationResponseTests(EndPointTests):
     def test_application_sites(self):
         self.call_endpoint(self.get_exporter_headers(), self.url + self.get_standard_application()["id"] + "/sites/")
 
-    def test_application_external_locations(self):
+    def test_application_external_locations_two(self):
         self.call_endpoint(
             self.get_exporter_headers(), self.url + self.get_standard_application()["id"] + "/external_locations/"
         )
 
-    def test_application_countries(self):
+    def test_application_countries_two(self):
         self.call_endpoint(
             self.get_exporter_headers(), self.url + self.get_standard_application()["id"] + "/countries/"
         )

--- a/api/applications/tests/test_ultimate_end_users.py
+++ b/api/applications/tests/test_ultimate_end_users.py
@@ -216,7 +216,7 @@ class UltimateEndUsersOnDraft(DataTestClient):
 
     @mock.patch("api.documents.tasks.scan_document_for_viruses.now")
     @mock.patch("api.documents.models.Document.delete_s3")
-    def test_delete_ultimate_end_user_success(self, delete_s3_function, scan_document_for_viruses_function):
+    def test_delete_ultimate_end_user_success_two(self, delete_s3_function, scan_document_for_viruses_function):
         self.assertEqual(self.draft.ultimate_end_users.count(), 1)
 
         url = reverse(

--- a/api/goods/tests/test_create.py
+++ b/api/goods/tests/test_create.py
@@ -658,7 +658,7 @@ class CreateGoodTests(DataTestClient):
             "Enter the certificate expiry date and include a day, month and year",
         )
 
-    def test_add_firearms_certificate_missing_checks(self):
+    def test_add_firearms_certificate_missing_checks_two(self):
         data = {
             "name": "Rifle",
             "description": "Firearm product",


### PR DESCRIPTION
These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

More details [here](https://codereview.doctor/features/python/best-practice/avoid-duplicate-unit-test-names).