### PR TITLE
Allow goods to be edited from internal endpoint as long as applicatio…

### DIFF
--- a/api/applications/views/goods.py
+++ b/api/applications/views/goods.py
@@ -235,7 +235,7 @@ class ApplicationGoodOnApplicationUpdateViewInternal(APIView):
 
     def put(self, request, **kwargs):
         application = self.get_application()
-        if application.status.status in get_case_statuses(read_only=True):
+        if CaseStatusEnum.is_terminal(application.status.status):
             return JsonResponse(
                 data={"errors": [strings.Applications.Generic.READ_ONLY]},
                 status=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
This allows the goods on a case to be edited as long as the status of the case is not terminal.

This differs from the other endpoint as this is for the internal application and we allow editing during different statuses to the exporter endpoint.