### PR TITLE
Add explicit tests for date based functions to handle discrepancies on the date the tests are run

### DIFF
--- a/api/cases/tasks.py
+++ b/api/cases/tasks.py
@@ -48,16 +48,21 @@ def today(time=None):
     return datetime.combine(timezone.localtime(), time, tzinfo=tz(settings.TIME_ZONE))
 
 
-def yesterday(date=timezone.localtime(), time=None):
+def yesterday(date=None, time=None):
     """
     returns the previous working day from the date provided (defaults to now) at the time provided (defaults to now)
     """
+    if not date:
+        date = timezone.localtime()
+
     day = date - timezone.timedelta(days=1)
 
     while is_bank_holiday(day, call_api=False) or is_weekend(day):
         day = day - timezone.timedelta(days=1)
+
     if time:
         day = datetime.combine(day.date(), time, tzinfo=tz(settings.TIME_ZONE))
+
     return day
 
 

--- a/api/cases/tests/test_tasks.py
+++ b/api/cases/tests/test_tasks.py
@@ -1,0 +1,73 @@
+import datetime
+
+from freezegun import freeze_time
+from parameterized import parameterized
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from ..tasks import today, yesterday
+
+
+@override_settings(TIME_ZONE="utc")
+@freeze_time("2020-01-01 12:00:01")
+class TodayTestCase(TestCase):
+    def test_today_without_time(self):
+        output = today()
+        self.assertEqual(
+            output,
+            datetime.datetime(2020, 1, 1, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+    def test_today_with_time(self):
+        output = today(time=datetime.time(1, 0, 1))
+        self.assertEqual(
+            output,
+            datetime.datetime(2020, 1, 1, 1, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+
+@override_settings(TIME_ZONE="utc")
+@freeze_time("2022-07-12 12:00:01")
+class YesterdayTestCase(TestCase):
+    FRIDAY = datetime.datetime(2022, 7, 8, 12, 0, 1)
+    SATURDAY = datetime.datetime(2022, 7, 9, 12, 0, 1)
+    SUNDAY = datetime.datetime(2022, 7, 10, 12, 0, 1)
+
+    DAY_BEFORE_BANK_HOLIDAY = datetime.datetime(2020, 12, 24, 12, 0, 1)
+    BANK_HOLIDAY = datetime.datetime(2020, 12, 25, 12, 0, 1)
+
+    def test_yesterday(self):
+        output = yesterday()
+        self.assertEqual(
+            output,
+            datetime.datetime(2022, 7, 11, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+    def test_yesterday_with_explicit_date(self):
+        output = yesterday(
+            date=datetime.datetime(2022, 7, 13, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+        self.assertEqual(
+            output,
+            datetime.datetime(2022, 7, 12, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+    def test_yesterday_with_explicit_time(self):
+        output = yesterday(
+            date=datetime.datetime(2022, 7, 13, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+            time=datetime.time(1, 0, 1),
+        )
+        self.assertEqual(
+            output,
+            datetime.datetime(2022, 7, 12, 1, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+    @parameterized.expand([(SATURDAY,), (SUNDAY,)])
+    def test_yesterday_on_weekend(self, date):
+        output = yesterday(date=date)
+        self.assertEqual(output, self.FRIDAY)
+
+    def test_yesterday_on_bank_holiday(self):
+        output = yesterday(date=self.BANK_HOLIDAY)
+        self.assertEqual(output, self.DAY_BEFORE_BANK_HOLIDAY)


### PR DESCRIPTION
We were getting non-deterministic code coverage results, even when testing against an empty commit there were cases where the code coverage went down.

This was due to the fact that there were functions being run that would change execution path depending on the day of the week, in this case if the day before was a bank holiday or a weekend it would affect the code coverage.

This pull request adds explicit tests to cover all of the possible execution paths of these date based functions.