### PR TITLE
[LTD-2511] Notify exporter added to organisation

### DIFF
--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -31,6 +31,7 @@ env = Env(
     STREAM_PAGE_SIZE=(int, 20),
     ENV=(str, "localhost"),
     EXPORTER_BASE_URL=(str, ""),
+    CASEWORKER_BASE_URL=(str, ""),
     GOV_NOTIFY_ENABLED=(bool, False),
     DOCUMENT_SIGNING_ENABLED=(bool, False),
 )
@@ -375,9 +376,14 @@ GOV_NOTIFY_KEY = env("GOV_NOTIFY_KEY")
 
 ENV = env("ENV")
 
-# If EXPORTER_BASE_URL is not provided, render the base_url using the environment
+# If EXPORTER_BASE_URL is not in env vars, build the base_url using the environment
 EXPORTER_BASE_URL = (
     env("EXPORTER_BASE_URL") if env("EXPORTER_BASE_URL") else f"https://exporter.lite.service.{ENV}.uktrade.digital"
+)
+
+# If CASEWORKER_BASE_URL is not in env vars, build the base_url using the environment
+CASEWORKER_BASE_URL = (
+    env("CASEWORKER_BASE_URL") if env("CASEWORKER_BASE_URL") else f"https://internal.lite.service.{ENV}.uktrade.digital"
 )
 
 # Demo flags

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -377,14 +377,10 @@ GOV_NOTIFY_KEY = env("GOV_NOTIFY_KEY")
 ENV = env("ENV")
 
 # If EXPORTER_BASE_URL is not in env vars, build the base_url using the environment
-EXPORTER_BASE_URL = (
-    env("EXPORTER_BASE_URL") if env("EXPORTER_BASE_URL") else f"https://exporter.lite.service.{ENV}.uktrade.digital"
-)
+EXPORTER_BASE_URL = env("EXPORTER_BASE_URL") or f"https://exporter.lite.service.{ENV}.uktrade.digital"
 
 # If CASEWORKER_BASE_URL is not in env vars, build the base_url using the environment
-CASEWORKER_BASE_URL = (
-    env("CASEWORKER_BASE_URL") if env("CASEWORKER_BASE_URL") else f"https://internal.lite.service.{ENV}.uktrade.digital"
-)
+CASEWORKER_BASE_URL = env("CASEWORKER_BASE_URL") or f"https://internal.lite.service.{ENV}.uktrade.digital"
 
 # Demo flags
 LITE_API_DEMO_FLAGS_CSV = env.str(

--- a/api/core/helpers.py
+++ b/api/core/helpers.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from urllib.parse import urljoin
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -96,3 +97,15 @@ def add_months(start_date, months, date_format=DATE_FORMAT):
     """
     new_date = start_date + relativedelta(months=+months)
     return new_date.strftime(date_format)
+
+
+def _get_frontend_url(base, path):
+    return urljoin(base, path)
+
+
+def get_caseworker_frontend_url(path):
+    return _get_frontend_url(settings.CASEWORKER_BASE_URL, path)
+
+
+def get_exporter_frontend_url(path):
+    return _get_frontend_url(settings.EXPORTER_BASE_URL, path)

--- a/api/core/tests/test_helpers.py
+++ b/api/core/tests/test_helpers.py
@@ -1,0 +1,26 @@
+from django.test import override_settings, TestCase
+from parameterized import parameterized
+
+from api.core import helpers
+
+
+class HelpersTest(TestCase):
+    @parameterized.expand(
+        [
+            ("/foo/bar/", "https://caseworker.lite.com/foo/bar/"),
+            ("foo/bar/", "https://caseworker.lite.com/foo/bar/"),
+        ]
+    )
+    @override_settings(CASEWORKER_BASE_URL="https://caseworker.lite.com")
+    def test_get_caseworker_frontend_url(self, path, expected_url):
+        assert helpers.get_caseworker_frontend_url(path) == expected_url
+
+    @parameterized.expand(
+        [
+            ("/foo/bar/", "https://exporter.lite.com/foo/bar/"),
+            ("foo/bar/", "https://exporter.lite.com/foo/bar/"),
+        ]
+    )
+    @override_settings(EXPORTER_BASE_URL="https://exporter.lite.com")
+    def test_get_exporter_frontend_url(self, path, expected_url):
+        assert helpers.get_exporter_frontend_url(path) == expected_url

--- a/api/users/notify.py
+++ b/api/users/notify.py
@@ -1,0 +1,8 @@
+from gov_notify.enums import TemplateType
+from gov_notify.payloads import ExporterUserAdded
+from gov_notify.service import send_email
+
+
+def notify_exporter_user_added(email, data):
+    payload = ExporterUserAdded(**data)
+    send_email(email, TemplateType.EXPORTER_USER_ADDED, payload)

--- a/api/users/tests/test_create_exporter.py
+++ b/api/users/tests/test_create_exporter.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from rest_framework import status
 from rest_framework.reverse import reverse_lazy
 
@@ -20,15 +22,24 @@ class CreateExporterUser(DataTestClient):
         }
         self.url = reverse_lazy("users:users")
 
-    def test_create_new_exporter_user_success(self):
+    @mock.patch("api.users.notify.notify_exporter_user_added")
+    def test_create_new_exporter_user_success(self, mocked_notify):
         previous_user_count = ExporterUser.objects.count()
 
         response = self.client.post(self.url, self.data, **self.exporter_headers)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ExporterUser.objects.count(), previous_user_count + 1)
+        mocked_notify.assert_called_with(
+            self.data["email"],
+            {
+                "organisation_name": self.organisation.name,
+                "exporter_frontend_url": "https://exporter.lite.service.localhost.uktrade.digital/",
+            },
+        )
 
-    def test_create_exporter_user_when_user_already_exists_doesnt_create_new_user(self):
+    @mock.patch("api.users.notify.notify_exporter_user_added")
+    def test_create_exporter_user_when_user_already_exists_doesnt_create_new_user(self, mocked_notify):
         """
         The endpoint being tested requires another exporter user to send the request
         This means that the new user being added must be attempted to be added by different exporter users
@@ -49,6 +60,26 @@ class CreateExporterUser(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ExporterUser.objects.count(), previous_user_count)
+        mocked_notify.assert_called_with(
+            self.data["email"],
+            {
+                "organisation_name": other_org.name,
+                "exporter_frontend_url": "https://exporter.lite.service.localhost.uktrade.digital/",
+            },
+        )
+
+    @mock.patch("api.users.notify.notify_exporter_user_added")
+    def test_create_exporter_user_when_user_already_associated_to_organisation(self, mocked_notify):
+        # Add new exporter user
+        self.client.post(self.url, self.data, **self.exporter_headers)
+        previous_user_count = ExporterUser.objects.count()
+        # Attempt to add the user to the same org again
+        response = self.client.post(self.url, self.data, **self.exporter_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(ExporterUser.objects.count(), previous_user_count)
+        # Expect just one notification to have fired (the initial add of this user only)
+        assert mocked_notify.call_count == 1
 
     def test_create_exporter_uppercase_email(self):
         previous_user_count = ExporterUser.objects.count()

--- a/api/users/tests/test_notify.py
+++ b/api/users/tests/test_notify.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+from faker import Faker
+from rest_framework.test import APITestCase
+
+from gov_notify.enums import TemplateType
+from gov_notify.payloads import ExporterUserAdded
+from api.users.notify import notify_exporter_user_added
+
+
+class NotifyTests(APITestCase):
+    @mock.patch("api.users.notify.send_email")
+    def test_notify_exporter_user_added(self, mock_send_email):
+        email = Faker().email()
+        data = {"organisation_name": "testorgname", "exporter_frontend_url": "https://some.domain/foo/"}
+        expected_payload = ExporterUserAdded(**data)
+
+        notify_exporter_user_added(email, data)
+
+        mock_send_email.assert_called_with(email, TemplateType.EXPORTER_USER_ADDED, expected_payload)

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -6,6 +6,7 @@ class TemplateType(Enum):
     APPLICATION_STATUS = "application_status"
     ORGANISATION_STATUS = "organisation_status"
     EXPORTER_REGISTERED_NEW_ORG = "exporter_registered_new_org"
+    EXPORTER_USER_ADDED = "exporter_user_added"
 
     @property
     def template_id(self):
@@ -17,4 +18,5 @@ class TemplateType(Enum):
             self.APPLICATION_STATUS: "b9c3403a-8d09-416e-acd3-99baabf5b043",
             self.ORGANISATION_STATUS: "c57ef67e-14fd-4af9-a9b2-5015040fa408",
             self.EXPORTER_REGISTERED_NEW_ORG: "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0",
+            self.EXPORTER_USER_ADDED: "c9b67dca-0916-453a-99c0-70ba563e1bdd",
         }[self]

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -42,3 +42,9 @@ class OrganisationStatusEmailData(EmailData):
 @dataclass(frozen=True)
 class ExporterRegistration(EmailData):
     organisation_name: str
+
+
+@dataclass(frozen=True)
+class ExporterUserAdded(EmailData):
+    organisation_name: str
+    exporter_frontend_url: str

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -13,6 +13,7 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
             (TemplateType.ORGANISATION_STATUS, "c57ef67e-14fd-4af9-a9b2-5015040fa408"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
+            (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -47,6 +47,13 @@ class DataclassTests(APITestCase):
                     "organisation_name": "testorgname",
                 },
             ),
+            (
+                payloads.ExporterUserAdded,
+                {
+                    "organisation_name": "testorgname",
+                    "exporter_frontend_url": "https://some.domain/foo",
+                },
+            ),
         ]
     )
     def test_valid_input(self, dataclass, data):


### PR DESCRIPTION
This change ensures that an exporter user is notified by email when they are added to an organisation.

This uses the following template: https://www.notifications.service.gov.uk/services/f3d8fb42-a34b-4d85-8ac2-a62006a197dc/templates/c9b67dca-0916-453a-99c0-70ba563e1bdd

TODO on merge: Ensure that EXPORTER_BASE_URL and CASEWORKER_BASE_URL are set properly in lite-api's production vault variables.  The default will not work since the URL has private-beta in the name rather than {{env}}