### PR TITLE
Add team name for caseworker actors.

### DIFF
--- a/api/audit_trail/serializers.py
+++ b/api/audit_trail/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from api.audit_trail.models import Audit
 from api.audit_trail.enums import AuditType
 from api.audit_trail.payload import format_payload
+from api.users.enums import UserType
 
 
 class AuditSerializer(serializers.ModelSerializer):
@@ -30,6 +31,7 @@ class AuditSerializer(serializers.ModelSerializer):
                 "first_name": instance.actor.first_name,
                 "last_name": instance.actor.last_name,
                 "type": instance.actor.type,
+                "team": instance.actor.team.name if instance.actor.type == UserType.INTERNAL else "",
             }
         else:
             # When an anonymous user is registering for an org,

--- a/api/cases/tests/test_activity.py
+++ b/api/cases/tests/test_activity.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+
+from api.cases.enums import AdviceType, AdviceLevel
+from test_helpers.clients import DataTestClient
+
+
+class ActivityViewTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        application = self.create_draft_standard_application(self.organisation)
+        self.case = self.submit_application(application)
+        self.url = reverse("cases:activity", kwargs={"pk": self.case.id})
+        # Give advice to generate some activity from the caseworker
+        self.advice_url = reverse("cases:user_advice", kwargs={"pk": self.case.id})
+        self.client.post(
+            self.advice_url,
+            **self.gov_headers,
+            data=[
+                {
+                    "type": AdviceType.APPROVE,
+                    "text": "I Am Easy to Find",
+                    "note": "I Am Easy to Find",
+                    "country": "GB",
+                    "level": AdviceLevel.USER,
+                }
+            ],
+        )
+
+    def test_view_pre_submitted_case_notes_post_submit(self):
+        response = self.client.get(self.url, **self.gov_headers)
+        data = response.json()["activity"]
+        assert len(data) == 2
+        assert data[0]["user"]["team"] == "Admin"
+        assert data[1]["user"]["team"] == ""


### PR DESCRIPTION
This is to support the following text on the FE notes and timeline -

```
[team-name]: [user-name] did [action]
```
