### PR TITLE
Run lite routing BDD tests in parallel to unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,27 @@ jobs:
     steps:
       - setup
       - run:
-          name: Run lite_routing BDD tests
+          name: Run lite_routing tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc lite_routing
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing/routing_rules_internal/tests/bdd lite_routing
+      - upload_code_coverage
+
+  lite_routing_bdd_tests:
+    docker:
+      - <<: *image_python
+      - <<: *image_postgres
+      - <<: *image_elasticsearch
+      - <<: *image_redis
+    working_directory: ~/lite-api
+    environment:
+      <<: *common_env_vars
+      LITE_API_ENABLE_ES: True
+    steps:
+      - setup
+      - run:
+          name: Run lite_routing tests
+          command: |
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc lite_routing/routing_rules_internal/tests/bdd
       - upload_code_coverage
 
   elastic_search_tests:
@@ -210,6 +228,7 @@ workflows:
       - tests
       - seeding_tests
       - lite_routing_tests
+      - lite_routing_bdd_tests
       - elastic_search_tests
       - check_migrations
       - linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
             chmod +x codecov
       - save_cache:
           paths:
-            - ./venv
+            - ./.venv
           key: dependencies-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
   upload_code_coverage:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: Run lite_routing tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc lite_routing/routing_rules_internal/tests/bdd
+            pipenv run pytest lite_routing/routing_rules_internal/tests/bdd
       - upload_code_coverage
 
   elastic_search_tests:


### PR DESCRIPTION
This splits out the lite routing tests into two separate jobs.

This is so that the tests run quicker as they run in parallel.

This also means code coverage isn't run when the lite routing BDD tests run. The BDD tests, beyond the actual things they are asserting, run a lot of incidental code and there is the possibility that this is increasing the code coverage beyond what is actually asserted.