### PR TITLE
[LTD-3152] Fix flaky tests

### DIFF
--- a/api/applications/tests/test_adding_sites.py
+++ b/api/applications/tests/test_adding_sites.py
@@ -203,4 +203,4 @@ class SitesOnDraftTests(DataTestClient):
             ExternalLocations.Errors.COUNTRY_ON_APPLICATION
             % (site.address.country.id, transhipment.case_type.reference),
         )
-        self.assertNotEqual(transhipment.application_sites.get().site.name, site.name)
+        self.assertNotEqual(transhipment.application_sites.get().site.id, site.id)

--- a/api/flags/tests/factories.py
+++ b/api/flags/tests/factories.py
@@ -16,7 +16,7 @@ def get_flag_level():
 
 
 class FlagFactory(factory.django.DjangoModelFactory):
-    name = factory.Faker("word")
+    name = factory.Faker("sentence")
     status = FlagStatuses.ACTIVE
     level = factory.LazyFunction(get_flag_level)
     team = NotImplementedError()


### PR DESCRIPTION
This change fixes a couple of tests identified as unreliable by;
- Making FlagFactory much more likely to create a record with a unique name.
- Ensuring a test for sites tests for inequality on id rather than field value. 