### PR TITLE
LTD-3005-Tests-for-lite-routing

### DIFF
--- a/api/cases/enforcement_check/tests/test_import_xml.py
+++ b/api/cases/enforcement_check/tests/test_import_xml.py
@@ -100,7 +100,6 @@ class ImportXML(DataTestClient):
         flags = self.case.flags.values_list("id", flat=True)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"file": Cases.EnforcementUnit.SUCCESSFUL_UPLOAD})
-        self.assertFalse(UUID(SystemFlags.ENFORCEMENT_CHECK_REQUIRED) in flags)
         self.assertFalse(UUID(SystemFlags.ENFORCEMENT_ORGANISATION_MATCH) in flags)
 
     def test_import_xml_case_doesnt_match_success(self):


### PR DESCRIPTION
Fix tests for the Related PR:
https://github.com/uktrade/lite-routing/pull/99

`FAILED api/cases/enforcement_check/tests/test_import_xml.py::ImportXML::test_import_xml_no_match_success - AssertionError: **** is not false`

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-3005
- [x] Jira ticket has the correct status.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data
- [ ] Includes screenshot(s) - ideally before and after, but at least after

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] Ran the `make manage download_geolocation_data` command
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)