### PR TITLE
Consolidate regime entries into a single view

### DIFF
--- a/api/staticdata/regimes/tests/test_views.py
+++ b/api/staticdata/regimes/tests/test_views.py
@@ -1,171 +1,60 @@
-from rest_framework import status
+from parameterized import parameterized
+
 from rest_framework.reverse import reverse
 
 from test_helpers.clients import DataTestClient
 
-from ..enums import (
-    RegimesEnum,
-    RegimeSubsectionsEnum,
-)
-from ..models import (
-    Regime,
-    RegimeEntry,
-    RegimeSubsection,
-)
-
-from .factories import (
-    RegimeFactory,
-    RegimeEntryFactory,
-    RegimeSubsectionFactory,
-)
+from ..enums import RegimesEnum
+from ..models import RegimeEntry
 
 
-class MTCREntriesTests(DataTestClient):
-    def setUp(self):
-        super().setUp()
-
-        self.mtcr_regime = Regime.objects.get(pk=RegimesEnum.MTCR)
-        self.mtcr_category_1_subsection = RegimeSubsection.objects.get(pk=RegimeSubsectionsEnum.MTCR_CATEGORY_1)
-        self.mtcr_category_2_subsection = RegimeSubsection.objects.get(pk=RegimeSubsectionsEnum.MTCR_CATEGORY_2)
-
-        # Clear out regime entries created by data migrations so we have a clean
-        # slate to test against
-        RegimeEntry.objects.all().delete()
-
-    def test_view(self):
-        non_mtcr_regime = RegimeFactory.create()
-        non_mtcr_regime_subsection = RegimeSubsectionFactory.create(regime=non_mtcr_regime)
-        RegimeEntryFactory.create(subsection=non_mtcr_regime_subsection)
-
-        RegimeEntryFactory.create(
-            id="5dd10250-3f51-4359-963b-2b05cbec20ae",
-            name="Z",
-            shortened_name="z",
-            subsection=self.mtcr_category_1_subsection,
-        )
-        RegimeEntryFactory.create(
-            id="9a1f90c2-844c-437f-9ea3-783bf226b060",
-            name="A",
-            shortened_name="a",
-            subsection=self.mtcr_category_2_subsection,
-        )
-
-        url = reverse("staticdata:regimes:mtcr_entries")
+class EntriesTests(DataTestClient):
+    @parameterized.expand(
+        [
+            ("mtcr_entries", "mtcr"),
+            ("wassenaar_entries", "wassenaar"),
+        ]
+    )
+    def test_redirects(self, url_path, regime_type):
+        url = reverse(f"staticdata:regimes:{url_path}")
         response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            [
-                {
-                    "name": "A",
-                    "shortened_name": "a",
-                    "pk": "9a1f90c2-844c-437f-9ea3-783bf226b060",
-                    "subsection": {
-                        "name": "MTCR Category 2",
-                        "pk": "77b14423-f33c-45a5-a512-61ddd380cf06",
-                        "regime": {
-                            "name": "MTCR",
-                            "pk": "b1c1f990-a7be-4bc8-9292-a8b5ea25c0dd",
-                        },
-                    },
+        self.assertRedirects(
+            response,
+            reverse(
+                "staticdata:regimes:entries",
+                kwargs={
+                    "regime_type": regime_type,
                 },
-                {
-                    "name": "Z",
-                    "shortened_name": "z",
-                    "pk": "5dd10250-3f51-4359-963b-2b05cbec20ae",
-                    "subsection": {
-                        "name": "MTCR Category 1",
-                        "pk": "e529df3d-d471-49be-94d7-7a4e5835df90",
-                        "regime": {
-                            "name": "MTCR",
-                            "pk": "b1c1f990-a7be-4bc8-9292-a8b5ea25c0dd",
-                        },
-                    },
-                },
-            ],
+            ),
+            status_code=301,
         )
 
-
-class WassenaarEntriesTests(DataTestClient):
-    def setUp(self):
-        super().setUp()
-
-        self.wassenaar_regime = Regime.objects.get(pk=RegimesEnum.WASSENAAR)
-        self.wassenaar_arrangement_subsection = RegimeSubsection.objects.get(
-            pk=RegimeSubsectionsEnum.WASSENAAR_ARRANGEMENT
+    def test_entries_invalid_regime_type(self):
+        url = reverse(
+            "staticdata:regimes:entries",
+            kwargs={
+                "regime_type": "not-found",
+            },
         )
-        self.wassenaar_arrangement_sensitive_subsection = RegimeSubsection.objects.get(
-            pk=RegimeSubsectionsEnum.WASSENAAR_ARRANGEMENT_SENSITIVE
-        )
-        self.wassenaar_arrangement_very_sensitive_subsection = RegimeSubsection.objects.get(
-            pk=RegimeSubsectionsEnum.WASSENAAR_ARRANGEMENT_VERY_SENSITIVE
-        )
-
-        # Clear out regime entries created by data migrations so we have a clean
-        # slate to test against
-        RegimeEntry.objects.all().delete()
-
-    def test_view(self):
-        non_wassenaar_regime = RegimeFactory.create()
-        non_wassenaar_regime_subsection = RegimeSubsectionFactory.create(regime=non_wassenaar_regime)
-        RegimeEntryFactory.create(subsection=non_wassenaar_regime_subsection)
-
-        RegimeEntryFactory.create(
-            id="2b552cf7-cb5b-4ec4-a834-0eeb0a6af1ec",
-            name="C",
-            shortened_name="c",
-            subsection=self.wassenaar_arrangement_very_sensitive_subsection,
-        )
-        RegimeEntryFactory.create(
-            id="2817d81b-bf0d-454b-ae82-1e8aa7734833",
-            name="B",
-            shortened_name="b",
-            subsection=self.wassenaar_arrangement_sensitive_subsection,
-        )
-        RegimeEntryFactory.create(
-            id="2798b8b1-f771-4ad6-acbc-0e07f642c6d8",
-            name="A",
-            shortened_name="a",
-            subsection=self.wassenaar_arrangement_subsection,
-        )
-
-        url = reverse("staticdata:regimes:wassenaar_entries")
         response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    @parameterized.expand(
+        [
+            (RegimesEnum.MTCR, "mtcr"),
+            (RegimesEnum.WASSENAAR, "wassenaar"),
+        ]
+    )
+    def test_entries_filters_by_regime_type(self, regime_pk, regime_type):
+        url = reverse(
+            "staticdata:regimes:entries",
+            kwargs={
+                "regime_type": regime_type,
+            },
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
-            [
-                {
-                    "pk": "2798b8b1-f771-4ad6-acbc-0e07f642c6d8",
-                    "name": "A",
-                    "shortened_name": "a",
-                    "subsection": {
-                        "pk": "a67b1acd-0578-4b83-af66-36ac56f00296",
-                        "name": "Wassenaar Arrangement",
-                        "regime": {"pk": "66e5fc8d-67c7-4a5a-9d11-2eb8dbc57f7d", "name": "WASSENAAR"},
-                    },
-                },
-                {
-                    "pk": "2817d81b-bf0d-454b-ae82-1e8aa7734833",
-                    "name": "B",
-                    "shortened_name": "b",
-                    "subsection": {
-                        "pk": "3bafdc58-f994-4e44-9f89-b01a037b9676",
-                        "name": "Wassenaar Arrangement Sensitive",
-                        "regime": {"pk": "66e5fc8d-67c7-4a5a-9d11-2eb8dbc57f7d", "name": "WASSENAAR"},
-                    },
-                },
-                {
-                    "pk": "2b552cf7-cb5b-4ec4-a834-0eeb0a6af1ec",
-                    "name": "C",
-                    "shortened_name": "c",
-                    "subsection": {
-                        "pk": "deb7099a-dfeb-47c7-9dce-d9228a8337e0",
-                        "name": "Wassenaar Arrangement Very Sensitive",
-                        "regime": {"pk": "66e5fc8d-67c7-4a5a-9d11-2eb8dbc57f7d", "name": "WASSENAAR"},
-                    },
-                },
-            ],
+            len(response.json()),
+            RegimeEntry.objects.filter(subsection__regime=regime_pk).count(),
         )

--- a/api/staticdata/regimes/urls.py
+++ b/api/staticdata/regimes/urls.py
@@ -6,6 +6,7 @@ from . import views
 app_name = "regimes"
 
 urlpatterns = [
+    path("entries/<str:regime_type>/", views.EntriesView.as_view(), name="entries"),
     path("mtcr/entries/", views.MTCREntriesView.as_view(), name="mtcr_entries"),
     path("wassenaar/entries/", views.WassenaarEntriesView.as_view(), name="wassenaar_entries"),
 ]

--- a/api/staticdata/regimes/views.py
+++ b/api/staticdata/regimes/views.py
@@ -2,23 +2,56 @@ from rest_framework import generics
 
 from api.core.authentication import HawkOnlyAuthentication
 
-from .enums import RegimesEnum
+from django.db.models.functions import Lower
+from django.http import Http404
+from django.urls import reverse
+from django.views.generic.base import RedirectView
+
 from .models import RegimeEntry
 from .serializers import RegimeEntrySerializer
 
 
-class BaseEntriesView(generics.ListAPIView):
+class EntriesView(generics.ListAPIView):
     authentication_classes = (HawkOnlyAuthentication,)
     pagination_class = None
     serializer_class = RegimeEntrySerializer
 
     def get_queryset(self):
-        return RegimeEntry.objects.filter(subsection__regime=self.regime_type).order_by("name")
+        regime_type = self.kwargs["regime_type"]
+
+        regime_entries = (
+            RegimeEntry.objects.annotate(regime_slug=Lower("subsection__regime__name"))
+            .filter(
+                regime_slug=regime_type,
+            )
+            .order_by("name")
+        )
+
+        if not regime_entries.exists():
+            raise Http404
+
+        return regime_entries
 
 
-class MTCREntriesView(BaseEntriesView):
-    regime_type = RegimesEnum.MTCR
+class MTCREntriesView(RedirectView):
+    permanent = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        return reverse(
+            "staticdata:regimes:entries",
+            kwargs={
+                "regime_type": "mtcr",
+            },
+        )
 
 
-class WassenaarEntriesView(BaseEntriesView):
-    regime_type = RegimesEnum.WASSENAAR
+class WassenaarEntriesView(RedirectView):
+    permanent = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        return reverse(
+            "staticdata:regimes:entries",
+            kwargs={
+                "regime_type": "wassenaar",
+            },
+        )


### PR DESCRIPTION
This still keeps the previous URLs intact but redirects to the new URL for backwards compatibility with our frontend until we explicitly make the same change on the frontend