### PR TITLE
LTD-2907: Enable filtering Denials search results based on entity country

### DIFF
--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -4,6 +4,7 @@ from django_elasticsearch_dsl.registries import registry
 from elasticsearch_dsl import analysis
 
 from api.external_data import models
+from api.search.application.documents import lowercase_normalizer
 
 
 class DataField(fields.ObjectField):
@@ -17,7 +18,11 @@ class DenialDocumentType(Document):
     address = fields.TextField()
     reference = fields.KeywordField()
     notifying_government = fields.TextField()
-    country = fields.TextField()
+    country = fields.TextField(
+        fields={
+            "raw": fields.KeywordField(normalizer=lowercase_normalizer),
+        },
+    )
     item_list_codes = fields.TextField()
     item_description = fields.TextField()
     consignee_name = fields.TextField()

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -43,8 +43,15 @@ class DenialSearchView(DocumentViewSet):
     filter_backends = [
         filter_backends.SearchFilterBackend,
         filter_backends.SourceBackend,
+        filter_backends.FilteringFilterBackend,
     ]
     search_fields = ["name", "address"]
+    filter_fields = {
+        "country": {
+            "enabled": True,
+            "field": "country.raw",
+        }
+    }
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())


### PR DESCRIPTION
## Change description

This is achieved by adding the model field to `filter_fields`. This will allow the filtering backend to parse the query params for this field and filter the documents. Also added lowercase analyser for this field in case if the country name is in lowercase.

