### PR TITLE
LTD-3239: Add a 'my cases' tab/filter

### DIFF
--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -132,11 +132,15 @@ class CasesSearchView(generics.ListAPIView):
     def get_filters(self, request):
         filters = {key: value for key, value in request.GET.items() if key not in ["hidden", "queue_id", "flags"]}
 
+        search_tabs = ("my_cases", "open_queries")
+        selected_tab = request.GET.get("selected_tab")
+        if selected_tab and selected_tab in search_tabs:
+            filters[selected_tab] = True
+
         filters["flags"] = request.GET.getlist("flags", [])
         filters["submitted_from"] = make_date_from_params("submitted_from", filters)
         filters["submitted_to"] = make_date_from_params("submitted_to", filters)
         filters["finalised_from"] = make_date_from_params("finalised_from", filters)
         filters["finalised_to"] = make_date_from_params("finalised_to", filters)
-        filters["only_open_queries"] = True if request.GET.get("only_open_queries") == "True" else False
 
         return filters


### PR DESCRIPTION
### aim

[LTD-3239](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3239)

The frontend for the cases/queues view is going to have several tabs that aim to filter out cases. We have already introduced the 'all cases' and 'open queries' tabs, but now that one more is being added ('my cases') we need to change the way the logic for filtering is handled (it's not either/or anymore).

[Together with this Frontend PR](https://github.com/uktrade/lite-frontend/pull/1064) I'm proposing:
 
_on the frontend_
1. instead of a param for each tab (e.g. `only_open_queries`) we have a param whose value is the selected tab e.g. `selected_tab=open_queries`
2. in the view, to get a count for each tab, we the tab names and make a HEAD request to get the count like we do currently, and save that in a dict for each tab, as well as its URL and whether it is selected.

_on the backend_
1. the view takes a look at the `selected_tab` value and passes the manager `True` for the name of the selected tab. e.g. `open_queries=True`
2. the manager can then apply the right filter. 

Would be great to get feedback on the structure/naming of this approach.



[LTD-3239]: https://uktrade.atlassian.net/browse/LTD-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ