### PR TITLE
Allow editing of section certificate details via attach endpoint

### DIFF
--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -304,9 +304,31 @@ class FirearmDetailsAttachingSerializer(serializers.Serializer):
         allow_null=True,
         required=False,
     )
+    section_certificate_missing = serializers.BooleanField(allow_null=True, required=False)
+    section_certificate_missing_reason = serializers.CharField(allow_blank=True, required=False)
+    section_certificate_number = serializers.CharField(
+        allow_blank=True, allow_null=True, required=False, max_length=100
+    )
+    section_certificate_date_of_expiry = serializers.DateField(
+        allow_null=True, required=False, error_messages={"invalid": strings.Goods.FIREARM_GOOD_NO_EXPIRY_DATE}
+    )
 
     def update(self, instance, validated_data):
-        instance.category = validated_data.get("category", instance.category)
+        for field_to_update in [
+            "category",
+            "section_certificate_missing",
+            "section_certificate_missing_reason",
+            "section_certificate_number",
+            "section_certificate_date_of_expiry",
+        ]:
+            setattr(
+                instance,
+                field_to_update,
+                validated_data.get(
+                    field_to_update,
+                    getattr(instance, field_to_update),
+                ),
+            )
         instance.save()
         return instance
 

--- a/api/goods/tests/test_edit.py
+++ b/api/goods/tests/test_edit.py
@@ -577,21 +577,28 @@ class GoodsAttachingTests(DataTestClient):
         )
         self.url = reverse("goods:good_attaching", kwargs={"pk": str(self.good.id)})
 
-    def test_editing_firearm_category(self):
+    def test_editing_firearm(self):
         self.good.firearm_details.category = None
+        self.good.firearm_details.section_certificate_missing = None
+        self.good.firearm_details.section_certificate_missing_reason = "previous missing reason"
+        self.good.firearm_details.section_certificate_number = None
+        self.good.firearm_details.section_certificate_date_of_expiry = None
         self.good.firearm_details.save()
 
-        url = reverse("goods:good_details", kwargs={"pk": str(self.good.id)})
         data = {
             "firearm_details": {
                 "category": [
                     "NON_AUTOMATIC_SHOTGUN",
                     "NON_AUTOMATIC_RIM_FIRED_RIFLE",
                 ],
+                "section_certificate_missing": False,
+                "section_certificate_missing_reason": "",
+                "section_certificate_number": "55555",
+                "section_certificate_date_of_expiry": "2025-11-5",
             },
         }
         response = self.client.put(
-            url,
+            self.url,
             data,
             **self.exporter_headers,
         )
@@ -604,4 +611,20 @@ class GoodsAttachingTests(DataTestClient):
                 "NON_AUTOMATIC_SHOTGUN",
                 "NON_AUTOMATIC_RIM_FIRED_RIFLE",
             ],
+        )
+        self.assertIs(
+            self.good.firearm_details.section_certificate_missing,
+            False,
+        )
+        self.assertEqual(
+            self.good.firearm_details.section_certificate_missing_reason,
+            "",
+        )
+        self.assertEqual(
+            self.good.firearm_details.section_certificate_number,
+            "55555",
+        )
+        self.assertEqual(
+            self.good.firearm_details.section_certificate_date_of_expiry,
+            date(2025, 11, 5),
         )


### PR DESCRIPTION
This is the companion pull request for: https://github.com/uktrade/lite-frontend/pull/815.

This allows fields to be edited on the original good model that are required when attaching. This is part of the "upgrade" process from original goods that didn't have the required section certificate fields added when they were created and we then add them as part of the attaching process.