### PR TITLE
Only send licence issued notification when the recommendation was "ap…

### DIFF
--- a/api/cases/notify.py
+++ b/api/cases/notify.py
@@ -22,9 +22,9 @@ def _notify_exporter_licence_issued(email, data):
     )
 
 
-def notify_exporter_licence_issued(licence):
-    exporter = licence.case.submitted_by
-    case = licence.case.get_case()
+def notify_exporter_licence_issued(case):
+    exporter = case.submitted_by
+    case = case.get_case()
     _notify_exporter_licence_issued(
         exporter.email,
         {

--- a/api/cases/tests/test_grant_licence.py
+++ b/api/cases/tests/test_grant_licence.py
@@ -56,7 +56,7 @@ class FinaliseCaseTests(DataTestClient):
             self.assertTrue(document.visible_to_exporter)
         self.assertEqual(Audit.objects.count(), 4)
         send_exporter_notifications_func.assert_called()
-        mock_notify.assert_called_with(licence)
+        mock_notify.assert_called_with(self.standard_case.get_case())
 
     def test_grant_standard_application_wrong_permission_failure(self):
         self.gov_user.role.permissions.set([GovPermissions.MANAGE_CLEARANCE_FINAL_ADVICE.name])
@@ -109,7 +109,7 @@ class FinaliseCaseTests(DataTestClient):
             self.assertTrue(document.visible_to_exporter)
         self.assertEqual(Audit.objects.count(), 5)
         send_exporter_notifications_func.assert_called()
-        mock_notify.assert_called_with(licence)
+        mock_notify.assert_called_with(clearance_case.get_case())
 
     def test_grant_clearance_wrong_permission_failure(self):
         clearance_case = self.create_mod_clearance_application(self.organisation, CaseTypeEnum.EXHIBITION)
@@ -166,7 +166,7 @@ class FinaliseCaseTests(DataTestClient):
             self.assertTrue(document.visible_to_exporter)
         # self.assertEqual(Audit.objects.count(), 4)
         send_exporter_notifications_func.assert_called()
-        mock_notify_licence_issue.assert_called_with(licence)
+        mock_notify_licence_issue.assert_called_with(self.standard_case.get_case())
 
         self.change_status_url = reverse("applications:manage_status", kwargs={"pk": self.standard_case.id})
         data = {"status": CaseStatusEnum.REVOKED}

--- a/api/cases/tests/test_nlr_licence.py
+++ b/api/cases/tests/test_nlr_licence.py
@@ -25,9 +25,15 @@ class RefuseCaseTests(DataTestClient):
             decisions=[Decision.objects.get(name=AdviceType.NO_LICENCE_REQUIRED)],
         )
 
+    @mock.patch("api.cases.views.views.notify_exporter_licence_issued")
     @mock.patch("api.cases.views.views.notify_exporter_no_licence_required")
     @mock.patch("api.cases.generated_documents.models.GeneratedCaseDocument.send_exporter_notifications")
-    def test_no_licence_required_standard_application_success(self, send_exporter_notifications_func, mock_notify):
+    def test_no_licence_required_standard_application_success(
+        self,
+        send_exporter_notifications_func,
+        mock_notify_exporter_no_licence_required,
+        mock_notify_exporter_licence_issued,
+    ):
         self.gov_user.role.permissions.set([GovPermissions.MANAGE_LICENCE_FINAL_ADVICE.name])
         self.create_generated_case_document(self.application, self.template, advice_type=AdviceType.NO_LICENCE_REQUIRED)
 
@@ -41,5 +47,6 @@ class RefuseCaseTests(DataTestClient):
 
         self.assertEqual(Audit.objects.count(), 2)
         case = get_case(self.application.id)
-        mock_notify.assert_called_with(case)
+        mock_notify_exporter_no_licence_required.assert_called_with(case)
+        mock_notify_exporter_licence_issued.assert_not_called()
         send_exporter_notifications_func.assert_called()

--- a/api/cases/tests/test_notify.py
+++ b/api/cases/tests/test_notify.py
@@ -30,11 +30,11 @@ class NotifyTests(DataTestClient):
     def test_notify_licence_issued(self, mock_send_email):
         expected_payload = ExporterLicenceIssued(
             user_first_name=self.exporter_user.first_name,
-            application_reference=self.licence.case.reference_code,
+            application_reference=self.case.reference_code,
             exporter_frontend_url="https://exporter.lite.service.localhost.uktrade.digital/",
         )
 
-        notify_exporter_licence_issued(self.licence)
+        notify_exporter_licence_issued(self.case)
 
         mock_send_email.assert_called_with(
             self.exporter_user.email,


### PR DESCRIPTION
This only sends licence issue notification when a licence is actually approved.

There are other scenarios where our code effectively "issues" a licence but it may have been for a different reason where the licence, in real terms, isn't actually issued.

This makes it explicit that we only want to send this notification when the licence is issued (approved in this case).