### PR TITLE
LTD-2694: Re-instate audit UPDATED_STATUS when case is finalised

### DIFF
--- a/api/cases/tests/test_grant_licence.py
+++ b/api/cases/tests/test_grant_licence.py
@@ -54,7 +54,7 @@ class FinaliseCaseTests(DataTestClient):
         self.assertEqual(self.standard_case.status, CaseStatus.objects.get(status=CaseStatusEnum.FINALISED))
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
-        self.assertEqual(Audit.objects.count(), 4)
+        self.assertEqual(Audit.objects.count(), 5)
         send_exporter_notifications_func.assert_called()
         mock_notify.assert_called_with(self.standard_case.get_case())
 
@@ -107,7 +107,7 @@ class FinaliseCaseTests(DataTestClient):
         self.assertEqual(clearance_case.status, CaseStatus.objects.get(status=CaseStatusEnum.FINALISED))
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
-        self.assertEqual(Audit.objects.count(), 5)
+        self.assertEqual(Audit.objects.count(), 6)
         send_exporter_notifications_func.assert_called()
         mock_notify.assert_called_with(clearance_case.get_case())
 

--- a/api/cases/tests/test_nlr_licence.py
+++ b/api/cases/tests/test_nlr_licence.py
@@ -45,7 +45,7 @@ class RefuseCaseTests(DataTestClient):
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
 
-        self.assertEqual(Audit.objects.count(), 2)
+        self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify_exporter_no_licence_required.assert_called_with(case)
         mock_notify_exporter_licence_issued.assert_not_called()

--- a/api/cases/tests/test_refuse_licence.py
+++ b/api/cases/tests/test_refuse_licence.py
@@ -39,7 +39,7 @@ class RefuseCaseTests(DataTestClient):
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
 
-        self.assertEqual(Audit.objects.count(), 2)
+        self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify.assert_called_with(case)
         send_exporter_notifications_func.assert_called()

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -818,6 +818,7 @@ class FinaliseView(UpdateAPIView):
             pass
 
         # Finalise Case
+        old_status = case.status.status
         case.status = get_case_status_by_status(CaseStatusEnum.FINALISED)
         case.save()
 
@@ -842,6 +843,16 @@ class FinaliseView(UpdateAPIView):
                 target=case,
                 payload={"case_reference": case.reference_code, "decision": decision, "licence_reference": ""},
             )
+
+        audit_trail_service.create(
+            actor=request.user,
+            verb=AuditType.UPDATED_STATUS,
+            target=case,
+            payload={
+                "status": {"new": case.status.status, "old": old_status},
+                "additional_text": request.data.get("note"),
+            },
+        )
 
         # Show documents to exporter & notify
         documents = GeneratedCaseDocument.objects.filter(advice_type__isnull=False, case=case)


### PR DESCRIPTION
## Change description

This was removed during Notes and Timeline changes but this affects reporting.
Some of the reports use this event to determine when the case is finalised.