### PR TITLE
Docs update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - lite
 
   api:
+    platform: linux/amd64
     env_file:
       - .env
     build: .

--- a/local.env
+++ b/local.env
@@ -14,9 +14,9 @@ OAUTHLIB_INSECURE_TRANSPORT=True
 INTERNAL_USERS=[{"email": "", "role": "Super User"}]
 # 'email' is required
 # 'role' defaults to 'Super User' if not specified
-EXPORTER_USERS=[{"email": "", "organisation": "Archway Communications", "role": "Super User"}]
+EXPORTER_USERS=[{"email": "", "organisation": "Archway Communications", "role": "Administrator"}]
 # 'email' is required
-# 'organisation' defaults to 'Archway Communications' and 'role' defaults to  and 'Super User' if not specified
+# 'organisation' defaults to 'Archway Communications' and role to Administrator if not specificied
 
 # INTERNAL_USERS are also seeded as exporter users so they do not need to be added
 # to the EXPORTER_USERS variable


### PR DESCRIPTION
This PR contains 2 commits:

1. [use Administrator role for initial seed of exporter users](https://github.com/uktrade/lite-api/commit/2b9fb8a305e9525213e55734bedccfa3c5230b50) 

Super User was changed to Administrator in this PR https://github.com/uktrade/lite-api/pull/1019

2. [specify linux/amd64 platform in docker-compose](https://github.com/uktrade/lite-api/commit/ee341fd0a2a0b9c5fa1327591f66940eb4844059) 

This enables devs on Mac M1s to run on amd64. Workaround for issue with building against the wrong library version [1]
[1]https://github.com/psycopg/psycopg2/issues/1360

### feedback

I'm not sure if specifying the default platform in `docker-compose.yml` will break anything for other users, e.g. those running on Windows?