### PR TITLE
LTD-2644-CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ image_elasticsearch: &image_elasticsearch
 image_redis: &image_redis
   image: circleci/redis:3.2-alpine
 
+parameters:
+  lite_routing_branch_name:
+    type: string
+    default: "default"
+
 commands:
   setup:
     steps:
@@ -35,6 +40,25 @@ commands:
           command: |
             git submodule sync
             git submodule update --init
+      - when:
+          condition:
+            not:
+              and:
+                # If not equal default run this step.
+                - equal:
+                    [
+                      default,
+                      << pipeline.parameters.lite_routing_branch_name >>,
+                    ]
+          steps:
+            - run:
+                name: Git lite_routing Checkout
+                command: |
+                  echo lite_routing checkout to << pipeline.parameters.lite_routing_branch_name >>
+                  cd lite_routing
+                  git checkout << pipeline.parameters.lite_routing_branch_name >>
+                  cd ..
+
       # Download and cache dependencies
       # ensure this step occurs *before* installing dependencies
       - restore_cache:


### PR DESCRIPTION
Added condition if parameter branch_name is not `default` it will trigger the checkout job for CircleCI.

SS if branch_name exists:
![Screenshot 2022-08-19 at 21 39 08](https://user-images.githubusercontent.com/24960282/185703660-fca299c1-caf6-42fc-aa57-62dfefd84e29.png)


### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-2644
- [x] Jira ticket has the correct status.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [x] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
