### PR TITLE
Allow updating of regime entries for `GoodOnApplication`

### DIFF
--- a/api/applications/serializers/good.py
+++ b/api/applications/serializers/good.py
@@ -25,6 +25,7 @@ from api.goods.serializers import GoodSerializerInternal, FirearmDetailsSerializ
 from api.licences.models import GoodOnLicence
 from api.organisations.models import DocumentOnOrganisation
 from api.staticdata.control_list_entries.serializers import ControlListEntrySerializer
+from api.staticdata.regimes.serializers import RegimeEntrySerializer
 from api.staticdata.units.enums import Units
 from api.users.models import ExporterUser
 from api.users.serializers import ExporterUserSimpleSerializer
@@ -85,7 +86,7 @@ class GoodOnApplicationViewSerializer(serializers.ModelSerializer):
     audit_trail = serializers.SerializerMethodField()
     is_good_controlled = KeyValueChoiceField(choices=GoodControlled.choices)
     firearm_details = FirearmDetailsSerializer()
-    regime_entries = serializers.SerializerMethodField()
+    regime_entries = RegimeEntrySerializer(many=True, read_only=True)
 
     class Meta:
         model = GoodOnApplication
@@ -122,9 +123,6 @@ class GoodOnApplicationViewSerializer(serializers.ModelSerializer):
 
     def get_flags(self, instance):
         return list(instance.good.flags.values("id", "name", "colour", "label"))
-
-    def get_regime_entries(self, instance):
-        return list(instance.regime_entries.values_list("name", flat=True))
 
     def get_good_application_documents(self, instance):
         documents = GoodOnApplicationDocument.objects.filter(

--- a/api/applications/serializers/good.py
+++ b/api/applications/serializers/good.py
@@ -85,6 +85,7 @@ class GoodOnApplicationViewSerializer(serializers.ModelSerializer):
     audit_trail = serializers.SerializerMethodField()
     is_good_controlled = KeyValueChoiceField(choices=GoodControlled.choices)
     firearm_details = FirearmDetailsSerializer()
+    regime_entries = serializers.SerializerMethodField()
 
     class Meta:
         model = GoodOnApplication
@@ -116,10 +117,14 @@ class GoodOnApplicationViewSerializer(serializers.ModelSerializer):
             "is_onward_altered_processed_comments",
             "is_onward_incorporated",
             "is_onward_incorporated_comments",
+            "regime_entries",
         )
 
     def get_flags(self, instance):
         return list(instance.good.flags.values("id", "name", "colour", "label"))
+
+    def get_regime_entries(self, instance):
+        return list(instance.regime_entries.values_list("name", flat=True))
 
     def get_good_application_documents(self, instance):
         documents = GoodOnApplicationDocument.objects.filter(

--- a/api/audit_trail/formatters.py
+++ b/api/audit_trail/formatters.py
@@ -181,6 +181,11 @@ def product_reviewed(**payload):
     else:
         text += f"Control list entry: No change from '{payload['old_control_list_entry']}'\n"
 
+    if payload.get("old_regime_entries") != payload.get("new_regime_entries"):
+        text += f"Regimes: Changed from '{payload['old_regime_entries']}' to '{payload['new_regime_entries']}'\n"
+    else:
+        text += f"Regimes: No change from '{payload.get('old_regime_entries', 'No regimes')}'\n"
+
     if payload["old_report_summary"] != payload["report_summary"]:
         text += f"Report summary: Changed from '{payload['old_report_summary']}' to '{payload['report_summary']}'"
     else:

--- a/api/audit_trail/tests/test_formatters.py
+++ b/api/audit_trail/tests/test_formatters.py
@@ -268,6 +268,7 @@ class FormattersTest(DataTestClient):
                 "reviewed the line 1 assessment for Sniper rifles\n"
                 "Licence required: Changed from 'No' to 'Yes'\n"
                 "Control list entry: No change from 'ML8a'\n"
+                "Regimes: No change from 'No regimes'\n"
                 "Report summary: Changed from 'None' to 'Sniper rifles (10)'",
             ),
             (
@@ -284,7 +285,27 @@ class FormattersTest(DataTestClient):
                 "reviewed the line 2 assessment for Sniper rifles\n"
                 "Licence required: Changed from 'No' to 'Yes'\n"
                 "Control list entry: Changed from 'ML8a' to 'ML8b'\n"
+                "Regimes: No change from 'No regimes'\n"
                 "Report summary: No change from 'Sniper rifles (10)'",
+            ),
+            (
+                {
+                    "line_no": 1,
+                    "good_name": "Sniper rifles",
+                    "old_is_good_controlled": "No",
+                    "new_is_good_controlled": "Yes",
+                    "old_control_list_entry": "ML8a",
+                    "new_control_list_entry": "ML8b",
+                    "old_report_summary": "None",
+                    "report_summary": "Sniper rifles (10)",
+                    "old_regime_entries": "REGIME1",
+                    "new_regime_entries": "REGIME2",
+                },
+                "reviewed the line 1 assessment for Sniper rifles\n"
+                "Licence required: Changed from 'No' to 'Yes'\n"
+                "Control list entry: Changed from 'ML8a' to 'ML8b'\n"
+                "Regimes: Changed from 'REGIME1' to 'REGIME2'\n"
+                "Report summary: Changed from 'None' to 'Sniper rifles (10)'",
             ),
         ]
     )

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -751,6 +751,7 @@ class GoodOnApplicationSerializer(serializers.ModelSerializer):
     destinations = serializers.SerializerMethodField()
     submitted_at = serializers.ReadOnlyField(source="application.submitted_at")
     goods_starting_point = serializers.ReadOnlyField(source="application.standardapplication.goods_starting_point")
+    regime_entries = serializers.SerializerMethodField()
 
     class Meta:
         model = GoodOnApplication
@@ -769,6 +770,7 @@ class GoodOnApplicationSerializer(serializers.ModelSerializer):
             "wassenaar",
             "submitted_at",
             "goods_starting_point",
+            "regime_entries",
         )
 
     def get_queue(self, obj):
@@ -777,6 +779,9 @@ class GoodOnApplicationSerializer(serializers.ModelSerializer):
 
     def get_control_list_entries(self, obj):
         return [cle.rating for cle in obj.get_control_list_entries().all()]
+
+    def get_regime_entries(self, obj):
+        return [regime_entry.name for regime_entry in obj.regime_entries.all()]
 
     def get_wassenaar(self, obj):
         return obj.good.flags.filter(name="WASSENAAR").exists()

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -28,6 +28,7 @@ from lite_content.lite_api import strings
 from api.organisations.models import Organisation
 from api.queries.goods_query.models import GoodsQuery
 from api.staticdata.control_list_entries.serializers import ControlListEntrySerializer
+from api.staticdata.regimes.models import RegimeEntry
 from api.staticdata.missing_document_reasons.enums import GoodMissingDocumentReasons
 from api.staticdata.statuses.libraries.get_case_status import get_status_value_from_case_status_enum
 from api.users.models import ExporterUser
@@ -926,10 +927,16 @@ class ControlGoodOnApplicationSerializer(GoodControlReviewSerializer):
 
     is_precedent = serializers.BooleanField(required=False, default=False)
     is_wassenaar = serializers.BooleanField(required=False, default=False)
+    regime_entries = PrimaryKeyRelatedField(many=True, queryset=RegimeEntry.objects.all())
 
     class Meta(GoodControlReviewSerializer.Meta):
         model = GoodOnApplication
-        fields = GoodControlReviewSerializer.Meta.fields + ("end_use_control", "is_precedent", "is_wassenaar")
+        fields = GoodControlReviewSerializer.Meta.fields + (
+            "end_use_control",
+            "is_precedent",
+            "is_wassenaar",
+            "regime_entries",
+        )
 
     def update(self, instance, validated_data):
         super().update(instance, validated_data)

--- a/api/staticdata/regimes/serializers.py
+++ b/api/staticdata/regimes/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+
+from .models import RegimeEntry
+
+
+class RegimeEntrySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RegimeEntry
+        fields = ["pk", "name"]

--- a/api/staticdata/regimes/tests/test_views.py
+++ b/api/staticdata/regimes/tests/test_views.py
@@ -48,5 +48,5 @@ class MTCREntriesTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json(),
-            {"entries": [[str(r.pk), r.name] for r in sorted(mtcr_regimes, key=lambda r: r.name)]},
+            [{"pk": str(r.pk), "name": r.name} for r in sorted(mtcr_regimes, key=lambda r: r.name)],
         )

--- a/api/staticdata/regimes/views.py
+++ b/api/staticdata/regimes/views.py
@@ -1,23 +1,14 @@
-from django.http import JsonResponse
-
-from rest_framework.views import APIView
+from rest_framework import generics
 
 from api.core.authentication import HawkOnlyAuthentication
 
 from .enums import RegimesEnum
 from .models import RegimeEntry
+from .serializers import RegimeEntrySerializer
 
 
-class MTCREntriesView(APIView):
+class MTCREntriesView(generics.ListAPIView):
     authentication_classes = (HawkOnlyAuthentication,)
-
-    def get(self, request):
-        entries = (
-            RegimeEntry.objects.filter(subsection__regime=RegimesEnum.MTCR).order_by("name").values_list("pk", "name")
-        )
-
-        return JsonResponse(
-            data={
-                "entries": list(entries),
-            }
-        )
+    pagination_class = None
+    queryset = RegimeEntry.objects.filter(subsection__regime=RegimesEnum.MTCR).order_by("name")
+    serializer_class = RegimeEntrySerializer

--- a/api/workflow/tests/test_flagging_rules.py
+++ b/api/workflow/tests/test_flagging_rules.py
@@ -121,6 +121,7 @@ class FlaggingRulesAutomation(DataTestClient):
             "report_summary": "test report summary",
             "control_list_entries": ["ML8b"],
             "is_good_controlled": True,
+            "regime_entries": [],
         }
 
         response = self.client.post(self.url, data, **self.gov_headers)


### PR DESCRIPTION
This makes setting regime data on a good independent of the flags.

For wassenaar this was simply just handled by setting a flag and then basing the regime on that flag, now we're expanding the available regimes then this isn't going to be a viable strategy going forward.

The old wassenaar flag setting is retained for backwards compatibility whilst the frontend is transitioned to the more granular way of handling regimes.