### PR TITLE
skip obsolete DB routing rule tests, python rules covered separately

### DIFF
--- a/api/workflow/routing_rules/tests/test_routing_rules_creation.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_creation.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 from rest_framework import status
 
@@ -9,6 +10,7 @@ from test_helpers.clients import DataTestClient
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleCreationTests(DataTestClient):
     def test_all_data_works(self):
         self.gov_user.role = self.super_user_role

--- a/api/workflow/routing_rules/tests/test_routing_rules_creation.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_creation.py
@@ -10,7 +10,6 @@ from test_helpers.clients import DataTestClient
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleCreationTests(DataTestClient):
     def test_all_data_works(self):
         self.gov_user.role = self.super_user_role

--- a/api/workflow/routing_rules/tests/test_routing_rules_permissions.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_permissions.py
@@ -8,7 +8,6 @@ from test_helpers.clients import DataTestClient
 from api.users.models import Role
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleCreationTests(DataTestClient):
     def setUp(self):
         super(RoutingRuleCreationTests, self).setUp()

--- a/api/workflow/routing_rules/tests/test_routing_rules_permissions.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_permissions.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 from rest_framework import status
 
@@ -7,6 +8,7 @@ from test_helpers.clients import DataTestClient
 from api.users.models import Role
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleCreationTests(DataTestClient):
     def setUp(self):
         super(RoutingRuleCreationTests, self).setUp()

--- a/api/workflow/routing_rules/tests/test_routing_rules_update.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_update.py
@@ -1,3 +1,4 @@
+import pytest as pytest
 from django.urls import reverse
 from rest_framework import status
 
@@ -9,6 +10,7 @@ from test_helpers.clients import DataTestClient
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleUpdateTests(DataTestClient):
     def test_update_to_have_all_data(self):
         self.gov_user.role = self.super_user_role
@@ -97,6 +99,7 @@ class RoutingRuleUpdateTests(DataTestClient):
         self.assertIsNone(routing_rule["country"])
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleStatusChangeTests(DataTestClient):
     def test_deactivate(self):
         self.gov_user.role = self.super_user_role

--- a/api/workflow/routing_rules/tests/test_routing_rules_update.py
+++ b/api/workflow/routing_rules/tests/test_routing_rules_update.py
@@ -10,7 +10,6 @@ from test_helpers.clients import DataTestClient
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleUpdateTests(DataTestClient):
     def test_update_to_have_all_data(self):
         self.gov_user.role = self.super_user_role
@@ -99,7 +98,6 @@ class RoutingRuleUpdateTests(DataTestClient):
         self.assertIsNone(routing_rule["country"])
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class RoutingRuleStatusChangeTests(DataTestClient):
     def test_deactivate(self):
         self.gov_user.role = self.super_user_role

--- a/api/workflow/tests/test_automated_case_routing.py
+++ b/api/workflow/tests/test_automated_case_routing.py
@@ -15,7 +15,6 @@ from api.workflow.automation import run_routing_rules
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class ParameterSetRoutingRuleModelMethodTests(DataTestClient):
     def test_routing_rule_parameters_are_returned_in_a_set(self):
         routing_rule = self.create_routing_rule(
@@ -123,7 +122,6 @@ class ParameterSetCaseModelMethodTests(DataTestClient):
         self.assertIn(case.case_type, parameter_set)
 
 
-@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class CaseRoutingAutomationTests(DataTestClient):
     def test_case_routed_to_new_queue_when_status_changed(self):
         self.create_routing_rule(
@@ -310,11 +308,10 @@ class CaseRoutingAutomationTests(DataTestClient):
             additional_rules=[],
         )
 
-        case = self.create_open_application_case(organisation=self.organisation)
+        case = self.create_standard_application_case(organisation=self.organisation)
         run_routing_rules(case)
 
-        self.assertIn(queue_2, set(case.queues.all()))
-        self.assertEqual(case.status, under_review)
+        self.assertEqual(case.status, CaseStatus.objects.get(status="submitted"))
 
     def test_rules_not_run_if_flags_dont_match(self):
         flag_1 = FlagFactory(team=self.team)
@@ -330,13 +327,12 @@ class CaseRoutingAutomationTests(DataTestClient):
         )
         rule.flags_to_include.set([flag_1, flag_2])
 
-        case = self.create_open_application_case(organisation=self.organisation)
+        case = self.create_standard_application_case(organisation=self.organisation)
         case.flags.set([flag_2, flag_3])
 
         run_routing_rules(case)
 
-        self.assertEqual(len(case.queues.all()), 2)
-        self.assertNotEqual(case.status, CaseStatus.objects.get(status="submitted"))
+        self.assertEqual(case.status, CaseStatus.objects.get(status="submitted"))
 
     def test_rules_not_run_if_flags_match(self):
         flag_1 = FlagFactory(team=self.team)

--- a/api/workflow/tests/test_automated_case_routing.py
+++ b/api/workflow/tests/test_automated_case_routing.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 from api.applications.models import CountryOnApplication, PartyOnApplication
 from api.cases.models import CaseType
@@ -14,6 +15,7 @@ from api.workflow.automation import run_routing_rules
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class ParameterSetRoutingRuleModelMethodTests(DataTestClient):
     def test_routing_rule_parameters_are_returned_in_a_set(self):
         routing_rule = self.create_routing_rule(
@@ -121,6 +123,7 @@ class ParameterSetCaseModelMethodTests(DataTestClient):
         self.assertIn(case.case_type, parameter_set)
 
 
+@pytest.mark.skip("Legacy routing rules obsolete as of C5")
 class CaseRoutingAutomationTests(DataTestClient):
     def test_case_routed_to_new_queue_when_status_changed(self):
         self.create_routing_rule(


### PR DESCRIPTION
all rules migrated to python criteria