### PR TITLE
LTD-3209: Update GoodOnLicence serializer to include name and controlled status

### DIFF
--- a/api/data_workspace/tests/test_license_views.py
+++ b/api/data_workspace/tests/test_license_views.py
@@ -71,6 +71,7 @@ class DataWorkspaceTests(DataTestClient):
         expected_fields = (
             "good_on_application_id",
             "usage",
+            "name",
             "description",
             "units",
             "applied_for_quantity",
@@ -79,6 +80,7 @@ class DataWorkspaceTests(DataTestClient):
             "licenced_value",
             "applied_for_value_per_item",
             "licenced_value_per_item",
+            "is_good_controlled",
             "control_list_entries",
             "advice",
             "id",

--- a/api/licences/serializers/view_licence.py
+++ b/api/licences/serializers/view_licence.py
@@ -10,6 +10,7 @@ from api.cases.models import CaseType
 from api.cases.serializers import SimpleAdviceSerializer
 from api.core.serializers import KeyValueChoiceField, CountrySerializerField, ControlListEntryField
 from api.goods.models import Good
+from api.goods.enums import GoodControlled
 from api.goodstype.models import GoodsType
 from api.licences.enums import LicenceStatus
 from api.licences.helpers import serialize_goods_on_licence, get_approved_countries
@@ -148,6 +149,7 @@ class ApplicationLicenceSerializer(serializers.ModelSerializer):
 class GoodOnLicenceViewSerializer(serializers.Serializer):
     good_on_application_id = serializers.UUIDField(source="good.id")
     usage = serializers.FloatField()
+    name = serializers.CharField(source="good.good.name")
     description = serializers.CharField(source="good.good.description")
     units = KeyValueChoiceField(source="good.unit", choices=Units.choices)
     applied_for_quantity = serializers.FloatField(source="good.quantity")
@@ -156,7 +158,8 @@ class GoodOnLicenceViewSerializer(serializers.Serializer):
     licenced_value = serializers.FloatField(source="value")
     applied_for_value_per_item = serializers.SerializerMethodField()
     licenced_value_per_item = serializers.SerializerMethodField()
-    control_list_entries = ControlListEntrySerializer(source="good.good.control_list_entries", many=True)
+    is_good_controlled = KeyValueChoiceField(source="good.is_good_controlled", choices=GoodControlled.choices)
+    control_list_entries = ControlListEntrySerializer(source="good.control_list_entries", many=True)
     advice = serializers.SerializerMethodField()
 
     def get_advice(self, instance):

--- a/api/licences/tests/test_get_licence.py
+++ b/api/licences/tests/test_get_licence.py
@@ -48,7 +48,12 @@ class GetLicenceTests(DataTestClient):
         self.assertEqual(response_data["duration"], licence.duration)
         self.assertEqual(response_data["goods_on_licence"][0]["good_on_application_id"], str(good_on_application.id))
         self.assertEqual(response_data["goods_on_licence"][0]["usage"], good_on_licence.usage)
+        self.assertEqual(response_data["goods_on_licence"][0]["name"], good.name)
         self.assertEqual(response_data["goods_on_licence"][0]["description"], good.description)
+        self.assertEqual(
+            response_data["goods_on_licence"][0]["is_good_controlled"],
+            good_on_application.is_good_controlled,
+        )
         self.assertEqual(response_data["goods_on_licence"][0]["units"]["key"], good_on_application.unit)
         self.assertEqual(response_data["goods_on_licence"][0]["applied_for_quantity"], good_on_application.quantity)
         self.assertEqual(response_data["goods_on_licence"][0]["applied_for_value"], good_on_application.value)
@@ -63,7 +68,8 @@ class GetLicenceTests(DataTestClient):
             good_on_licence.value / good_on_licence.quantity,
         )
         self.assertEqual(
-            len(response_data["goods_on_licence"][0]["control_list_entries"]), good.control_list_entries.count()
+            len(response_data["goods_on_licence"][0]["control_list_entries"]),
+            good_on_application.control_list_entries.count(),
         )
         self.assertEqual(response_data["goods_on_licence"][0]["advice"]["type"]["key"], good_advice.type)
         self.assertEqual(response_data["goods_on_licence"][0]["advice"]["text"], good_advice.text)

--- a/api/licences/tests/test_get_licences.py
+++ b/api/licences/tests/test_get_licences.py
@@ -108,8 +108,8 @@ class GetLicencesTests(DataTestClient):
                     str(good_on_application.id),
                 )
                 self.assertEqual(
-                    licence_data["goods"][0]["control_list_entries"][0]["rating"],
-                    good_on_application.good.control_list_entries.all()[0].rating,
+                    [clc["rating"] for clc in licence_data["goods"][0]["control_list_entries"]],
+                    [clc.rating for clc in good_on_application.control_list_entries.all()],
                 )
 
     def test_get_standard_licences_only(self):


### PR DESCRIPTION
## Change description

This is used when finalise form is presented to user in case of re-issuing a licence. We need to show name of the product on that form.