### PR TITLE
Ltd 3260 sanctions files

### DIFF
--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -1,6 +1,8 @@
 import itertools
 import logging
 
+from dateutil import parser
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
@@ -138,6 +140,16 @@ class Command(BaseCommand):
                     if postcode not in normalize_address(address):
                         address += " " + postcode
 
+                    try:
+                        item["lastupdated"] = normalize_datetime(item["lastupdated"])
+                    except KeyError:
+                        pass
+
+                    try:
+                        item["datedesignated"] = normalize_datetime(item["datedesignated"])
+                    except KeyError:
+                        pass
+
                     # We need to hash the data that uniquely identifies records atm we only care about names
                     unique_id = hash_values([item["groupid"], name])
                     document = documents.SanctionDocumentType(
@@ -188,6 +200,16 @@ class Command(BaseCommand):
                     name = join_fields(primary_name, fields=["name1", "name2", "name3", "name4", "name5", "name6"])
                     address = ",".join(address_list)
 
+                    try:
+                        item["lastupdated"] = normalize_datetime(item["lastupdated"])
+                    except KeyError:
+                        pass
+
+                    try:
+                        item["datedesignated"] = normalize_datetime(item["datedesignated"])
+                    except KeyError:
+                        pass
+
                     unique_id = item.get("ofsigroupid", "UNKNOWN")
                     document = documents.SanctionDocumentType(
                         meta={"id": f"uk:{unique_id}"},
@@ -223,3 +245,7 @@ def normalize_address(value):
         return ""
 
     return value.replace(" ", "")
+
+
+def normalize_datetime(value):
+    return parser.parse(value).isoformat()

--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -15,7 +15,7 @@ from api.external_data import documents
 from api.flags.enums import SystemFlags
 import hashlib
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_un_sanctions():
@@ -111,16 +111,17 @@ class Command(BaseCommand):
                     successful += 1
                 except:
                     failed += 1
-                    log.exception(
+                    logger.exception(
                         "Error loading un sanction record -> %s",
+                        item["dataid"],
                         exc_info=True,
                     )
-            log.info(
-                f"uk sanctions (successful:{successful} failed:{failed})",
+            logger.info(
+                f"un sanctions (successful:{successful} failed:{failed})",
             )
         except:
-            log.exception(
-                "Error loading un sanctions -> %s",
+            logger.exception(
+                "Error loading un sanctions",
                 exc_info=True,
             )
 
@@ -165,16 +166,17 @@ class Command(BaseCommand):
                     successful += 1
                 except:
                     failed += 1
-                    log.exception(
+                    logger.exception(
                         "Error loading office financial sanction record -> %s",
+                        f"ofs:{unique_id}",
                         exc_info=True,
                     )
-            log.info(
+            logger.info(
                 f"office financial sanctions (successful:{successful} failed:{failed})",
             )
         except:
-            log.exception(
-                "Error office financial sanctions -> %s",
+            logger.exception(
+                "Error office financial sanctions",
                 exc_info=True,
             )
 
@@ -224,16 +226,17 @@ class Command(BaseCommand):
                 except:
 
                     failed += 1
-                    log.exception(
+                    logger.exception(
                         "Error loading uk sanction record -> %s",
+                        f"uk:{unique_id}",
                         exc_info=True,
                     )
-            log.info(
+            logger.info(
                 f"uk sanctions (successful:{successful} failed:{failed})",
             )
         except:
-            log.exception(
-                "Error loading uk sanctions -> %s",
+            logger.exception(
+                "Error loading uk sanctions",
                 exc_info=True,
             )
 

--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -224,7 +224,6 @@ class Command(BaseCommand):
                     document.save()
                     successful += 1
                 except:
-
                     failed += 1
                     logger.exception(
                         "Error loading uk sanction record -> %s",

--- a/api/external_data/management/commands/tests/test_ingest_sanctions.py
+++ b/api/external_data/management/commands/tests/test_ingest_sanctions.py
@@ -219,3 +219,11 @@ class PopulateSanctionsTests(DataTestClient):
                 content=b"<note><to>Tove</to></note>",
             )
             ingest_sanctions.get_office_financial_sanctions_implementation()
+
+    def test_get_uk_sanctions_list(self):
+        with requests_mock.Mocker() as m:
+            m.get(
+                settings.SANCTION_LIST_SOURCES["uk_sanctions_file"],
+                content=b"<designations><designation>Designation</designation></designations>",
+            )
+            ingest_sanctions.get_uk_sanctions_list()

--- a/api/external_data/management/commands/tests/test_ingest_sanctions.py
+++ b/api/external_data/management/commands/tests/test_ingest_sanctions.py
@@ -207,6 +207,379 @@ class PopulateSanctionsTests(DataTestClient):
         self.assertEqual(results_three.hits[1]["flag_uuid"], "00000000-0000-0000-0000-000000000041")
         self.assertEqual(results_three.hits[1]["reference"], "1234")
 
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_mixed_date_formats(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        # This is to test the case where the first documents to go into the
+        # index set a particular date format and then subsequent documents that
+        # are saved which don't match that date format fail to save
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "AFG0001",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "HAJI KHAIRULLAH HAJI SATTAR MONEY EXCHANGE",
+                            "nametype": "Primary Name",
+                        },
+                        {
+                            "name1": "SATTAR MONEY EXCHANGE",
+                            "nametype": "alias",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "Branch Office 10",
+                            "addressLine2": "Suite numbers 196-197",
+                        },
+                        {
+                            "addressLine1": "Branch Office 13",
+                            "addressLine2": "Sarafi Market",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [
+                    {
+                        "address1": None,
+                        "address2": None,
+                        "address3": None,
+                        "address4": None,
+                        "address5": None,
+                        "address6": None,
+                        "aliastype": "Prime Alias",
+                        "aliastypename": "Prime Alias",
+                        "businessregnumber": None,
+                        "country": None,
+                        "countryofbirth": None,
+                        "currentowners": None,
+                        "datelisted": "2001-10-12T00:00:00",
+                        "datelistedday": "12",
+                        "datelistedmonth": "10",
+                        "datelistedyear": "2001",
+                        "dateofbirth": None,
+                        "dateofbirthid": None,
+                        "dayofbirth": None,
+                        "emailaddress": None,
+                        "fcoid": "AQD0104",
+                        "flagofvessel": None,
+                        "fulladdress": None,
+                        "furtheridentifiyinginformation": "Pakistan. Review pursuant to Security",
+                        "gender": None,
+                        "groupid": "6897",
+                        "groupstatus": "Asset Freeze Targets",
+                        "grouptypedescription": "Individual",
+                        "grpstatus": "A",
+                        "hin": None,
+                        "id": "109",
+                        "imonumber": None,
+                        "lastupdated": "2020-12-31T00:00:00",
+                        "lastupdatedday": "31",
+                        "lastupdatedmonth": "12",
+                        "lastupdatedyear": "2020",
+                        "datedesignated": "2020-12-10T00:00:00",
+                        "lengthofvessel": None,
+                        "listingtype": "UK and UN",
+                        "monthofbirth": None,
+                        "name1": "Haji",
+                        "name2": "Agha",
+                        "name3": None,
+                        "name4": None,
+                        "name5": None,
+                        "name6": "Abdul Manan",
+                        "nametitle": "Haji",
+                        "nationalidnumber": None,
+                        "nationality": None,
+                        "orgtype": None,
+                        "otherinformation": "(UN Ref):QDi.018. Also referred to as Abdul Man’am",
+                        "parentcompany": None,
+                        "passportdetails": None,
+                        "phonenumber": None,
+                        "position": None,
+                        "postcode": None,
+                        "previousflags": None,
+                        "previousowners": None,
+                        "regimename": "ISIL (Da'esh) and Al-Qaida",
+                        "subsidiaries": None,
+                        "tonnageofvessel": None,
+                        "townofbirth": None,
+                        "typeofvessel": None,
+                        "ukstatementofreasons": None,
+                        "website": None,
+                        "yearbuilt": None,
+                        "yearofbirth": None,
+                    }
+                ]
+            }
+        }
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [
+                        {
+                            "dataid": "6908555",
+                            "versionnum": "1",
+                            "first_name": "RI",
+                            "second_name": "WON HO",
+                            "third_name": None,
+                            "un_list_type": "DPRK",
+                            "reference_number": "KPi.033",
+                            "listed_on": "2016-11-30",
+                            "comments1": "Ri Won Ho is a DPRK Ministry of State Security Official stationed in Syria.",
+                            "designation": {"value": "DPRK Ministry of State Security Official"},
+                            "nationality": {"value": "Democratic People's Republic of Korea"},
+                            "list_name": {"value": "UN List"},
+                            "last_day_updated": {"value": None},
+                            "individual_alias": {"quality": None, "alias_name": None},
+                            "individual_address": [{"country": None}],
+                            "individual_date_of_birth": {"type_of_date": "EXACT", "date": "1964-07-17"},
+                            "individual_place_of_birth": None,
+                            "individual_document": {"type_of_document": "Passport", "number": "381310014"},
+                            "sort_key": None,
+                            "sort_key_last_mod": None,
+                        }
+                    ],
+                },
+                "entities": {
+                    "entity": [
+                        {
+                            "comments1": "The Propaganda and Agitation Department has full control over",
+                            "dataid": "6908629",
+                            "entity_address": [
+                                {"city": "Pyongyang", "country": "Democratic People's Republic of Korea"}
+                            ],
+                            "entity_alias": {"alias_name": None, "quality": None},
+                            "first_name": "PROPAGANDA AND AGITATION DEPARTMENT (PAD)",
+                            "last_day_updated": {"value": None},
+                            "list_name": {"value": "UN List"},
+                            "listed_on": "2017-09-11",
+                            "reference_number": "KPe.053",
+                            "sort_key": None,
+                            "sort_key_last_mod": None,
+                            "un_list_type": "DPRK",
+                            "versionnum": "1",
+                        }
+                    ]
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        doc = documents.SanctionDocumentType.get("uk:1234")
+        self.assertEqual(
+            doc.data.lastupdated,
+            "2020-12-31T00:00:00",
+        )
+        self.assertEqual(
+            doc.data.datedesignated,
+            "2020-12-10T00:00:00",
+        )
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_normalizes_dates(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "AFG0001",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "HAJI KHAIRULLAH HAJI SATTAR MONEY EXCHANGE",
+                            "nametype": "Primary Name",
+                        },
+                        {
+                            "name1": "SATTAR MONEY EXCHANGE",
+                            "nametype": "alias",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "Branch Office 10",
+                            "addressLine2": "Suite numbers 196-197",
+                        },
+                        {
+                            "addressLine1": "Branch Office 13",
+                            "addressLine2": "Sarafi Market",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [
+                    {
+                        "address1": None,
+                        "address2": None,
+                        "address3": None,
+                        "address4": None,
+                        "address5": None,
+                        "address6": None,
+                        "aliastype": "Prime Alias",
+                        "aliastypename": "Prime Alias",
+                        "businessregnumber": None,
+                        "country": None,
+                        "countryofbirth": None,
+                        "currentowners": None,
+                        "datelisted": "2001-10-12T00:00:00",
+                        "datelistedday": "12",
+                        "datelistedmonth": "10",
+                        "datelistedyear": "2001",
+                        "dateofbirth": None,
+                        "dateofbirthid": None,
+                        "dayofbirth": None,
+                        "emailaddress": None,
+                        "fcoid": "AQD0104",
+                        "flagofvessel": None,
+                        "fulladdress": None,
+                        "furtheridentifiyinginformation": "Pakistan. Review pursuant to Security",
+                        "gender": None,
+                        "groupid": "6897",
+                        "groupstatus": "Asset Freeze Targets",
+                        "grouptypedescription": "Individual",
+                        "grpstatus": "A",
+                        "hin": None,
+                        "id": "109",
+                        "imonumber": None,
+                        "lastupdated": "2020/12/31",
+                        "lastupdatedday": "31",
+                        "lastupdatedmonth": "12",
+                        "lastupdatedyear": "2020",
+                        "datedesignated": "2020/12/10",
+                        "lengthofvessel": None,
+                        "listingtype": "UK and UN",
+                        "monthofbirth": None,
+                        "name1": "Haji",
+                        "name2": "Agha",
+                        "name3": None,
+                        "name4": None,
+                        "name5": None,
+                        "name6": "Abdul Manan",
+                        "nametitle": "Haji",
+                        "nationalidnumber": None,
+                        "nationality": None,
+                        "orgtype": None,
+                        "otherinformation": "(UN Ref):QDi.018. Also referred to as Abdul Man’am",
+                        "parentcompany": None,
+                        "passportdetails": None,
+                        "phonenumber": None,
+                        "position": None,
+                        "postcode": None,
+                        "previousflags": None,
+                        "previousowners": None,
+                        "regimename": "ISIL (Da'esh) and Al-Qaida",
+                        "subsidiaries": None,
+                        "tonnageofvessel": None,
+                        "townofbirth": None,
+                        "typeofvessel": None,
+                        "ukstatementofreasons": None,
+                        "website": None,
+                        "yearbuilt": None,
+                        "yearofbirth": None,
+                    }
+                ]
+            }
+        }
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [
+                        {
+                            "dataid": "6908555",
+                            "versionnum": "1",
+                            "first_name": "RI",
+                            "second_name": "WON HO",
+                            "third_name": None,
+                            "un_list_type": "DPRK",
+                            "reference_number": "KPi.033",
+                            "listed_on": "2016-11-30",
+                            "comments1": "Ri Won Ho is a DPRK Ministry of State Security Official stationed in Syria.",
+                            "designation": {"value": "DPRK Ministry of State Security Official"},
+                            "nationality": {"value": "Democratic People's Republic of Korea"},
+                            "list_name": {"value": "UN List"},
+                            "last_day_updated": {"value": None},
+                            "individual_alias": {"quality": None, "alias_name": None},
+                            "individual_address": [{"country": None}],
+                            "individual_date_of_birth": {"type_of_date": "EXACT", "date": "1964-07-17"},
+                            "individual_place_of_birth": None,
+                            "individual_document": {"type_of_document": "Passport", "number": "381310014"},
+                            "sort_key": None,
+                            "sort_key_last_mod": None,
+                        }
+                    ],
+                },
+                "entities": {
+                    "entity": [
+                        {
+                            "comments1": "The Propaganda and Agitation Department has full control over",
+                            "dataid": "6908629",
+                            "entity_address": [
+                                {"city": "Pyongyang", "country": "Democratic People's Republic of Korea"}
+                            ],
+                            "entity_alias": {"alias_name": None, "quality": None},
+                            "first_name": "PROPAGANDA AND AGITATION DEPARTMENT (PAD)",
+                            "last_day_updated": {"value": None},
+                            "list_name": {"value": "UN List"},
+                            "listed_on": "2017-09-11",
+                            "reference_number": "KPe.053",
+                            "sort_key": None,
+                            "sort_key_last_mod": None,
+                            "un_list_type": "DPRK",
+                            "versionnum": "1",
+                        }
+                    ]
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        doc = documents.SanctionDocumentType.get("uk:1234")
+        self.assertEqual(
+            doc.data.lastupdated,
+            "2020-12-31T00:00:00",
+        )
+        self.assertEqual(
+            doc.data.datedesignated,
+            "2020-12-10T00:00:00",
+        )
+
+        doc = documents.SanctionDocumentType.get("ofs:28f40249140f9c08d1d0172fb834dea1")  # /PS-IGNORE
+        self.assertEqual(
+            doc.data.lastupdated,
+            "2020-12-31T00:00:00",
+        )
+        self.assertEqual(
+            doc.data.datedesignated,
+            "2020-12-10T00:00:00",
+        )
+
     def test_get_un_sanctions(self):
         with requests_mock.Mocker() as m:
             m.get(settings.SANCTION_LIST_SOURCES["un_sanctions_file"], content=b"<note><to>Tove</to></note>")


### PR DESCRIPTION
This fixes an issue where the date format across the various sanctions files was different and this was causing OpenSearch to throw an exception when indexing some documents. 

It appears that whatever format is used first in the index is then used as the default for all other documents. 

The fix here is to make sure that the date format is consistent across all documents. 