### PR TITLE
LTD-2310: Copy existing certificate number if there is a valid certificate

### DIFF
--- a/api/goods/helpers.py
+++ b/api/goods/helpers.py
@@ -112,11 +112,6 @@ def update_firearms_certificate_data(organisation_id, firearm_data):
             del firearm_data["section_certificate_number"]
         return firearm_data
 
-    if has_valid_rfd and has_valid_section5:
-        # because user is not asked to upload the certificate again
-        # it fails validation if this is not removed here
-        del firearm_data["section_certificate_number"]
-
     return firearm_data
 
 


### PR DESCRIPTION
## Change description

Currently if we have a vlid RFD and Section5 certificate then when copying
the data to GoodOnApplication then we are removing certificate number, because
of this the certificate is empty in GoodOnApplication.