### PR TITLE
Lock cloudfoundry Python buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 applications:
   - buildpacks:
       - https://github.com/cloudfoundry/apt-buildpack.git
-      - python_buildpack
+      - https://github.com/cloudfoundry/python-buildpack.git#v1.7.58
     timeout: 360
     memory: 1G
     health-check-type: http


### PR DESCRIPTION
The latest buildpack drops support for the version of Python we have specified in our runtime

Whilst trying to upgrade we wanted to switch the rest of our tooling to match that Python version so that we could fully test against the new intendend Python version however this caused our tests to fail

Given all of the above we have chosen to lock our buildpack version, for now, so that we can fix the rest of our setup and then switch back to an unpinned buildpack