### PR TITLE
new cloud build file release GCR trigger

### DIFF
--- a/cloudbuild-release.yaml
+++ b/cloudbuild-release.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/sre-docker-registry/github.com/uktrade/lite-api', '-f', 'Dockerfile.e2e', '.', '--build-arg', 'GIT_ACCESS_CODE=${_GITKEY}' ]
+images:
+  - 'gcr.io/sre-docker-registry/github.com/uktrade/lite-api:${TAG_NAME}'


### PR DESCRIPTION
This creates a new Cloud build file to use within new GCR trigger to allow adding tag to lite-api image during git release