### PR TITLE
[LTD-2923] Add case_status to MOVE_CASE audit trail payload

### DIFF
--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -177,6 +177,7 @@ class SetQueues(APIView):
                     "queues": sorted([queue.name for queue in new_queues]),
                     "queue_ids": sorted([str(queue.id) for queue in new_queues]),
                     "additional_text": note,
+                    "case_status": case.status.status,
                 },
             )
         return JsonResponse(data={"queues": list(request_queues)}, status=status.HTTP_200_OK)

--- a/api/workflow/automation.py
+++ b/api/workflow/automation.py
@@ -71,6 +71,7 @@ def run_routing_rules(case: Case, keep_status: bool = False):
                             "queue_ids": [str(rule.queue.id)],
                             "id": str(rule.id),
                             "tier": rule.tier,
+                            "case_status": case.status.status,
                         },
                     )
                     # Only assign active users to the case

--- a/api/workflow/user_queue_assignment.py
+++ b/api/workflow/user_queue_assignment.py
@@ -81,7 +81,11 @@ def user_queue_assignment_workflow(queues: [Queue], case: Case):
                 actor=system_user,
                 verb=AuditType.MOVE_CASE,
                 action_object=case.get_case(),
-                payload={"queues": queue.countersigning_queue.name, "queue_ids": [str(queue.countersigning_queue_id)]},
+                payload={
+                    "queues": queue.countersigning_queue.name,
+                    "queue_ids": [str(queue.countersigning_queue_id)],
+                    "case_status": case.status.status,
+                },
             )
 
     # Move case to next non-terminal state if unassigned from all queues


### PR DESCRIPTION
This change adds `case_status` as an attribute to the payload for MOVE_CASE audit trail events.  This will enable us to add routing rules which fire if a case did/did not visit certain queues when it was in a certain state previously, related PR: https://github.com/uktrade/lite-routing/pull/79