### PR TITLE
[LTD-2541] Goods incorrectly shown as assessed

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -1,5 +1,7 @@
+import logging
 import uuid
 
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -41,6 +43,9 @@ from api.staticdata.trade_control.enums import TradeControlProductCategory, Trad
 from api.staticdata.units.enums import Units
 from api.users.models import ExporterUser
 from lite_content.lite_api.strings import PartyErrors
+
+
+gona_copy_logger = logging.getLogger(settings.GOOD_ON_APPLICATION_COPY_LOGGER)
 
 
 class ApplicationException(APIException):
@@ -410,6 +415,22 @@ class GoodOnApplication(AbstractGoodOnApplication):
         if self.is_good_controlled is None:
             return self.good.control_list_entries
         return self.control_list_entries
+
+    def save(self, *args, **kwargs):
+        """LTD-2541 - we want to flag when a GoodOnApplication object
+        is saved with properties that seem to be copied from the
+        associated Good.
+        """
+        super().save(*args, **kwargs)
+        cle = set(self.control_list_entries.all())
+        good_cle = set(self.good.control_list_entries.all())
+        if cle == good_cle and cle != set():
+            gona_copy_logger.warning(
+                "Saving GoodOnApplication (%s) with CLE copied from Good: (%s)",
+                str(self.id),
+                str(self.good_id),
+                stack_info=True,
+            )
 
 
 class GoodOnApplicationDocument(Document):

--- a/api/applications/tests/test_models.py
+++ b/api/applications/tests/test_models.py
@@ -1,0 +1,70 @@
+from django.conf import settings
+
+from test_helpers.clients import DataTestClient
+from parameterized import parameterized
+from api.staticdata.control_list_entries.models import ControlListEntry
+
+
+gona_copy_logger = settings.GOOD_ON_APPLICATION_COPY_LOGGER
+
+
+class GoodOnApplicationSave(DataTestClient):
+    @parameterized.expand(
+        [
+            [
+                ["ML1a"],
+                ["ML1a"],
+            ],
+            [
+                ["ML1a", "ML1b"],
+                ["ML1a", "ML1b"],
+            ],
+        ]
+    )
+    def test_save_log(self, good_cle, gona_cle):
+        with self.assertLogs(logger=gona_copy_logger, level="WARNING") as log:
+            application = self.create_draft_standard_application(
+                organisation=self.organisation, user=self.exporter_user
+            )
+            good = self.create_good(
+                "A good", self.organisation, is_good_controlled=good_cle != [], control_list_entries=good_cle
+            )
+            gona = self.create_good_on_application(application, good)
+            gona.control_list_entries.set(ControlListEntry.objects.filter(rating__in=gona_cle))
+            gona.save()
+            assert len(log.output) == 1
+            exp_log = f"WARNING:good_on_application_copy_logger:Saving GoodOnApplication ({str(gona.id)}) with CLE copied from Good: ({str(good.id)})"
+            assert exp_log in log.output[0]
+
+    @parameterized.expand(
+        [
+            [
+                [],
+                [],
+            ],
+            [
+                ["ML1a"],
+                [],
+            ],
+            [
+                [],
+                ["ML1a"],
+            ],
+            [
+                ["ML1a", "ML1b"],
+                ["ML1a"],
+            ],
+        ]
+    )
+    def test_save_no_log(self, good_cle, gona_cle):
+        with self.assertRaises(AssertionError) as err, self.assertLogs(logger=gona_copy_logger, level="WARNING"):
+            application = self.create_draft_standard_application(
+                organisation=self.organisation, user=self.exporter_user
+            )
+            good = self.create_good(
+                "A good", self.organisation, is_good_controlled=good_cle != [], control_list_entries=good_cle
+            )
+            gona = self.create_good_on_application(application, good)
+            gona.control_list_entries.set(ControlListEntry.objects.filter(rating__in=gona_cle))
+            gona.save()
+        self.assertEqual(f"no logs of level WARNING or higher triggered on {gona_copy_logger}", str(err.exception))

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -312,6 +312,7 @@ if LITE_API_ENABLE_ES:
 
 
 DENIAL_REASONS_DELETION_LOGGER = "denial_reasons_deletion_logger"
+GOOD_ON_APPLICATION_COPY_LOGGER = "good_on_application_copy_logger"
 
 
 if "test" not in sys.argv:
@@ -330,6 +331,7 @@ if "test" not in sys.argv:
         "root": {"handlers": ["stdout", "ecs"], "level": env("LOG_LEVEL").upper()},
         "loggers": {
             DENIAL_REASONS_DELETION_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
+            GOOD_ON_APPLICATION_COPY_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
         },
     }
 else:


### PR DESCRIPTION
Reported in [LTD-2541](https://uktrade.atlassian.net/browse/LTD-2541), there are intermittent instances when a `GoodOnApplication` object is created with values (specifically `control_list_entries`) that seem to be copied over from the associated `Good`. 

It is not obvious where this is happening in the code and why. The purpose of this PR is to provide some visibility about the source of this issue. 

The product implication of the bug is that when TAU officers try to assess the products on a case, they will find that one or more products have already been assessed - because the underlying system relies upon `control_list_entries` on `GoodOnApplication` being `null` when un-assessed.

P.S. this PR is probably temporary, until we hopefully find out the source of LTD-2541, at which point, we should probably revert this.