### PR TITLE
[LTD-2514] Notify exporter of ecju query

### DIFF
--- a/api/cases/notify.py
+++ b/api/cases/notify.py
@@ -1,6 +1,9 @@
+from django.db.models import F
+
 from api.core.helpers import get_exporter_frontend_url
+from api.cases.models import Case
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import ExporterLicenceIssued
+from gov_notify.payloads import ExporterECJUQuery, ExporterLicenceIssued
 from gov_notify.service import send_email
 
 
@@ -24,3 +27,31 @@ def notify_exporter_licence_issued(licence):
             "exporter_frontend_url": get_exporter_frontend_url("/"),
         },
     )
+
+
+def notify_exporter_ecju_query(case_pk):
+    case_info = (
+        Case.objects.annotate(
+            email=F("submitted_by__baseuser_ptr__email"), first_name=F("submitted_by__baseuser_ptr__first_name")
+        )
+        .values("id", "email", "first_name", "reference_code")
+        .get(id=case_pk)
+    )
+
+    # This deliberately avoids using a more specific URL since there are a few possible here,
+    # so the likelihood of them changing in the exporter app is higher
+    exporter_frontend_url = get_exporter_frontend_url("/")
+
+    _notify_exporter_ecju_query(
+        case_info["email"],
+        {
+            "exporter_first_name": case_info["first_name"] or "",
+            "case_reference": case_info["reference_code"],
+            "exporter_frontend_url": exporter_frontend_url,
+        },
+    )
+
+
+def _notify_exporter_ecju_query(email, data):
+    payload = ExporterECJUQuery(**data)
+    send_email(email, TemplateType.EXPORTER_ECJU_QUERY, payload)

--- a/api/cases/tests/test_case_ecju_queries.py
+++ b/api/cases/tests/test_case_ecju_queries.py
@@ -235,7 +235,6 @@ class ECJUQueriesComplianceCreateTest(DataTestClient):
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual(ecju_query.question, self.data["question"])
-        self.assertEqual(mock_client.send_email.call_count, 2)
 
     @mock.patch("gov_notify.service.client")
     def test_query_sends_email_to_each_application_submitter_site(self, mock_client):
@@ -260,7 +259,6 @@ class ECJUQueriesComplianceCreateTest(DataTestClient):
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual(ecju_query.question, self.data["question"])
-        self.assertEqual(mock_client.send_email.call_count, 2)
 
     @mock.patch("gov_notify.service.client")
     def test_query_sends_email_to_each_application_submitter_no_duplicates(self, mock_client):
@@ -282,7 +280,6 @@ class ECJUQueriesComplianceCreateTest(DataTestClient):
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual(ecju_query.question, self.data["question"])
-        self.assertEqual(mock_client.send_email.call_count, 1)
 
 
 class ECJUQueriesResponseTests(DataTestClient):

--- a/api/cases/tests/test_case_ecju_queries.py
+++ b/api/cases/tests/test_case_ecju_queries.py
@@ -167,7 +167,8 @@ class ECJUQueriesViewTests(DataTestClient):
 
 class ECJUQueriesCreateTest(DataTestClient):
     @parameterized.expand([ECJUQueryType.ECJU, ECJUQueryType.PRE_VISIT_QUESTIONNAIRE, ECJUQueryType.COMPLIANCE_ACTIONS])
-    def test_gov_user_can_create_ecju_queries(self, query_type):
+    @mock.patch("api.cases.views.views.notify.notify_exporter_ecju_query")
+    def test_gov_user_can_create_ecju_queries(self, query_type, mock_notify):
         """
         When a GOV user submits a valid query to a case
         Then the request is successful and the query is saved
@@ -184,6 +185,8 @@ class ECJUQueriesCreateTest(DataTestClient):
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual("Test ECJU Query question?", ecju_query.question)
+
+        mock_notify.assert_called_with(case.id)
 
     @parameterized.expand([[""], [None], ["a" * 5001]])
     def test_submit_invalid_data_failure(self, data):
@@ -210,22 +213,18 @@ class ECJUQueriesComplianceCreateTest(DataTestClient):
             status=get_case_status_by_status(CaseStatusEnum.OPEN),
         )
 
-        self.create_licence(self.create_open_application_case(self.organisation), status=LicenceStatus.ISSUED)
+        self.licence_1 = self.create_licence(
+            self.create_open_application_case(self.organisation), status=LicenceStatus.ISSUED
+        )
 
         application = self.create_open_application_case(self.organisation)
         application.submitted_by = ExporterUserFactory()
         application.save()
-        self.create_licence(application, status=LicenceStatus.ISSUED)
+        self.licence_2 = self.create_licence(application, status=LicenceStatus.ISSUED)
         self.data = {"question": "Test ECJU Query question?", "query_type": PicklistType.PRE_VISIT_QUESTIONNAIRE}
 
-    @mock.patch("gov_notify.service.client")
-    def test_query_sends_email_to_each_application_submitter(self, mock_client):
-        """
-        When a GOV user submits a valid query to a compliance case
-        Then the request is successful and the query is saved
-        And an email is sent to each user that submitted a valid application
-        on that site which has a licence
-        """
+    @mock.patch("api.cases.views.views.notify.notify_exporter_ecju_query")
+    def test_query_create(self, mock_notify):
         url = reverse("cases:case_ecju_queries", kwargs={"pk": self.compliance_case.id})
 
         response = self.client.post(url, self.data, **self.gov_headers)
@@ -235,51 +234,7 @@ class ECJUQueriesComplianceCreateTest(DataTestClient):
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual(ecju_query.question, self.data["question"])
-
-    @mock.patch("gov_notify.service.client")
-    def test_query_sends_email_to_each_application_submitter_site(self, mock_client):
-        """
-        When a GOV user submits a valid query to a compliance visit case
-        Then the request is successful and the query is saved
-        And an email is sent to each user that submitted a valid application
-        on that site which has a licence
-        """
-        compliance_site_case = ComplianceVisitCaseFactory(
-            site_case=self.compliance_case,
-            organisation=self.organisation,
-            status=get_case_status_by_status(CaseStatusEnum.OPEN),
-        )
-
-        url = reverse("cases:case_ecju_queries", kwargs={"pk": compliance_site_case.id})
-
-        response = self.client.post(url, self.data, **self.gov_headers)
-        response_data = response.json()
-        ecju_query = EcjuQuery.objects.get()
-
-        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
-        self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
-        self.assertEqual(ecju_query.question, self.data["question"])
-
-    @mock.patch("gov_notify.service.client")
-    def test_query_sends_email_to_each_application_submitter_no_duplicates(self, mock_client):
-        """
-        When a GOV user submits a valid query to a compliance case
-        Then the request is successful and the query is saved
-        And an email is sent to each user that submitted a valid application
-        on that site which has a licence, without duplicates
-        """
-        for application in BaseApplication.objects.all():
-            application.submitted_by = self.exporter_user
-            application.save()
-        url = reverse("cases:case_ecju_queries", kwargs={"pk": self.compliance_case.id})
-
-        response = self.client.post(url, self.data, **self.gov_headers)
-        response_data = response.json()
-        ecju_query = EcjuQuery.objects.get()
-
-        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
-        self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
-        self.assertEqual(ecju_query.question, self.data["question"])
+        mock_notify.assert_called_with(self.compliance_case.id)
 
 
 class ECJUQueriesResponseTests(DataTestClient):

--- a/api/cases/tests/test_helpers.py
+++ b/api/cases/tests/test_helpers.py
@@ -1,0 +1,1 @@
+# TODO; test notify_ecju_query in total isolation

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1,7 +1,5 @@
-from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.db.models import F
 from django.http.response import JsonResponse, HttpResponse
 from rest_framework import status
 from rest_framework.exceptions import ParseError
@@ -11,12 +9,11 @@ from api.applications.models import GoodOnApplication
 from api.applications.serializers.advice import CountersignAdviceSerializer, CountryWithFlagsSerializer
 from api.audit_trail import service as audit_trail_service
 from api.audit_trail.enums import AuditType
+from api.cases import notify
 from api.cases.enums import (
     CaseTypeSubTypeEnum,
     AdviceType,
     AdviceLevel,
-    CaseTypeTypeEnum,
-    CaseTypeReferenceEnum,
 )
 from api.cases.generated_documents.models import GeneratedCaseDocument
 from api.cases.generated_documents.serializers import AdviceDocumentGovSerializer
@@ -44,7 +41,6 @@ from api.cases.models import (
     Advice,
     GoodCountryDecision,
     CaseAssignment,
-    Case,
     CaseReviewDate,
 )
 from api.cases.notify import notify_exporter_licence_issued
@@ -64,7 +60,6 @@ from api.cases.serializers import (
 )
 from api.cases.service import get_destinations
 from api.compliance.helpers import generate_compliance_site_case
-from api.compliance.models import ComplianceVisitCase
 from api.core import constants
 from api.core.authentication import GovAuthentication, SharedAuthentication, ExporterAuthentication
 from api.core.constants import GovPermissions
@@ -80,7 +75,6 @@ from api.licences.models import Licence
 from api.licences.service import get_case_licences
 from lite_content.lite_api.strings import Documents, Cases
 from api.organisations.libraries.get_organisation import get_request_user_organisation_id
-from api.organisations.models import Site
 from api.parties.models import Party
 from api.parties.serializers import PartySerializer, AdditionalContactSerializer
 from api.queues.models import Queue
@@ -489,42 +483,8 @@ class ECJUQueries(APIView):
                 payload={"ecju_query": data["question"]},
             )
 
-            # Send an email to the user(s) that submitted the application
-            case_info = (
-                Case.objects.annotate(email=F("submitted_by__baseuser_ptr__email"), name=F("baseapplication__name"))
-                .values("id", "email", "name", "reference_code", "case_type__type", "case_type__reference")
-                .get(id=pk)
-            )
+            notify.notify_exporter_ecju_query(pk)
 
-            # For each licence in a compliance case, email the user that submitted the application
-            if case_info["case_type__type"] == CaseTypeTypeEnum.COMPLIANCE:
-                emails = set()
-                case_id = case_info["id"]
-                link = f"{settings.EXPORTER_BASE_URL}/compliance/{pk}/ecju-queries/"
-
-                if case_info["case_type__reference"] == CaseTypeReferenceEnum.COMP_VISIT:
-                    # If the case is a compliance visit case, use the parent compliance site case ID instead
-                    case_id = ComplianceVisitCase.objects.get(pk=case_id).site_case_id
-                    link = f"{settings.EXPORTER_BASE_URL}/compliance/{case_id}/visit/{pk}/ecju-queries/"
-
-                site = Site.objects.get(compliance__id=case_id)
-
-                for licence in Case.objects.filter_for_cases_related_to_compliance_case(case_id):
-                    emails.add(licence.submitted_by.email)
-
-                # TODO: Replace the below with new template
-                # for email in emails:
-                #    gov_notify_service.send_email(
-                #        email_address=email,
-                #        template_type=TemplateType.ECJU_COMPLIANCE_CREATED,
-                #        data=EcjuComplianceCreatedEmailData(
-                #            query=serializer.data["question"],
-                #            case_reference=case_info["reference_code"],
-                #            site_name=site.name,
-                #            site_address=str(site.address),
-                #            link=link,
-                #        ),
-                #    )
             return JsonResponse(data={"ecju_query_id": serializer.data["id"]}, status=status.HTTP_201_CREATED)
 
 

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -76,9 +76,6 @@ from api.documents.libraries.s3_operations import document_download_stream
 from api.documents.models import Document
 from api.goods.serializers import GoodOnApplicationSerializer
 from api.goods.enums import GoodStatus
-from gov_notify import service as gov_notify_service
-from gov_notify.enums import TemplateType
-from gov_notify.payloads import EcjuComplianceCreatedEmailData
 from api.licences.models import Licence
 from api.licences.service import get_case_licences
 from lite_content.lite_api.strings import Documents, Cases
@@ -515,18 +512,19 @@ class ECJUQueries(APIView):
                 for licence in Case.objects.filter_for_cases_related_to_compliance_case(case_id):
                     emails.add(licence.submitted_by.email)
 
-                for email in emails:
-                    gov_notify_service.send_email(
-                        email_address=email,
-                        template_type=TemplateType.ECJU_COMPLIANCE_CREATED,
-                        data=EcjuComplianceCreatedEmailData(
-                            query=serializer.data["question"],
-                            case_reference=case_info["reference_code"],
-                            site_name=site.name,
-                            site_address=str(site.address),
-                            link=link,
-                        ),
-                    )
+                # TODO: Replace the below with new template
+                # for email in emails:
+                #    gov_notify_service.send_email(
+                #        email_address=email,
+                #        template_type=TemplateType.ECJU_COMPLIANCE_CREATED,
+                #        data=EcjuComplianceCreatedEmailData(
+                #            query=serializer.data["question"],
+                #            case_reference=case_info["reference_code"],
+                #            site_name=site.name,
+                #            site_address=str(site.address),
+                #            link=link,
+                #        ),
+                #    )
             return JsonResponse(data={"ecju_query_id": serializer.data["id"]}, status=status.HTTP_201_CREATED)
 
 

--- a/api/goods/tests/test_serializers.py
+++ b/api/goods/tests/test_serializers.py
@@ -4,8 +4,8 @@ from api.applications.tests.factories import (
     GoodOnApplicationFactory,
     StandardApplicationFactory,
 )
-from api.parties.tests.factories import PartyFactory
 from api.staticdata.countries.factories import CountryFactory
+from api.parties.tests.factories import PartyFactory
 from test_helpers.clients import DataTestClient
 
 from api.applications.tests.factories import PartyOnApplicationFactory
@@ -42,6 +42,9 @@ class GoodOnApplicationSerializerTests(DataTestClient):
 
         party_on_application = PartyOnApplicationFactory.create(
             application=self.application,
+            party__country__id="IT",
+            party__country__name="Italy",
+            party__country__type="2",
         )
         self.assertEqual(
             GoodOnApplicationSerializer().get_destinations(self.a_good_on_application),
@@ -54,6 +57,9 @@ class GoodOnApplicationSerializerTests(DataTestClient):
 
         another_party_on_application = PartyOnApplicationFactory.create(
             application=self.application,
+            party__country__id="UK",
+            party__country__name="United Kingdom",
+            party__country__type="1",
         )
         self.assertNotEqual(
             party_on_application.party.country.name,

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -8,6 +8,7 @@ class TemplateType(Enum):
     EXPORTER_LICENCE_ISSUED = "exporter_licence_issued"
     EXPORTER_ORGANISATION_APPROVED = "exporter_organisation_approved"
     EXPORTER_ORGANISATION_REJECTED = "exporter_organisation_rejected"
+    EXPORTER_ECJU_QUERY = "exporter_ecju_query"
 
     @property
     def template_id(self):
@@ -21,4 +22,5 @@ class TemplateType(Enum):
             self.EXPORTER_LICENCE_ISSUED: "f2757d61-2319-4279-82b2-a52170b0222a",
             self.EXPORTER_ORGANISATION_APPROVED: "d5e94717-ae78-4d18-8064-ecfcd99143f1",
             self.EXPORTER_ORGANISATION_REJECTED: "1dec3acd-94b0-47bb-832a-384ba5c6f51a",
+            self.EXPORTER_ECJU_QUERY: "84431173-72a9-43a1-8926-b43dec7871f9",
         }[self]

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -2,7 +2,6 @@ from enum import Enum
 
 
 class TemplateType(Enum):
-    ECJU_COMPLIANCE_CREATED = "ecju_compliance_created"
     APPLICATION_STATUS = "application_status"
     EXPORTER_REGISTERED_NEW_ORG = "exporter_registered_new_org"
     EXPORTER_USER_ADDED = "exporter_user_added"
@@ -16,7 +15,6 @@ class TemplateType(Enum):
         Return Gov Notify template ID for respective template type.
         """
         return {
-            self.ECJU_COMPLIANCE_CREATED: "b23f4c55-fef0-4d8f-a10b-1ad7f8e7c672",
             self.APPLICATION_STATUS: "b9c3403a-8d09-416e-acd3-99baabf5b043",
             self.EXPORTER_REGISTERED_NEW_ORG: "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0",
             self.EXPORTER_USER_ADDED: "c9b67dca-0916-453a-99c0-70ba563e1bdd",

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -19,15 +19,6 @@ class EcjuCreatedEmailData(EmailData):
 
 
 @dataclass(frozen=True)
-class EcjuComplianceCreatedEmailData(EmailData):
-    query: str
-    case_reference: str
-    site_name: str
-    site_address: str
-    link: str
-
-
-@dataclass(frozen=True)
 class ApplicationStatusEmailData(EmailData):
     case_reference: str
     application_reference: str

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -54,3 +54,10 @@ class ExporterOrganisationApproved(EmailData):
 class ExporterOrganisationRejected(EmailData):
     exporter_first_name: str
     organisation_name: str
+
+
+@dataclass(frozen=True)
+class ExporterECJUQuery(EmailData):
+    case_reference: str
+    exporter_first_name: str
+    exporter_frontend_url: str

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -12,12 +12,9 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
-<<<<<<< HEAD
             (TemplateType.EXPORTER_ORGANISATION_APPROVED, "d5e94717-ae78-4d18-8064-ecfcd99143f1"),
             (TemplateType.EXPORTER_ORGANISATION_REJECTED, "1dec3acd-94b0-47bb-832a-384ba5c6f51a"),
-=======
             (TemplateType.EXPORTER_ECJU_QUERY, "84431173-72a9-43a1-8926-b43dec7871f9"),
->>>>>>> Add email notification to exporter for new ECJU query
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -9,7 +9,6 @@ from gov_notify.enums import TemplateType
 class TemplateTypeTests(APITestCase):
     @parameterized.expand(
         [
-            (TemplateType.ECJU_COMPLIANCE_CREATED, "b23f4c55-fef0-4d8f-a10b-1ad7f8e7c672"),
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -12,8 +12,12 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
+<<<<<<< HEAD
             (TemplateType.EXPORTER_ORGANISATION_APPROVED, "d5e94717-ae78-4d18-8064-ecfcd99143f1"),
             (TemplateType.EXPORTER_ORGANISATION_REJECTED, "1dec3acd-94b0-47bb-832a-384ba5c6f51a"),
+=======
+            (TemplateType.EXPORTER_ECJU_QUERY, "84431173-72a9-43a1-8926-b43dec7871f9"),
+>>>>>>> Add email notification to exporter for new ECJU query
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -53,6 +53,14 @@ class DataclassTests(APITestCase):
                     "organisation_name": "testorgname",
                 },
             ),
+            (
+                payloads.ExporterECJUQuery,
+                {
+                    "case_reference": "testref",
+                    "exporter_first_name": "testname",
+                    "exporter_frontend_url": "https://some.domain/foo",
+                },
+            ),
         ]
     )
     def test_valid_input(self, dataclass, data):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -18,16 +18,6 @@ class DataclassTests(APITestCase):
                 },
             ),
             (
-                payloads.EcjuComplianceCreatedEmailData,
-                {
-                    "query": "testquery",
-                    "case_reference": "testref",
-                    "site_name": "testsitename",
-                    "site_address": "testaddress",
-                    "link": "testlink",
-                },
-            ),
-            (
                 payloads.ApplicationStatusEmailData,
                 {
                     "case_reference": "testref",


### PR DESCRIPTION
This change ensures that exporter users are notified by email when a query is opened on their application.

The following template is used: https://www.notifications.service.gov.uk/services/f3d8fb42-a34b-4d85-8ac2-a62006a197dc/templates/84431173-72a9-43a1-8926-b43dec7871f9