### PR TITLE
API endpoint for getting Report Summary data

### DIFF
--- a/api/staticdata/report_summaries/serializers.py
+++ b/api/staticdata/report_summaries/serializers.py
@@ -1,0 +1,20 @@
+from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
+from rest_framework import serializers
+
+
+class ReportSummaryPrefixSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReportSummaryPrefix
+        fields = (
+            "id",
+            "name",
+        )
+
+
+class ReportSummarySubjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReportSummarySubject
+        fields = (
+            "id",
+            "name",
+        )

--- a/api/staticdata/report_summaries/tests/test_views.py
+++ b/api/staticdata/report_summaries/tests/test_views.py
@@ -1,0 +1,28 @@
+from rest_framework.reverse import reverse
+
+from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
+from test_helpers.clients import DataTestClient
+
+
+class ReportSummaryPrefixesTests(DataTestClient):
+    def test_get_report_summary_prefixes_OK(self):
+        url = reverse("staticdata:report_summaries:prefix")
+        response = self.client.get(url, **self.exporter_headers)
+        prefixes = response.json()["report_summary_prefixes"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(prefixes) > 0)
+        self.assertEqual(len(prefixes), ReportSummaryPrefix.objects.count())
+        self.assertEqual(prefixes[0]["name"], ReportSummaryPrefix.objects.get(id=(prefixes[0]["id"])).name)
+
+
+class ReportSummarySubjectsTests(DataTestClient):
+    def test_get_report_summary_subjects_OK(self):
+        url = reverse("staticdata:report_summaries:subject")
+        response = self.client.get(url, **self.exporter_headers)
+        subjects = response.json()["report_summary_subjects"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(subjects) > 0)
+        self.assertEqual(len(subjects), ReportSummarySubject.objects.count())
+        self.assertEqual(subjects[0]["name"], ReportSummarySubject.objects.get(id=(subjects[0]["id"])).name)

--- a/api/staticdata/report_summaries/tests/test_views.py
+++ b/api/staticdata/report_summaries/tests/test_views.py
@@ -7,22 +7,34 @@ from test_helpers.clients import DataTestClient
 class ReportSummaryPrefixesTests(DataTestClient):
     def test_get_report_summary_prefixes_OK(self):
         url = reverse("staticdata:report_summaries:prefix")
-        response = self.client.get(url, **self.exporter_headers)
-        prefixes = response.json()["report_summary_prefixes"]
+        response = self.client.get(url, **self.gov_headers)
 
         self.assertEqual(response.status_code, 200)
+
+        prefixes = response.json()["report_summary_prefixes"]
         self.assertTrue(len(prefixes) > 0)
         self.assertEqual(len(prefixes), ReportSummaryPrefix.objects.count())
-        self.assertEqual(prefixes[0]["name"], ReportSummaryPrefix.objects.get(id=(prefixes[0]["id"])).name)
+
+        for prefix in prefixes:
+            db_prefix = ReportSummaryPrefix.objects.get(id=(prefix["id"]))
+
+            self.assertEqual(prefix["id"], str(db_prefix.id))
+            self.assertEqual(prefix["name"], db_prefix.name)
 
 
 class ReportSummarySubjectsTests(DataTestClient):
     def test_get_report_summary_subjects_OK(self):
         url = reverse("staticdata:report_summaries:subject")
-        response = self.client.get(url, **self.exporter_headers)
-        subjects = response.json()["report_summary_subjects"]
+        response = self.client.get(url, **self.gov_headers)
 
         self.assertEqual(response.status_code, 200)
+
+        subjects = response.json()["report_summary_subjects"]
         self.assertTrue(len(subjects) > 0)
         self.assertEqual(len(subjects), ReportSummarySubject.objects.count())
-        self.assertEqual(subjects[0]["name"], ReportSummarySubject.objects.get(id=(subjects[0]["id"])).name)
+
+        for subject in subjects:
+            db_subject = ReportSummarySubject.objects.get(id=(subject["id"]))
+
+            self.assertEqual(subject["id"], str(db_subject.id))
+            self.assertEqual(subject["name"], db_subject.name)

--- a/api/staticdata/report_summaries/urls.py
+++ b/api/staticdata/report_summaries/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+
+app_name = "report_summaries"
+
+urlpatterns = [
+    path("prefixes/", views.ReportSummaryPrefixView.as_view(), name="prefix"),
+    path("subjects/", views.ReportSummarySubjectView.as_view(), name="subject"),
+]

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -1,13 +1,13 @@
 from django.http import JsonResponse
 from rest_framework.views import APIView
 
-from api.core.authentication import SharedAuthentication
+from api.core.authentication import GovAuthentication
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
 from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
 
 
 class ReportSummaryPrefixView(APIView):
-    authentication_classes = (SharedAuthentication,)
+    authentication_classes = (GovAuthentication,)
 
     def get(self, request):
         """
@@ -18,7 +18,7 @@ class ReportSummaryPrefixView(APIView):
 
 
 class ReportSummarySubjectView(APIView):
-    authentication_classes = (SharedAuthentication,)
+    authentication_classes = (GovAuthentication,)
 
     def get(self, request):
         """

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -1,0 +1,28 @@
+from django.http import JsonResponse
+from rest_framework.views import APIView
+
+from api.core.authentication import SharedAuthentication
+from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
+from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
+
+
+class ReportSummaryPrefixView(APIView):
+    authentication_classes = (SharedAuthentication,)
+
+    def get(self, request):
+        """
+        Returns report summary prefixes
+        """
+        prefixes = ReportSummaryPrefixSerializer(ReportSummaryPrefix.objects.all(), many=True).data
+        return JsonResponse(data={"report_summary_prefixes": prefixes})
+
+
+class ReportSummarySubjectView(APIView):
+    authentication_classes = (SharedAuthentication,)
+
+    def get(self, request):
+        """
+        Returns report summary subjects
+        """
+        subjects = ReportSummarySubjectSerializer(ReportSummarySubject.objects.all(), many=True).data
+        return JsonResponse(data={"report_summary_subjects": subjects})

--- a/api/staticdata/urls.py
+++ b/api/staticdata/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path("item-types/", include("api.staticdata.good_item_types.urls")),
     path("trade-control/", include("api.staticdata.trade_control.urls")),
     path("regimes/", include("api.staticdata.regimes.urls")),
+    path("report_summary/", include("api.staticdata.report_summaries.urls")),
 ]


### PR DESCRIPTION
In order for the frontend to populate the report summary prefix and subject search fields, we need endpoints on the API.