### PR TITLE
LTD-2541: Reset products verification status when an application is copied

### DIFF
--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -73,6 +73,7 @@ from api.core.helpers import convert_date_to_string, str_to_bool
 from api.core.permissions import assert_user_has_permission
 from api.flags.enums import FlagStatuses, SystemFlags
 from api.flags.models import Flag
+from api.goods.enums import GoodStatus
 from api.goods.serializers import GoodCreateSerializer
 from api.goods.models import FirearmGoodDetails
 from api.goodstype.models import GoodsType
@@ -780,6 +781,9 @@ class ApplicationCopy(APIView):
         # Save
         self.new_application.created_at = now()
         self.new_application.save()
+
+        self.reset_products_assessment_status(self.new_application)
+
         return JsonResponse(data={"data": self.new_application.id}, status=status.HTTP_201_CREATED)
 
     def strip_id_for_application_copy(self):
@@ -910,6 +914,12 @@ class ApplicationCopy(APIView):
                     F680ClearanceApplication.objects.get(id=self.old_application_id).types.values_list("id", flat=True)
                 )
             )
+
+    def reset_products_assessment_status(self, application):
+        for product_on_application in application.goods.all():
+            product = product_on_application.good
+            product.status = GoodStatus.DRAFT
+            product.save()
 
 
 class ExhibitionDetails(ListCreateAPIView):

--- a/api/goods/tests/factories.py
+++ b/api/goods/tests/factories.py
@@ -2,7 +2,7 @@ import factory
 from django.utils import timezone
 
 from api.goods import models
-from api.goods.enums import ItemCategory, Component, MilitaryUse, FirearmGoodType, GoodPvGraded
+from api.goods.enums import ItemCategory, Component, MilitaryUse, FirearmGoodType, GoodPvGraded, GoodStatus
 from api.staticdata.control_list_entries.helpers import get_control_list_entry
 
 
@@ -22,6 +22,7 @@ class GoodFactory(factory.django.DjangoModelFactory):
     information_security_details = None
     modified_military_use_details = None
     component_details = None
+    status = GoodStatus.DRAFT
 
     class Meta:
         model = models.Good


### PR DESCRIPTION
## Change description

When we create new applications by making a copy of an existing application
currently we are retaining the product's verification status. Because of this
when this application is submitted, the products are already shown as
verified without TAU assessing them. Fix this by resetting the verification
status when an application is copied.