### PR TITLE
[LTD-2512] Notify organisation approved or rejected

### DIFF
--- a/api/organisations/helpers.py
+++ b/api/organisations/helpers.py
@@ -1,8 +1,5 @@
-from django.db.models import F
-
 from api.audit_trail import service as audit_trail_service
 from api.audit_trail.enums import AuditType
-from api.core.helpers import get_exporter_frontend_url
 from api.organisations import notify
 from api.organisations.enums import OrganisationType, OrganisationStatus
 
@@ -75,9 +72,6 @@ def audit_edited_organisation_fields(user, organisation, new_org, is_non_uk=None
 
 
 def audit_reviewed_organisation(user, organisation, decision):
-    organisation_members = organisation.users.annotate(
-        email=F("user__baseuser_ptr__email"), first_name=F("user__baseuser_ptr__first_name")
-    ).values_list("email", "first_name")
 
     if decision == OrganisationStatus.ACTIVE:
         audit_trail_service.create(
@@ -88,15 +82,7 @@ def audit_reviewed_organisation(user, organisation, decision):
                 "organisation_name": organisation.name,
             },
         )
-        for email, first_name in organisation_members:
-            notify.notify_exporter_organisation_approved(
-                email,
-                {
-                    "exporter_first_name": first_name or "",
-                    "organisation_name": organisation.name,
-                    "exporter_frontend_url": get_exporter_frontend_url("/"),
-                },
-            )
+        notify.notify_exporter_organisation_approved(organisation)
     else:
         audit_trail_service.create(
             actor=user,
@@ -106,3 +92,4 @@ def audit_reviewed_organisation(user, organisation, decision):
                 "organisation_name": organisation.name,
             },
         )
+        notify.notify_exporter_organisation_rejected(organisation)

--- a/api/organisations/helpers.py
+++ b/api/organisations/helpers.py
@@ -82,7 +82,6 @@ def audit_reviewed_organisation(user, organisation, decision):
                 "organisation_name": organisation.name,
             },
         )
-        notify.notify_exporter_organisation_approved(organisation)
     else:
         audit_trail_service.create(
             actor=user,
@@ -92,4 +91,10 @@ def audit_reviewed_organisation(user, organisation, decision):
                 "organisation_name": organisation.name,
             },
         )
+
+
+def notify_organisation_reviewed(organisation, decision):
+    if decision == OrganisationStatus.ACTIVE:
+        notify.notify_exporter_organisation_approved(organisation)
+    else:
         notify.notify_exporter_organisation_rejected(organisation)

--- a/api/organisations/helpers.py
+++ b/api/organisations/helpers.py
@@ -3,9 +3,6 @@ from django.db.models import F
 from api.audit_trail import service as audit_trail_service
 from api.audit_trail.enums import AuditType
 from api.organisations.enums import OrganisationType, OrganisationStatus
-from gov_notify import service as gov_notify_service
-from gov_notify.payloads import OrganisationStatusEmailData
-from gov_notify.enums import TemplateType
 
 
 def add_edited_audit_entry(user, organisation, key, old_value, new_value):
@@ -93,11 +90,4 @@ def audit_reviewed_organisation(user, organisation, decision):
             payload={
                 "organisation_name": organisation.name,
             },
-        )
-
-    for email in organisation.users.annotate(email=F("user__baseuser_ptr__email")).values_list("email", flat=True):
-        gov_notify_service.send_email(
-            email_address=email,
-            template_type=TemplateType.ORGANISATION_STATUS,
-            data=OrganisationStatusEmailData(organisation_name=organisation.name),
         )

--- a/api/organisations/notify.py
+++ b/api/organisations/notify.py
@@ -1,5 +1,8 @@
+from django.db.models import F
+
+from api.core.helpers import get_exporter_frontend_url
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved
+from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved, ExporterOrganisationRejected
 from gov_notify.service import send_email
 
 
@@ -8,6 +11,42 @@ def notify_exporter_registration(email, data):
     send_email(email, TemplateType.EXPORTER_REGISTERED_NEW_ORG, payload)
 
 
-def notify_exporter_organisation_approved(email, data):
+def _get_organisation_members(organisation):
+    return organisation.users.annotate(
+        email=F("user__baseuser_ptr__email"), first_name=F("user__baseuser_ptr__first_name")
+    ).values_list("email", "first_name")
+
+
+def notify_exporter_organisation_approved(organisation):
+    organisation_members = _get_organisation_members(organisation)
+    for email, first_name in organisation_members:
+        _notify_exporter_organisation_approved(
+            email,
+            {
+                "exporter_first_name": first_name or "",
+                "organisation_name": organisation.name,
+                "exporter_frontend_url": get_exporter_frontend_url("/"),
+            },
+        )
+
+
+def _notify_exporter_organisation_approved(email, data):
     payload = ExporterOrganisationApproved(**data)
     send_email(email, TemplateType.EXPORTER_ORGANISATION_APPROVED, payload)
+
+
+def notify_exporter_organisation_rejected(organisation):
+    organisation_members = _get_organisation_members(organisation)
+    for email, first_name in organisation_members:
+        _notify_exporter_organisation_rejected(
+            email,
+            {
+                "exporter_first_name": first_name or "",
+                "organisation_name": organisation.name,
+            },
+        )
+
+
+def _notify_exporter_organisation_rejected(email, data):
+    payload = ExporterOrganisationRejected(**data)
+    send_email(email, TemplateType.EXPORTER_ORGANISATION_REJECTED, payload)

--- a/api/organisations/notify.py
+++ b/api/organisations/notify.py
@@ -1,8 +1,13 @@
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import ExporterRegistration
+from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved
 from gov_notify.service import send_email
 
 
 def notify_exporter_registration(email, data):
     payload = ExporterRegistration(**data)
     send_email(email, TemplateType.EXPORTER_REGISTERED_NEW_ORG, payload)
+
+
+def notify_exporter_organisation_approved(email, data):
+    payload = ExporterOrganisationApproved(**data)
+    send_email(email, TemplateType.EXPORTER_ORGANISATION_APPROVED, payload)

--- a/api/organisations/tests/test_helpers.py
+++ b/api/organisations/tests/test_helpers.py
@@ -1,0 +1,24 @@
+from unittest import mock
+
+from api.organisations.enums import OrganisationStatus
+from api.organisations.helpers import notify_organisation_reviewed
+from api.organisations.tests.factories import OrganisationFactory
+from test_helpers.clients import DataTestClient
+
+
+class TestHelpers(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.organisation = OrganisationFactory(status=OrganisationStatus.IN_REVIEW)
+
+    @mock.patch("api.organisations.notify.notify_exporter_organisation_approved")
+    def test_notify_organisation_reviewed_active(self, mocked_notify):
+        decision = OrganisationStatus.ACTIVE
+        notify_organisation_reviewed(self.organisation, decision)
+        mocked_notify.assert_called_with(self.organisation)
+
+    @mock.patch("api.organisations.notify.notify_exporter_organisation_rejected")
+    def test_notify_organisation_reviewed_rejected(self, mocked_notify):
+        decision = OrganisationStatus.REJECTED
+        notify_organisation_reviewed(self.organisation, decision)
+        mocked_notify.assert_called_with(self.organisation)

--- a/api/organisations/tests/test_notify.py
+++ b/api/organisations/tests/test_notify.py
@@ -4,8 +4,8 @@ from faker import Faker
 from rest_framework.test import APITestCase
 
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import ExporterRegistration
-from api.organisations.notify import notify_exporter_registration
+from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved
+from api.organisations.notify import notify_exporter_registration, notify_exporter_organisation_approved
 
 
 class NotifyTests(APITestCase):
@@ -18,3 +18,17 @@ class NotifyTests(APITestCase):
         notify_exporter_registration(email, data)
 
         mock_send_email.assert_called_with(email, TemplateType.EXPORTER_REGISTERED_NEW_ORG, expected_payload)
+
+    @mock.patch("api.organisations.notify.send_email")
+    def test_exporter_organisation_approved(self, mock_send_email):
+        email = Faker().email()
+        data = {
+            "organisation_name": "testorgname",
+            "exporter_first_name": "testname",
+            "exporter_frontend_url": "https://test.url/foo",
+        }
+        expected_payload = ExporterOrganisationApproved(**data)
+
+        notify_exporter_organisation_approved(email, data)
+
+        mock_send_email.assert_called_with(email, TemplateType.EXPORTER_ORGANISATION_APPROVED, expected_payload)

--- a/api/organisations/tests/test_notify.py
+++ b/api/organisations/tests/test_notify.py
@@ -1,34 +1,54 @@
 from unittest import mock
 
 from faker import Faker
-from rest_framework.test import APITestCase
+from test_helpers.clients import DataTestClient
 
+from api.organisations.tests.factories import OrganisationFactory
+from api.users.tests.factories import UserOrganisationRelationshipFactory
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved
-from api.organisations.notify import notify_exporter_registration, notify_exporter_organisation_approved
+from gov_notify.payloads import ExporterRegistration, ExporterOrganisationApproved, ExporterOrganisationRejected
+from api.organisations import notify
 
 
-class NotifyTests(APITestCase):
+class NotifyTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.organisation = OrganisationFactory()
+        UserOrganisationRelationshipFactory(organisation=self.organisation, user=self.exporter_user)
+
     @mock.patch("api.organisations.notify.send_email")
     def test_notify_exporter_registration(self, mock_send_email):
         email = Faker().email()
         data = {"organisation_name": "testorgname"}
         expected_payload = ExporterRegistration(**data)
 
-        notify_exporter_registration(email, data)
+        notify.notify_exporter_registration(email, data)
 
         mock_send_email.assert_called_with(email, TemplateType.EXPORTER_REGISTERED_NEW_ORG, expected_payload)
 
     @mock.patch("api.organisations.notify.send_email")
     def test_exporter_organisation_approved(self, mock_send_email):
-        email = Faker().email()
-        data = {
-            "organisation_name": "testorgname",
-            "exporter_first_name": "testname",
-            "exporter_frontend_url": "https://test.url/foo",
-        }
-        expected_payload = ExporterOrganisationApproved(**data)
+        expected_payload = ExporterOrganisationApproved(
+            exporter_first_name=self.exporter_user.first_name,
+            organisation_name=self.organisation.name,
+            exporter_frontend_url="https://exporter.lite.service.localhost.uktrade.digital/",
+        )
 
-        notify_exporter_organisation_approved(email, data)
+        notify.notify_exporter_organisation_approved(self.organisation)
 
-        mock_send_email.assert_called_with(email, TemplateType.EXPORTER_ORGANISATION_APPROVED, expected_payload)
+        mock_send_email.assert_called_with(
+            self.exporter_user.email, TemplateType.EXPORTER_ORGANISATION_APPROVED, expected_payload
+        )
+
+    @mock.patch("api.organisations.notify.send_email")
+    def test_exporter_organisation_rejected(self, mock_send_email):
+        expected_payload = ExporterOrganisationRejected(
+            exporter_first_name=self.exporter_user.first_name,
+            organisation_name=self.organisation.name,
+        )
+
+        notify.notify_exporter_organisation_rejected(self.organisation)
+
+        mock_send_email.assert_called_with(
+            self.exporter_user.email, TemplateType.EXPORTER_ORGANISATION_REJECTED, expected_payload
+        )

--- a/api/organisations/tests/test_organisations.py
+++ b/api/organisations/tests/test_organisations.py
@@ -851,14 +851,19 @@ class EditOrganisationStatusTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["status"]["key"], OrganisationStatus.ACTIVE)
         self.assertEqual(Audit.objects.count(), 1)
-        mocked_notify.assert_called_with(
-            self.exporter_user.email,
-            {
-                "exporter_first_name": self.exporter_user.first_name,
-                "organisation_name": self.organisation.name,
-                "exporter_frontend_url": "https://exporter.lite.service.localhost.uktrade.digital/",
-            },
-        )
+        mocked_notify.assert_called_with(self.organisation)
+
+    @mock.patch("api.organisations.notify.notify_exporter_organisation_rejected")
+    def test_set_organisation_status_rejected_success(self, mocked_notify):
+        self.gov_user.role.permissions.set([GovPermissions.MANAGE_ORGANISATIONS.name])
+        data = {"status": OrganisationStatus.REJECTED}
+
+        response = self.client.put(self.url, data, **self.gov_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"]["key"], OrganisationStatus.REJECTED)
+        self.assertEqual(Audit.objects.count(), 1)
+        mocked_notify.assert_called_with(self.organisation)
 
     def test_set_organisation_status__without_permission_failure(self):
         data = {"status": OrganisationStatus.ACTIVE}

--- a/api/organisations/views/organisations.py
+++ b/api/organisations/views/organisations.py
@@ -15,7 +15,11 @@ from api.core.helpers import str_to_bool
 from api.core.permissions import check_user_has_permission, assert_user_has_permission
 from lite_content.lite_api.strings import Organisations
 from api.organisations.enums import OrganisationStatus, OrganisationType
-from api.organisations.helpers import audit_edited_organisation_fields, audit_reviewed_organisation
+from api.organisations.helpers import (
+    audit_edited_organisation_fields,
+    audit_reviewed_organisation,
+    notify_organisation_reviewed,
+)
 from api.organisations.libraries.get_organisation import get_organisation_by_pk, get_request_user_organisation
 from api.organisations.models import Organisation
 from api.organisations.serializers import (
@@ -232,6 +236,7 @@ class OrganisationStatusView(generics.UpdateAPIView):
         if serializer.is_valid():
             serializer.save()
             audit_reviewed_organisation(request.user, organisation, serializer.data["status"]["key"])
+            notify_organisation_reviewed(organisation, serializer.data["status"]["key"])
 
             return JsonResponse(data=serializer.data, status=status.HTTP_200_OK)
 

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -8,6 +8,7 @@ class TemplateType(Enum):
     EXPORTER_USER_ADDED = "exporter_user_added"
     EXPORTER_LICENCE_ISSUED = "exporter_licence_issued"
     EXPORTER_ORGANISATION_APPROVED = "exporter_organisation_approved"
+    EXPORTER_ORGANISATION_REJECTED = "exporter_organisation_rejected"
 
     @property
     def template_id(self):
@@ -21,4 +22,5 @@ class TemplateType(Enum):
             self.EXPORTER_USER_ADDED: "c9b67dca-0916-453a-99c0-70ba563e1bdd",
             self.EXPORTER_LICENCE_ISSUED: "f2757d61-2319-4279-82b2-a52170b0222a",
             self.EXPORTER_ORGANISATION_APPROVED: "d5e94717-ae78-4d18-8064-ecfcd99143f1",
+            self.EXPORTER_ORGANISATION_REJECTED: "1dec3acd-94b0-47bb-832a-384ba5c6f51a",
         }[self]

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -7,6 +7,7 @@ class TemplateType(Enum):
     EXPORTER_REGISTERED_NEW_ORG = "exporter_registered_new_org"
     EXPORTER_USER_ADDED = "exporter_user_added"
     EXPORTER_LICENCE_ISSUED = "exporter_licence_issued"
+    EXPORTER_ORGANISATION_APPROVED = "exporter_organisation_approved"
 
     @property
     def template_id(self):
@@ -19,4 +20,5 @@ class TemplateType(Enum):
             self.EXPORTER_REGISTERED_NEW_ORG: "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0",
             self.EXPORTER_USER_ADDED: "c9b67dca-0916-453a-99c0-70ba563e1bdd",
             self.EXPORTER_LICENCE_ISSUED: "f2757d61-2319-4279-82b2-a52170b0222a",
+            self.EXPORTER_ORGANISATION_APPROVED: "d5e94717-ae78-4d18-8064-ecfcd99143f1",
         }[self]

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -4,7 +4,6 @@ from enum import Enum
 class TemplateType(Enum):
     ECJU_COMPLIANCE_CREATED = "ecju_compliance_created"
     APPLICATION_STATUS = "application_status"
-    ORGANISATION_STATUS = "organisation_status"
     EXPORTER_REGISTERED_NEW_ORG = "exporter_registered_new_org"
     EXPORTER_USER_ADDED = "exporter_user_added"
     EXPORTER_LICENCE_ISSUED = "exporter_licence_issued"
@@ -17,7 +16,6 @@ class TemplateType(Enum):
         return {
             self.ECJU_COMPLIANCE_CREATED: "b23f4c55-fef0-4d8f-a10b-1ad7f8e7c672",
             self.APPLICATION_STATUS: "b9c3403a-8d09-416e-acd3-99baabf5b043",
-            self.ORGANISATION_STATUS: "c57ef67e-14fd-4af9-a9b2-5015040fa408",
             self.EXPORTER_REGISTERED_NEW_ORG: "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0",
             self.EXPORTER_USER_ADDED: "c9b67dca-0916-453a-99c0-70ba563e1bdd",
             self.EXPORTER_LICENCE_ISSUED: "f2757d61-2319-4279-82b2-a52170b0222a",

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -50,3 +50,10 @@ class ExporterLicenceIssued(EmailData):
     user_first_name: str
     application_reference: str
     exporter_frontend_url: str
+
+
+@dataclass(frozen=True)
+class ExporterOrganisationApproved(EmailData):
+    exporter_first_name: str
+    organisation_name: str
+    exporter_frontend_url: str

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -35,11 +35,6 @@ class ApplicationStatusEmailData(EmailData):
 
 
 @dataclass(frozen=True)
-class OrganisationStatusEmailData(EmailData):
-    organisation_name: str
-
-
-@dataclass(frozen=True)
 class ExporterRegistration(EmailData):
     organisation_name: str
 

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -57,3 +57,9 @@ class ExporterOrganisationApproved(EmailData):
     exporter_first_name: str
     organisation_name: str
     exporter_frontend_url: str
+
+
+@dataclass(frozen=True)
+class ExporterOrganisationRejected(EmailData):
+    exporter_first_name: str
+    organisation_name: str

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -14,6 +14,7 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
             (TemplateType.EXPORTER_ORGANISATION_APPROVED, "d5e94717-ae78-4d18-8064-ecfcd99143f1"),
+            (TemplateType.EXPORTER_ORGANISATION_REJECTED, "1dec3acd-94b0-47bb-832a-384ba5c6f51a"),
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -11,7 +11,6 @@ class TemplateTypeTests(APITestCase):
         [
             (TemplateType.ECJU_COMPLIANCE_CREATED, "b23f4c55-fef0-4d8f-a10b-1ad7f8e7c672"),
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
-            (TemplateType.ORGANISATION_STATUS, "c57ef67e-14fd-4af9-a9b2-5015040fa408"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
         ]

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -13,6 +13,7 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.APPLICATION_STATUS, "b9c3403a-8d09-416e-acd3-99baabf5b043"),
             (TemplateType.EXPORTER_REGISTERED_NEW_ORG, "6096c45e-0cbb-4ecd-a7a9-0ad674e1d2c0"),
             (TemplateType.EXPORTER_USER_ADDED, "c9b67dca-0916-453a-99c0-70ba563e1bdd"),
+            (TemplateType.EXPORTER_ORGANISATION_APPROVED, "d5e94717-ae78-4d18-8064-ecfcd99143f1"),
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -48,6 +48,21 @@ class DataclassTests(APITestCase):
                     "exporter_frontend_url": "https://some.domain/foo",
                 },
             ),
+            (
+                payloads.ExporterOrganisationApproved,
+                {
+                    "exporter_first_name": "testname",
+                    "organisation_name": "testorgname",
+                    "exporter_frontend_url": "https://some.domain/foo",
+                },
+            ),
+            (
+                payloads.ExporterOrganisationRejected,
+                {
+                    "exporter_first_name": "testname",
+                    "organisation_name": "testorgname",
+                },
+            ),
         ]
     )
     def test_valid_input(self, dataclass, data):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -36,12 +36,6 @@ class DataclassTests(APITestCase):
                 },
             ),
             (
-                payloads.OrganisationStatusEmailData,
-                {
-                    "organisation_name": "testorgname",
-                },
-            ),
-            (
                 payloads.ExporterRegistration,
                 {
                     "organisation_name": "testorgname",

--- a/gov_notify/tests/test_service.py
+++ b/gov_notify/tests/test_service.py
@@ -4,20 +4,20 @@ from rest_framework.test import APITestCase
 
 from gov_notify import service
 from gov_notify.enums import TemplateType
-from gov_notify.payloads import OrganisationStatusEmailData
+from gov_notify.payloads import ExporterRegistration
 
 
 class GovNotifyTemplateTests(APITestCase):
     @mock.patch("gov_notify.service.client")
     def test_send_email(self, mock_client):
         email = "fake@email.com"
-        template_type = TemplateType.ORGANISATION_STATUS
+        template_type = TemplateType.EXPORTER_REGISTERED_NEW_ORG
         data = {"organisation_name": "testorgname"}
 
-        organisation_status_data = OrganisationStatusEmailData(**data)
+        organisation_status_data = ExporterRegistration(**data)
 
         service.send_email(email_address=email, template_type=template_type, data=organisation_status_data)
 
         mock_client.send_email.assert_called_with(
-            email_address=email, template_id=TemplateType.ORGANISATION_STATUS.template_id, data=data
+            email_address=email, template_id=TemplateType.EXPORTER_REGISTERED_NEW_ORG.template_id, data=data
         )


### PR DESCRIPTION
This change ensures that an exporter user is notified by email when their organisation is approved or rejected.

This uses the following templates:
- approved - https://www.notifications.service.gov.uk/services/f3d8fb42-a34b-4d85-8ac2-a62006a197dc/templates/d5e94717-ae78-4d18-8064-ecfcd99143f1
- rejected - https://www.notifications.service.gov.uk/services/f3d8fb42-a34b-4d85-8ac2-a62006a197dc/templates/1dec3acd-94b0-47bb-832a-384ba5c6f51a 