### PR TITLE
Ltd 3190 case status detailed

### DIFF
--- a/api/cases/tests/views/search/test_service.py
+++ b/api/cases/tests/views/search/test_service.py
@@ -14,6 +14,20 @@ class TestSearchService(DataTestClient):
         self.case = self.create_standard_application_case(self.organisation).get_case()
         new_status = "1"
         Audit.objects.create(
+            actor=self.exporter_user,
+            verb=AuditType.UPDATED_APPLICATION_NAME,
+            target_object_id=self.case.id,
+            target_content_type=ContentType.objects.get_for_model(Case),
+            payload={"old_name": "draft", "new_name": "2nd_draft"},
+        )
+        Audit.objects.create(
+            actor=self.exporter_user,
+            verb=AuditType.UPDATED_APPLICATION_NAME,
+            target_object_id=self.case.id,
+            target_content_type=ContentType.objects.get_for_model(Case),
+            payload={"old_name": "2nd_draft", "new_name": "3rd_draft"},
+        )
+        Audit.objects.create(
             actor=self.gov_user,
             verb=AuditType.UPDATED_STATUS,
             action_object_object_id=self.case.id,

--- a/api/cases/tests/views/search/test_service.py
+++ b/api/cases/tests/views/search/test_service.py
@@ -1,0 +1,39 @@
+from api.audit_trail.enums import AuditType
+from api.audit_trail.models import Audit
+from api.cases.models import Case
+from api.cases.views.search import service
+from django.contrib.contenttypes.models import ContentType
+from test_helpers.clients import DataTestClient
+
+
+class TestSearchService(DataTestClient):
+    def setUp(self):
+        super().setUp()
+
+    def test_populate_activity_updates(self):
+        self.case = self.create_standard_application_case(self.organisation).get_case()
+        new_status = "1"
+        Audit.objects.create(
+            actor=self.gov_user,
+            verb=AuditType.UPDATED_STATUS,
+            action_object_object_id=self.case.id,
+            action_object_content_type=ContentType.objects.get_for_model(Case),
+            payload={"status": {"new": new_status, "old": "2"}},
+        )
+        old_name = "old_app_name"
+        new_name = "new_app_name"
+        Audit.objects.create(
+            actor=self.exporter_user,
+            verb=AuditType.UPDATED_APPLICATION_NAME,
+            target_object_id=self.case.id,
+            target_content_type=ContentType.objects.get_for_model(Case),
+            payload={"old_name": old_name, "new_name": new_name},
+        )
+        cases = service.populate_activity_updates([{"id": str(self.case.id)}])
+        ## check only 2 reocr
+        assert len(cases[0]["activity_updates"]) == 2
+        assert (
+            cases[0]["activity_updates"][0]["text"]
+            == f'updated the application name from "{old_name}" to "{new_name}".'
+        )
+        assert cases[0]["activity_updates"][1]["text"] == f"updated the status to: {new_status}."

--- a/api/cases/tests/views/search/test_service.py
+++ b/api/cases/tests/views/search/test_service.py
@@ -30,7 +30,7 @@ class TestSearchService(DataTestClient):
             payload={"old_name": old_name, "new_name": new_name},
         )
         cases = service.populate_activity_updates([{"id": str(self.case.id)}])
-        ## check only 2 reocr
+        # check only 2 records are present, sorted newest first
         assert len(cases[0]["activity_updates"]) == 2
         assert (
             cases[0]["activity_updates"][0]["text"]

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -233,7 +233,7 @@ def populate_activity_updates(cases: List[Dict]):
         # get case id from either of the audit record fields
         if activity.target_object_id in case_ids:
             case_id = activity.target_object_id
-        elif activity.action_object_object_id in case_ids:
+        else:
             case_id = activity.action_object_object_id
 
         activity_obj = AuditSerializer(activity).data

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-import time
 from typing import List, Dict
 
 from django.conf import settings

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -3,13 +3,13 @@ from typing import List, Dict
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, F
-from django.db.models import Value
+from django.db.models import Count, F, Q, Value
 from django.db.models.functions import Concat
 from django.utils import timezone
 
 from api.applications.models import HmrcQuery, PartyOnApplication
 from api.audit_trail.models import Audit
+from api.audit_trail.serializers import AuditSerializer
 from api.cases.enums import CaseTypeEnum, CaseTypeSubTypeEnum, AdviceType
 from api.cases.models import Case
 from api.common.dates import working_days_in_range, number_of_days_since, working_hours_in_range
@@ -205,5 +205,66 @@ def populate_destinations(cases: List[Dict]):
                 destinations.append(data)
 
         case["destinations"] = destinations
+
+    return cases
+
+
+def populate_activity_updates(cases: List[Dict]):
+    obj_type = ContentType.objects.get_for_model(Case)
+    case_ids = [case["id"] for case in cases]
+    ## case_id can be present against 1 of 2 fields so filters required
+    obj_as_action_filter = Q(action_object_object_id__in=case_ids, action_object_content_type=obj_type)
+    obj_as_target_filter = Q(target_object_id__in=case_ids, target_content_type=obj_type)
+    ## get all data related to all cases
+    activities_qs = Audit.objects.filter(obj_as_action_filter | obj_as_target_filter).order_by("-updated_at")
+    case_id_indexes = {case["id"]: i for i, case in enumerate(cases)}
+    ## iterate over audit records once and add if less than 2 records are present against the case
+    for activity in activities_qs:
+        case_id = None
+        ## get case id from either of the audit record fields
+        if activity.target_object_id in case_ids:
+            case_id = activity.target_object_id
+        elif activity.action_object_object_id in case_ids:
+            case_id = activity.action_object_object_id
+        ## skips record if case not in case_ids i.e. already has 2 records
+        if not case_id:
+            continue
+        activity_obj = AuditSerializer(activity).data
+        if "activity_updates" in cases[case_id_indexes[case_id]]:
+            ## add second record and remove case_id for case_ids
+            cases[case_id_indexes[case_id]]["activity_updates"].append(activity_obj)
+            case_ids.remove(case_id)
+        else:
+            ## add first record against case
+            cases[case_id_indexes[case_id]]["activity_updates"] = [activity_obj]
+        if not case_ids:
+            break
+
+    ## double for loop but easier to follow, iterates over more records
+    # all_activities = list(activities_qs)
+    # case_ids = [case["id"] for case in cases]
+    # obj_as_action_filter = Q(action_object_object_id__in=case_ids, action_object_content_type=obj_type)
+    # obj_as_target_filter = Q(target_object_id__in=case_ids, target_content_type=obj_type)
+    # activities_qs = Audit.objects.filter(obj_as_action_filter | obj_as_target_filter).order_by("-updated_at")
+    # all_activities = list(activities_qs)
+    # for case in cases:
+    #     for activity in all_activities:
+    #         if activity.target_object_id != case["id"] and activity.action_object_object_id  != case["id"]:
+    #             continue
+    #         activity_obj = AuditSerializer(activity).data
+    #         if "activity_updates" in case:
+    #             case["activity_updates"].append(activity_obj)
+    #             break
+    #         else:
+    #             case["activity_updates"] = [activity_obj]
+    #     all_activities = [activity for activity in all_activities if activity.target_object_id != case["id"] and activity.action_object_object_id  != case["id"]]
+
+    ## several queries but simpler
+    # for case in cases:
+    #     obj_as_action_filter = Q(action_object_object_id=case["id"], action_object_content_type=obj_type)
+    #     obj_as_target_filter = Q(target_object_id=case["id"], target_content_type=obj_type)
+    #     activities_qs = Audit.objects.filter(obj_as_action_filter | obj_as_target_filter).order_by("-updated_at")[:2]
+    #     activity_objs = AuditSerializer(activities_qs, many=True).data
+    #     case["activity_updates"] = activity_objs
 
     return cases

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -244,7 +244,8 @@ def populate_activity_updates(cases: List[Dict]):
             case["activity_updates"] = [activity_obj]
     # filter down to 2 most recent records only
     for case in cases:
-        case["activity_updates"] = sorted(case["activity_updates"], key=lambda d: d["created_at"], reverse=True)
-        case["activity_updates"] = case["activity_updates"][:2]
+        if "activity_updates" in case:
+            case["activity_updates"] = sorted(case["activity_updates"], key=lambda d: d["created_at"], reverse=True)
+            case["activity_updates"] = case["activity_updates"][:2]
 
     return cases

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -72,6 +72,7 @@ class CasesSearchView(generics.ListAPIView):
         service.populate_organisation(cases)
         service.populate_is_recently_updated(cases)
         service.get_hmrc_sla_hours(cases)
+        service.populate_activity_updates(cases)
 
         # Get queue from system & my queues.
         # If this fails (i.e. I'm on a non team queue) fetch the queue data


### PR DESCRIPTION
add recent activity column to cases page
-enhanced cases templates to include extra data from the api

compared getting data via api using several queries and this appeared to be the quickest when run on local environment.
We needed last 2 audit activities per case but the case_id could be an action object or target object. Alternatives tried:

using union to get correct results from the fb
using filter to get last 2 activities per action and target (total 4) and filtering down to 2
a few different methods of massaging the data after retrieving results