### PR TITLE
LTD-2156: Update Good serializer to be able to save document related options

### DIFF
--- a/api/applications/tests/test_standard_application_submit.py
+++ b/api/applications/tests/test_standard_application_submit.py
@@ -532,9 +532,6 @@ class StandardApplicationTests(DataTestClient):
         self.assertNotIn(SystemFlags.WMD_END_USE_ID, case_flags)
         self.assertNotIn(SystemFlags.MARITIME_ANTI_PIRACY_ID, case_flags)
 
-        # only good on the draft not firearms
-        self.assertNotIn(SystemFlags.FIREARMS_ID, case_flags)
-
         html_to_pdf_func.assert_called_once()
         upload_bytes_file_func.assert_called_once()
 

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -268,6 +268,9 @@ class GoodCreateSerializer(serializers.ModelSerializer):
         choices=GoodPvGraded.choices, error_messages={"required": strings.Goods.FORM_DEFAULT_ERROR_RADIO_REQUIRED}
     )
     pv_grading_details = PvGradingDetailsSerializer(allow_null=True, required=False)
+    is_document_available = serializers.BooleanField(allow_null=True, required=False, default=None)
+    no_document_comments = serializers.CharField(allow_blank=True, required=False)
+    is_document_sensitive = serializers.BooleanField(allow_null=True, required=False, default=None)
     item_category = KeyValueChoiceField(
         choices=ItemCategory.choices, error_messages={"required": strings.Goods.FORM_NO_ITEM_CATEGORY_SELECTED}
     )
@@ -388,6 +391,9 @@ class GoodCreateSerializer(serializers.ModelSerializer):
         instance.part_number = validated_data.get("part_number", instance.part_number)
         instance.status = validated_data.get("status", instance.status)
         instance.is_pv_graded = validated_data.get("is_pv_graded", instance.is_pv_graded)
+        instance.is_document_available = validated_data.get("is_document_available", instance.is_document_available)
+        instance.no_document_comments = validated_data.get("no_document_comments", instance.no_document_comments)
+        instance.is_document_sensitive = validated_data.get("is_document_sensitive", instance.is_document_sensitive)
 
         if "control_list_entries" in validated_data:
             instance.control_list_entries.set(validated_data["control_list_entries"])

--- a/api/goods/tests/factories.py
+++ b/api/goods/tests/factories.py
@@ -12,10 +12,12 @@ class GoodFactory(factory.django.DjangoModelFactory):
     is_good_controlled = False
     part_number = factory.Faker("ean13")
     organisation = None
-    item_category = ItemCategory.GROUP1_COMPONENTS
+    item_category = ItemCategory.GROUP2_FIREARMS
     is_military_use = MilitaryUse.NO
     is_component = Component.NO
     is_pv_graded = GoodPvGraded.NO
+    is_document_available = True
+    is_document_sensitive = False
     uses_information_security = False
     information_security_details = None
     modified_military_use_details = None

--- a/api/goods/tests/test_goods_documents.py
+++ b/api/goods/tests/test_goods_documents.py
@@ -82,6 +82,32 @@ class GoodDocumentsTests(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_edit_product_document_availability(self):
+        draft = self.create_draft_standard_application(self.organisation)
+        good = GoodOnApplication.objects.get(application=draft).good
+        self.assertTrue(good.is_document_available)
+
+        url = reverse("goods:good", kwargs={"pk": good.id})
+        response = self.client.put(
+            url,
+            {"is_document_available": False, "no_document_comments": "Product not manufactured yet"},
+            **self.exporter_headers,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        good = response.json()["good"]
+        self.assertFalse(good["is_document_available"])
+        self.assertEqual(good["no_document_comments"], "Product not manufactured yet")
+
+    def test_edit_product_document_sensitivity(self):
+        draft = self.create_draft_standard_application(self.organisation)
+        good = GoodOnApplication.objects.get(application=draft).good
+        self.assertFalse(good.is_document_sensitive)
+
+        url = reverse("goods:good", kwargs={"pk": good.id})
+        response = self.client.put(url, {"is_document_sensitive": True}, **self.exporter_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()["good"]["is_document_sensitive"])
+
     def test_edit_product_document_description(self):
         draft = self.create_draft_standard_application(self.organisation)
         good = GoodOnApplication.objects.get(application=draft).good


### PR DESCRIPTION
## Change description

Currently we don't have any option to edit product document availability and sensitivity options as in the current wizard we ask these questions after a product is created.

In the new wizard however we ask these before a product is created and user has an option to edit these from summary screen. So update serializer to be able to save changes and also add unit tests.