### PR TITLE
LTD-2973: Add management command to truncate End-user name

### DIFF
--- a/api/licences/libraries/hmrc_integration_operations.py
+++ b/api/licences/libraries/hmrc_integration_operations.py
@@ -55,7 +55,7 @@ def send_licence(licence: Licence, action: str):
         licence.hmrc_integration_sent_at = timezone.now()
         licence.save()
 
-    logging.info(f"Successfully sent licence '{licence.id}', action '{action}' to HMRC Integration")
+    logging.info(f"Successfully sent licence '{licence.reference_code}', action '{action}' to HMRC Integration")
 
 
 def get_mail_status(licence: Licence):

--- a/api/support/management/commands/tests/test_truncating_end_user_name.py
+++ b/api/support/management/commands/tests/test_truncating_end_user_name.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from django.core.management import call_command
+from api.applications.models import PartyOnApplication, StandardApplication
+
+from api.cases.enums import AdviceType, AdviceLevel
+from api.licences.enums import LicenceStatus
+from api.licences.tests.factories import GoodOnLicenceFactory
+from api.licences.tests.test_api_to_hmrc_integration import MockResponse
+from test_helpers.clients import DataTestClient
+
+
+class TruncateEndUserNameMgmtCommandTests(DataTestClient):
+    def _create_good_on_licence(self, licence, good_on_application):
+        GoodOnLicenceFactory(
+            good=good_on_application,
+            licence=licence,
+            quantity=good_on_application.quantity,
+            usage=0.0,
+            value=good_on_application.value,
+        )
+
+    def create_siel_licence(self):
+        standard_application = self.create_standard_application_case(self.organisation)
+        self.create_advice(self.gov_user, standard_application, "good", AdviceType.APPROVE, AdviceLevel.FINAL)
+        licence = self.create_licence(standard_application, status=LicenceStatus.ISSUED)
+        self._create_good_on_licence(licence, standard_application.goods.first())
+        return licence
+
+    @mock.patch("api.support.management.commands.truncate_end_user_name.post")
+    def test_truncating_end_user_name_greater_than_80_chars(self, requests_post):
+        licence = self.create_siel_licence()
+        application = StandardApplication.objects.get(reference_code=licence.reference_code)
+        end_user = PartyOnApplication.objects.filter(application=application, party__type="end_user").first()
+        end_user.party.name = "".join("a" for i in range(100))
+        end_user.party.save()
+
+        requests_post.return_value = MockResponse("", 201)
+
+        self.assertIsNone(licence.hmrc_integration_sent_at)
+        call_command("truncate_end_user_name", licence.reference_code)
+
+        requests_post.assert_called_once()
+        licence.refresh_from_db()
+        self.assertIsNotNone(licence.hmrc_integration_sent_at)
+
+    @mock.patch("api.support.management.commands.truncate_end_user_name.post")
+    def test_truncating_end_user_name_less_than_80_chars(self, requests_post):
+        licence = self.create_siel_licence()
+        requests_post.return_value = MockResponse("", 201)
+
+        self.assertIsNone(licence.hmrc_integration_sent_at)
+        call_command("truncate_end_user_name", licence.reference_code)
+        requests_post.assert_not_called()
+        self.assertIsNone(licence.hmrc_integration_sent_at)

--- a/api/support/management/commands/truncate_end_user_name.py
+++ b/api/support/management/commands/truncate_end_user_name.py
@@ -1,0 +1,71 @@
+import logging
+
+from rest_framework import status
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from api.core.requests import post
+from api.licences.models import Licence
+from api.licences.serializers.hmrc_integration import HMRCIntegrationLicenceSerializer
+from api.licences.libraries.hmrc_integration_operations import HMRCIntegrationException, SEND_LICENCE_ENDPOINT
+
+
+class Command(BaseCommand):
+    help = """
+    Command to truncate End-user name (to 80 chars) and sends licence details to HMRC
+
+    This is required because HMRC spec allows only 80 chars otherwise we won't be able to
+    send licence details to HMRC
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "licence_reference",
+            type=str,
+            help="Reference number of the licence generated",
+        )
+
+    def handle(self, *args, **options):
+        licence_ref = options.pop("licence_reference")
+        logging.info("Given licence reference is: %s", licence_ref)
+
+        with transaction.atomic():
+            try:
+                licence = Licence.objects.get(reference_code=licence_ref)
+            except Licence.DoesNotExist:
+                logging.error("Licence (%s) not found, please provide valid licence reference", licence_ref)
+                return
+
+            data = {"licence": HMRCIntegrationLicenceSerializer(licence).data}
+            end_user = data["licence"]["end_user"]
+            if len(end_user["name"]) <= 80:
+                logging.info("End-user name already <= 80 chars, returning ...")
+                return
+
+            # HMRC spec allows only 80 chars
+            end_user["name"] = end_user["name"][:80]
+
+            data["licence"]["end_user"] = end_user
+            url = f"{settings.LITE_HMRC_INTEGRATION_URL}{SEND_LICENCE_ENDPOINT}"
+
+            response = post(
+                url,
+                data,
+                hawk_credentials=settings.HAWK_LITE_API_CREDENTIALS,
+                timeout=settings.LITE_HMRC_REQUEST_TIMEOUT,
+            )
+
+            if response.status_code not in [status.HTTP_200_OK, status.HTTP_201_CREATED]:
+                raise HMRCIntegrationException(
+                    f"An unexpected response was received when sending licence '{licence.id}', action INSERT to HMRC "
+                    f"Integration -> status={response.status_code}, message={response.text}"
+                )
+
+            if response.status_code == status.HTTP_201_CREATED:
+                licence.hmrc_integration_sent_at = timezone.now()
+                licence.save()
+
+            logging.info(f"Successfully sent licence '{licence.reference_code}', action INSERT to HMRC Integration")


### PR DESCRIPTION
## Change description

HMRC spec only allows 80 chars for End-user name but currently we don't have validation in UI or API to prevent this. We are only validating in `lite-hmrc` when licence details are sent to be forwarded to HMRC.

Because of this we failed to send few licence details. Using this mgmt command we can resend those details to `lite-hmrc` until we add these restrictions in the UI and API.