### PR TITLE
filter cases with open ECJU queries

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -181,6 +181,9 @@ class CaseQuerySet(models.QuerySet):
     def with_trigger_list(self):
         return self.filter(baseapplication__goods__nsg_list_type=NSGListType.TRIGGER_LIST)
 
+    def only_open_queries(self):
+        return self.filter(case_ecju_query__isnull=False, case_ecju_query__response__isnull=True)
+
     def order_by_date(self, order="-"):
         """
         :param order: ('', '-')
@@ -252,6 +255,7 @@ class CaseManager(models.Manager):
         sla_days_elapsed=None,
         is_nca_applicable=None,
         is_trigger_list=None,
+        only_open_queries=False,
         **kwargs,
     ):
         """
@@ -364,6 +368,9 @@ class CaseManager(models.Manager):
 
         if is_trigger_list:
             case_qs = case_qs.with_trigger_list()
+
+        if only_open_queries:
+            case_qs = case_qs.only_open_queries()
 
         if is_work_queue:
             case_qs = case_qs.annotate(

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -6,7 +6,8 @@ from rest_framework import status
 from api.audit_trail.models import Audit
 from api.audit_trail.enums import AuditType
 from api.cases.enums import CaseTypeEnum
-from api.cases.models import Case, CaseAssignment
+from api.cases.models import Case, CaseAssignment, EcjuQuery
+from api.picklists.enums import PicklistType
 from api.queues.constants import (
     UPDATED_CASES_QUEUE_ID,
     MY_ASSIGNED_CASES_QUEUE_ID,
@@ -248,6 +249,56 @@ class FilterAndSortTests(DataTestClient):
         for case in response_data["cases"]:
             case_type_reference = Case.objects.filter(pk=case["id"]).values_list("case_type__reference", flat=True)[0]
             self.assertEqual(case_type_reference, CaseTypeEnum.GOODS.reference)
+
+    def test_only_open_queries_gets_cases(self):
+        """
+        Given there is a case with an ECJU Query that has not been responded to
+        When a user requests to view cases with open queries
+        Then only cases with open queries are returned
+        """
+        ## create an ecju query for a case that should appear in tab
+        case_with_open_query = self.application_cases[0]
+        self.create_ecju_query(case_with_open_query, gov_user=self.gov_user)
+
+        ## create an ecju query with a response so it should not appear in tab
+        ecju_query_with_response = EcjuQuery(
+            question="ECJU Query 2",
+            case=self.application_cases[1],
+            response="I have a response",
+            raised_by_user=self.gov_user,
+            responded_by_user=self.exporter_user,
+            query_type=PicklistType.ECJU,
+        )
+        ecju_query_with_response.save()
+        url = f"{self.url}?only_open_queries=True"
+
+        response = self.client.get(url, **self.gov_headers)
+
+        response_data = response.json()
+
+        self.assertEqual(response_data["count"], 1)
+        self.assertEqual(response_data["results"]["cases"][0]["id"], str(case_with_open_query.id))
+
+    def test_only_open_queries_false_search(self):
+        """
+        Given there is a case with an ECJU Query that has not been responded to
+        When 'only_open_queries' is false and a team queue is not chosen
+        Then all cases are returned
+        """
+        all_cases = self.application_cases + self.clc_cases
+
+        ## create an open ecju query that should be returned
+        case_with_open_query = self.application_cases[0]
+        self.create_ecju_query(case_with_open_query, gov_user=self.gov_user)
+
+        url = f"{self.url}?only_open_queries=False"
+
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(len(response_data), len(all_cases))
+        cases_returned = [x["id"] for x in response_data]
+        self.assertIn(str(case_with_open_query.id), cases_returned)
 
 
 class UpdatedCasesQueueTests(DataTestClient):

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -44,6 +44,7 @@ class CasesSearchView(generics.ListAPIView):
         filters["submitted_to"] = make_date_from_params("submitted_to", filters)
         filters["finalised_from"] = make_date_from_params("finalised_from", filters)
         filters["finalised_to"] = make_date_from_params("finalised_to", filters)
+        filters["only_open_queries"] = True if request.GET.get("only_open_queries") == "True" else False
 
         page = self.paginate_queryset(
             Case.objects.search(


### PR DESCRIPTION
### aim

In this frontend PR https://github.com/uktrade/lite-frontend/pull/1049 we are adding tabs beneath the filters on the cases views (both all cases and for specific queues), one tab shows all cases (with whatever filters have been applied) the other tab shows cases that have an ECJU Query that has NOT been responded to by the user.

The tabs will return a query param on the request, and when it is true we want to apply the filter.

