### PR TITLE
LTD: Add Routing rule tier number to audit event

### DIFF
--- a/api/workflow/automation.py
+++ b/api/workflow/automation.py
@@ -56,7 +56,7 @@ def run_routing_rules(case: Case, keep_status: bool = False):
                             actor=system_user,
                             verb=AuditType.MOVE_CASE,
                             action_object=case.get_case(),
-                            payload={"queues": rule.queue.name},
+                            payload={"queues": rule.queue.name, "id": str(rule.id), "tier": rule.tier},
                         )
                         # Only assign active users to the case
                         if rule.user and rule.user.status == UserStatuses.ACTIVE:


### PR DESCRIPTION
## Change description

Currently when routing rules are applied and a Case is moved we don't know
the tier number of the rule applied. Add tier number to understand how
tier number affects routing rules.