### PR TITLE
address width adjustment for refusal letter

### DIFF
--- a/assets/css/refusal.css
+++ b/assets/css/refusal.css
@@ -16,7 +16,7 @@
     width: 90mm;
   }
   .document #sender-address {
-    margin-left: 10%;
+    width: 70mm;
   }
   .document #references {
     display: inline-block;


### PR DESCRIPTION
Adjust the width of the sender address column so that the email address will fit on one line when viewed by the exporter