### PR TITLE
LTD-2453: Retain previously assessed CLEs when a product is re-used in another application

### DIFF
--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -863,10 +863,14 @@ class ControlGoodOnApplicationSerializer(GoodControlReviewSerializer):
 
     def update(self, instance, validated_data):
         super().update(instance, validated_data)
-        instance.good.status = GoodStatus.VERIFIED
-        instance.good.control_list_entries.set(validated_data["control_list_entries"])
+        if instance.good.status == GoodStatus.VERIFIED:
+            instance.good.control_list_entries.add(*validated_data["control_list_entries"])
+        else:
+            instance.good.status = GoodStatus.VERIFIED
+            instance.good.control_list_entries.set(validated_data["control_list_entries"])
+            instance.good.flags.remove(SystemFlags.GOOD_NOT_YET_VERIFIED_ID)
+
         instance.good.save()
-        instance.good.flags.remove(SystemFlags.GOOD_NOT_YET_VERIFIED_ID)
         return instance
 
 


### PR DESCRIPTION
## Change description

When a new product is added to an application Exporter can specify CLE for
that product. This may not be the correct one depending on technicalities
and the parties involved for that application so caseworker may/can correct
this as part of their assessment.

Currently if the same product is re-used in some other application we are
replacing previous CLEs with the most recent assessment values.

The requirement is to show all of the previous assessment along with the
recent assessment also to the Exporter hence instead of overwriting we
add to existing values in the case where product is re-used.