### PR TITLE
Adjust case search API to respond with assigned queues

### DIFF
--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -40,6 +40,7 @@ from api.licences.helpers import get_open_general_export_licence_case
 from lite_content.lite_api import strings
 from api.queries.serializers import QueryViewSerializer
 from api.queues.models import Queue
+from api.queues.serializers import QueueListSerializer
 from api.staticdata.countries.models import Country
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.teams.models import Team
@@ -108,6 +109,7 @@ class CaseListSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     reference_code = serializers.CharField()
     case_type = PrimaryKeyRelatedSerializerField(queryset=CaseType.objects.all(), serializer=CaseTypeSerializer)
+    queues = PrimaryKeyRelatedSerializerField(many=True, queryset=Queue.objects.all(), serializer=QueueListSerializer)
     assignments = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     submitted_at = serializers.SerializerMethodField()
@@ -133,9 +135,10 @@ class CaseListSerializer(serializers.Serializer):
             return_value[user_id]["last_name"] = assignment.user.last_name
             return_value[user_id]["email"] = assignment.user.email
             return_value[user_id]["team_name"] = assignment.user.team.name
+            return_value[user_id]["team_id"] = str(assignment.user.team.id)
             if "queues" not in return_value[user_id]:
                 return_value[user_id]["queues"] = []
-            return_value[user_id]["queues"].append(assignment.queue.name)
+            return_value[user_id]["queues"].append({"name": assignment.queue.name, "id": str(assignment.queue.id)})
 
         return return_value
 


### PR DESCRIPTION
Extends the existing case search API endpoint as follows;
- Adds a `queues` field to case results returned so that callers are able to determine which queues a case is present on.
- Extends the `assignments` field value so that the team_id is returned for each assignment.
- Extends the `assignments` field value so the queues that the user is assigned on are expressed as an object (id/name) rather than just a string field (name) as previous.
   - Note that technically this is a backward compatibility breaking change, however it turns out that the frontend does not consume this particular field as it stands so it will not result in a breakage if old FE is consuming new API.  Due to this we should ensure that this API change is released before releasing the frontend change.

Companion frontend PR; https://github.com/uktrade/lite-frontend/pull/1055