### PR TITLE
LTD-3108-end-party-url-validation 

### DIFF
--- a/api/parties/serializers.py
+++ b/api/parties/serializers.py
@@ -127,6 +127,7 @@ class PartySerializer(serializers.ModelSerializer):
         :return: string to save for the website field
         """
         if value:
+            value = value.lower()
             validator = URLValidator()
             if "https://" not in value and "http://" not in value:
                 # Prepend string with https:// so user doesn't have to

--- a/api/parties/serializers.py
+++ b/api/parties/serializers.py
@@ -127,9 +127,8 @@ class PartySerializer(serializers.ModelSerializer):
         :return: string to save for the website field
         """
         if value:
-            value = value.lower()
             validator = URLValidator()
-            if "https://" not in value and "http://" not in value:
+            if "https://" not in value.lower() and "http://" not in value.lower():
                 # Prepend string with https:// so user doesn't have to
                 value = f"https://{value}"
             validator(value)

--- a/api/parties/tests/test_serializers.py
+++ b/api/parties/tests/test_serializers.py
@@ -9,16 +9,14 @@ from django.core.exceptions import ValidationError
     [
         ("http://workingexample.com", "http://workingexample.com"),
         ("http://www.workingexample.com", "http://www.workingexample.com"),
-        ("http://WWW.workingexample.com", "http://www.workingexample.com"),
+        ("http://WWW.workingexample.com", "http://WWW.workingexample.com"),
         ("http://workingexample.com", "http://workingexample.com"),
         ("workingexample.com", "https://workingexample.com"),
-        ("workingexample.com", "https://workingexample.com"),
-        ("HTTPS://workingexample.com", "https://workingexample.com"),
+        ("HTTPS://workingexample.com", "HTTPS://workingexample.com"),
     ]
 )
 def test_party_serializer_validate_website_valid(url_input, url_output):
-    assert url_input
-    # assert url_output == PartySerializer.validate_website(url_input)
+    assert url_output == PartySerializer.validate_website(url_input)
 
 
 def test_party_serializer_validate_website_invalid():

--- a/api/parties/tests/test_serializers.py
+++ b/api/parties/tests/test_serializers.py
@@ -1,0 +1,26 @@
+import pytest
+from parameterized import parameterized
+
+from api.parties.serializers import PartySerializer
+from django.core.exceptions import ValidationError
+
+
+@parameterized.expand(
+    [
+        ("http://workingexample.com", "http://workingexample.com"),
+        ("http://www.workingexample.com", "http://www.workingexample.com"),
+        ("http://WWW.workingexample.com", "http://www.workingexample.com"),
+        ("http://workingexample.com", "http://workingexample.com"),
+        ("workingexample.com", "https://workingexample.com"),
+        ("workingexample.com", "https://workingexample.com"),
+        ("HTTPS://workingexample.com", "https://workingexample.com"),
+    ]
+)
+def test_party_serializer_validate_website_valid(url_input, url_output):
+    assert url_input
+    # assert url_output == PartySerializer.validate_website(url_input)
+
+
+def test_party_serializer_validate_website_invalid():
+    with pytest.raises(ValidationError):
+        PartySerializer.validate_website("invalid@ur&l-i.am")


### PR DESCRIPTION
This is to fix an error where end party url was breaking during validation with a 500 error. 
When a user enters HTTP:// the code would add an additional http:// resulting in a validation error.

The whole string is converted to lower case as urls are inherently lower case anyway 