### PR TITLE
Handle case where `regime_entries` isn't sent through

### DIFF
--- a/api/goods/tests/test_control_codes.py
+++ b/api/goods/tests/test_control_codes.py
@@ -81,6 +81,25 @@ class GoodsVerifiedTestsStandardApplication(DataTestClient):
         self.assertEqual(verified_good_1.control_list_entries.get().rating, "ML1a")
         self.assertEqual(verified_good_2.control_list_entries.get().rating, "ML1a")
 
+    def test_payload_without_regime_entries(self):
+        data = {
+            "objects": [self.good_1.pk, self.good_2.pk],
+            "current_object": self.good_on_application_1.pk,
+            "comment": "I Am Easy to Find",
+            "report_summary": self.report_summary.text,
+            "control_list_entries": ["ML1a"],
+            "is_good_controlled": True,
+        }
+
+        response = self.client.post(self.url, data, **self.gov_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        verified_good_1 = Good.objects.get(pk=self.good_1.pk)
+        verified_good_2 = Good.objects.get(pk=self.good_2.pk)
+
+        self.assertEqual(verified_good_1.control_list_entries.get().rating, "ML1a")
+        self.assertEqual(verified_good_2.control_list_entries.get().rating, "ML1a")
+
     def test_report_summary_saved_goodonapplication(self):
         """
         Make sure report_summary is saved to the GoodOnApplication

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -138,7 +138,9 @@ class GoodsListControlCode(APIView):
             if "control_list_entries" in serializer.data or "is_good_controlled" in serializer.data:
                 new_control_list_entries = [item.rating for item in serializer.validated_data["control_list_entries"]]
                 new_is_controlled = serializer.validated_data["is_good_controlled"]
-                new_regime_entries = [regime_entry.name for regime_entry in serializer.validated_data["regime_entries"]]
+                new_regime_entries = [
+                    regime_entry.name for regime_entry in serializer.validated_data.get("regime_entries", [])
+                ]
 
                 if (
                     new_control_list_entries != old_control_list_entries


### PR DESCRIPTION
This is a non-mandatory field and as such we can't guarantee it will exist due to an frontend with older code