### PR TITLE
Add dockerfile so it could be published to gcr

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,20 @@
+FROM python:3.7-slim
+
+WORKDIR /app
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y libpq-dev gcc \
+  build-essential python3-dev python3-pip python3-setuptools python3-wheel \
+  python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 \
+  libffi-dev shared-mime-info swig
+
+RUN pip3 install pipenv
+
+ADD Pipfile* /app/
+
+RUN pipenv install --dev --system --deploy
+RUN pip3 install endesive==1.5.9
+
+ADD . /app
+
+CMD ./start-e2e.sh

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,66 @@
+version: '3.4'
+
+services:
+  api:
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - elasticsearch
+      - redis
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - 8100:8100
+    expose:
+      - 8100
+    command: /app/start-e2e.sh
+    stdin_open: true
+    tty: true
+
+  db:
+    image: "postgres"
+    environment:
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=lite-api
+    expose:
+      - 5432
+    ports:
+      - 5462:5432
+
+  # Elasticsearch Docker Images: https://www.docker.elastic.co/
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    container_name: elasticsearch
+    environment:
+      - xpack.security.enabled=false
+      - xpack.ml.enabled=false
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms128m -Xmx1g
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+  redis:
+    image: "redis:5-alpine"
+    container_name: redis
+    expose:
+      - 6379
+    ports:
+      - 6379:6379
+
+volumes:
+  elasticsearch-data:
+    driver: local

--- a/makefile
+++ b/makefile
@@ -1,5 +1,7 @@
 ARGUMENTS = $(filter-out $@,$(MAKECMDGOALS)) $(filter-out --,$(MAKEFLAGS))
 
+docker-base = docker-compose -p lite -f docker-compose.e2e.yml
+
 clean:
 	-find . -type f -name "*.pyc" -delete
 	-find . -type d -name "__pycache__" -delete
@@ -18,3 +20,9 @@ test:
 
 secrets:
 	cp local.env .env
+
+start-e2e:
+	$(docker-base) up
+
+stop-e2e:
+	$(docker-base) down

--- a/start-e2e.sh
+++ b/start-e2e.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -xe
+python /app/manage.py migrate --noinput
+
+# Load initial data
+python /app/manage.py seedall
+
+# Create initial users
+INTERNAL_USERS='[{"email"=>"foo@bar.gov.uk"}]' /app/manage.py seedinternalusers
+EXPORTER_USERS='[{"email"=>"foo@bar.com"}]' /app/manage.py seedexporterusers
+
+# Run background tasks
+python /app/manage.py process_tasks
+
+# Run runserver in a while loop as the whole docker container will otherwise die
+# when there is bad syntax
+while true; do
+    python /app/manage.py runserver_plus 0.0.0.0:8100
+    sleep 1
+done


### PR DESCRIPTION
The intent of this PR is to create a lite-api image that allows us to leave the api app in a state we need it so that it can be published and used in the frontend.

How to test this PR:

- Ensure you are in a clean state by running `docker-compose down`
- Start the new docker setup: `make start-e2e`
- Stop the new docker setup: `make stop-e2e`