### PR TITLE
Send applicant editing notification

### DIFF
--- a/api/applications/tests/test_application_status.py
+++ b/api/applications/tests/test_application_status.py
@@ -48,7 +48,8 @@ class ApplicationManageStatusTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.standard_application.status, get_case_status_by_status(CaseStatusEnum.SUBMITTED))
 
-    def test_exporter_set_application_status_applicant_editing_when_in_editable_status_success(self):
+    @mock.patch("api.applications.views.applications.notify_exporter_case_opened_for_editing")
+    def test_exporter_set_application_status_applicant_editing_when_in_editable_status_success(self, mock_notify):
         self.submit_application(self.standard_application)
 
         data = {"status": CaseStatusEnum.APPLICANT_EDITING}
@@ -63,6 +64,7 @@ class ApplicationManageStatusTests(DataTestClient):
         self.assertEqual(
             audit_event.payload, {"status": {"new": CaseStatusEnum.APPLICANT_EDITING, "old": CaseStatusEnum.SUBMITTED}}
         )
+        mock_notify.assert_called_with(self.standard_application)
 
     def test_exporter_set_application_status_withdrawn_when_application_not_terminal_success(self):
         self.submit_application(self.standard_application)
@@ -303,8 +305,7 @@ class ApplicationManageStatusTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(self.standard_application.status, get_case_status_by_status(CaseStatusEnum.WITHDRAWN))
 
-    @mock.patch("api.applications.views.applications.notify_exporter_case_opened_for_editing")
-    def test_gov_set_status_when_they_have_permission_to_reopen_closed_cases_success(self, mock_notify):
+    def test_gov_set_status_when_they_have_permission_to_reopen_closed_cases_success(self):
         self.standard_application.status = get_case_status_by_status(CaseStatusEnum.WITHDRAWN)
         self.standard_application.save()
 
@@ -322,7 +323,6 @@ class ApplicationManageStatusTests(DataTestClient):
         self.assertEqual(
             self.standard_application.status, get_case_status_by_status(CaseStatusEnum.REOPENED_FOR_CHANGES)
         )
-        mock_notify.assert_called_with(self.standard_application)
 
     def test_case_routing_automation(self):
         routing_queue = self.create_queue("new queue", self.team)

--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -530,7 +530,7 @@ class ApplicationManageStatus(APIView):
         if old_status != application.status:
             run_routing_rules(case=application, keep_status=True)
 
-            if application.status.status == CaseStatusEnum.REOPENED_FOR_CHANGES:
+            if application.status.status == CaseStatusEnum.APPLICANT_EDITING:
                 notify_exporter_case_opened_for_editing(application)
 
         data = get_application_view_serializer(application)(application, context={"user_type": request.user.type}).data


### PR DESCRIPTION
This was originally using the wrong case status (it was using the one that is set when the caseworker opens for editing not the one when the exporter opens for editing)