### PR TITLE
LTD-2641: Return current node if there is no parent node

### DIFF
--- a/api/staticdata/control_list_entries/helpers.py
+++ b/api/staticdata/control_list_entries/helpers.py
@@ -26,7 +26,7 @@ def convert_control_list_entries_to_tree(data):
     return ultimate_parents_of_tree_list
 
 
-def get_clc_parent_nodes(rating):
+def get_clc_parent_nodes(rating, parent_nodes=None):
     """
     A control list entry can be a group entry or a child of a child entry.
     Given a rating, this function provides the list of all parent nodes in the chain.
@@ -34,18 +34,25 @@ def get_clc_parent_nodes(rating):
     ML1 -> ML1a, ML1b, ML1c, ML1d
     ML1b -> ML1b1, ML1b2
     Given ML1b1, it returns [ML1, ML1b]
+
+    If the given rating itself is a parent node then it returns the same node.
     """
 
-    parent_nodes = []
     try:
         node = ControlListEntry.objects.get(rating=rating)
     except ControlListEntry.DoesNotExist:
         node = None
 
+    if parent_nodes is None:
+        parent_nodes = []
+    else:
+        parent_nodes.extend([rating])
+
+    if node and node.controlled and node.parent is None:
+        return [node.rating]
+
     if node and node.parent and node.parent.controlled:
-        parent_nodes.append(node.parent.rating)
-        next_parent = get_clc_parent_nodes(node.parent.rating)
-        parent_nodes.extend(next_parent)
+        get_clc_parent_nodes(node.parent.rating, parent_nodes)
 
     return parent_nodes
 

--- a/api/staticdata/control_list_entries/test.py
+++ b/api/staticdata/control_list_entries/test.py
@@ -45,7 +45,7 @@ class CLCListTests(DataTestClient):
 
     @parameterized.expand(
         [
-            ["ML1", []],
+            ["ML1", ["ML1"]],
             ["ML1c", ["ML1"]],
             ["ML1b1", ["ML1", "ML1b"]],
             ["ML1d1", ["ML1"]],
@@ -54,6 +54,7 @@ class CLCListTests(DataTestClient):
             ["ML2c4", ["ML2"]],
             ["6E003a1", ["6", "6E", "6E003", "6E003a"]],
             ["6A005d1d1a", ["6", "6A", "6A005", "6A005d", "6A005d1", "6A005d1d", "6A005d1d1"]],
+            ["PL9004", ["PL9004"]],
             ["INVALID_CLC", []],
         ]
     )


### PR DESCRIPTION
## Change description

We have a helper function that returns all parent nodes of a given
CLE rating but if the given rating itself is a parent and it doesn't 
have a parent then it doesn't return anything. 
This makes flagging rules fail if that parent is specified as matching_group,
in which case rule doesn't get applied.