### PR TITLE
Report Summary endpoint filtering

### DIFF
--- a/api/staticdata/report_summaries/helpers.py
+++ b/api/staticdata/report_summaries/helpers.py
@@ -1,0 +1,23 @@
+from django.db.models import BinaryField, Case, When
+
+
+def filtered_ordered_queryset(model_class, part_of_name):
+    """
+    Creates a queryset to get rows for the model where the
+    'name' column contains the part_of_name parameter. The results
+    are sorted so that entries where the name is prefixed by
+    the part_of_name appear higher in the rankings and
+    alphabetically after that.
+    """
+    queryset = model_class.objects.all()
+    if part_of_name:
+        queryset = queryset.filter(name__icontains=part_of_name)
+        queryset = queryset.annotate(
+            is_prefixed=Case(
+                When(name__istartswith=part_of_name.lower(), then=True),
+                default=False,
+                output_field=BinaryField(),
+            ),
+        )
+        queryset = queryset.order_by("-is_prefixed", "name")
+    return queryset

--- a/api/staticdata/report_summaries/helpers.py
+++ b/api/staticdata/report_summaries/helpers.py
@@ -1,15 +1,13 @@
 from django.db.models import BinaryField, Case, When
 
 
-def filtered_ordered_queryset(model_class, part_of_name):
+def filter_and_order_by_name(queryset, part_of_name):
     """
-    Creates a queryset to get rows for the model where the
-    'name' column contains the part_of_name parameter. The results
-    are sorted so that entries where the name is prefixed by
-    the part_of_name appear higher in the rankings and
-    alphabetically after that.
+    Filters a queryset to get rows where the 'name' column contains
+    the part_of_name parameter. The results are sorted so that entries
+    where the name is prefixed by the part_of_name appear higher in the
+    rankings and alphabetically after that.
     """
-    queryset = model_class.objects.all()
     if part_of_name:
         queryset = queryset.filter(name__icontains=part_of_name)
         queryset = queryset.annotate(

--- a/api/staticdata/report_summaries/tests/test_views.py
+++ b/api/staticdata/report_summaries/tests/test_views.py
@@ -1,12 +1,18 @@
+from parameterized import parameterized
 from rest_framework.reverse import reverse
 
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
 from test_helpers.clients import DataTestClient
 
 
-class ReportSummaryPrefixesTests(DataTestClient):
+def get_url(name_filter=None):
+    query = f"?name={name_filter}" if name_filter else ""
+    return reverse("staticdata:report_summaries:prefix") + query
+
+
+class ReportSummaryPrefixesWithNoFilterReturnsEverythingTests(DataTestClient):
     def test_get_report_summary_prefixes_OK(self):
-        url = reverse("staticdata:report_summaries:prefix")
+        url = get_url()
         response = self.client.get(url, **self.gov_headers)
 
         self.assertEqual(response.status_code, 200)
@@ -20,6 +26,52 @@ class ReportSummaryPrefixesTests(DataTestClient):
 
             self.assertEqual(prefix["id"], str(db_prefix.id))
             self.assertEqual(prefix["name"], db_prefix.name)
+
+    @parameterized.expand(
+        [
+            [
+                "mix of prefix and contains results and sorts with prefixed first",
+                "eq",
+                [
+                    "equipment for the development of",
+                    "equipment for the production of",
+                    "equipment for the use of",
+                    "alignment equipment for",
+                    "calibration equipment for",
+                    "control equipment for",
+                    "counter-countermeasure equipment for",
+                    "countermeasure equipment for",
+                    "decoying equipment for",
+                    "fire simulation equipment for",
+                    "guidance equipment for",
+                    "information security equipment",
+                    "launching/handling/control equipment for",
+                    "launching/handling/control/support equipment for",
+                    "oil and gas industry equipment/materials",
+                    "software enabling equipment to function as",
+                    "test equipment for",
+                    "training equipment for",
+                ],
+            ],
+            [
+                "single result by narrowing filter",
+                "equipment to",
+                [
+                    "software enabling equipment to function as",
+                ],
+            ],
+        ]
+    )
+    def test_get_report_summary_prefixes_with_name_filter(self, name, filter, expected_results):
+        url = get_url(filter)
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 200)
+
+        prefixes = [prefix["name"] for prefix in response.json()["report_summary_prefixes"]]
+        self.assertEqual(len(prefixes), len(expected_results))
+
+        self.assertEqual(prefixes, expected_results)
 
 
 class ReportSummarySubjectsTests(DataTestClient):

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -2,7 +2,7 @@ from django.http import JsonResponse
 from rest_framework.views import APIView
 
 from api.core.authentication import GovAuthentication
-from api.staticdata.report_summaries.helpers import filtered_ordered_queryset
+from api.staticdata.report_summaries.helpers import filter_and_order_by_name
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
 from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
 
@@ -12,9 +12,7 @@ class ReportSummaryPrefixView(APIView):
 
     def get_queryset(self):
         part_of_name = self.request.GET.get("name")
-        model_class = ReportSummaryPrefix
-        prefixes = filtered_ordered_queryset(model_class, part_of_name)
-        return prefixes
+        return filter_and_order_by_name(ReportSummaryPrefix.objects.all(), part_of_name)
 
     def get(self, request):
         """
@@ -29,9 +27,7 @@ class ReportSummarySubjectView(APIView):
 
     def get_queryset(self):
         part_of_name = self.request.GET.get("name")
-        model_class = ReportSummarySubject
-        prefixes = filtered_ordered_queryset(model_class, part_of_name)
-        return prefixes
+        return filter_and_order_by_name(ReportSummarySubject.objects.all(), part_of_name)
 
     def get(self, request):
         """

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -7,6 +7,28 @@ from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSu
 from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
 
 
+def filtered_ordered_queryset(model_class, part_of_name):
+    """
+    Creates a queryset to get rows for the model where the
+    'name' column contains the part_of_name parameter. The results
+    are sorted so that entries where the name is prefixed by
+    the part_of_name appear higher in the rankings and
+    alphabetically after that.
+    """
+    queryset = model_class.objects.all()
+    if part_of_name:
+        queryset = queryset.filter(name__icontains=part_of_name)
+        queryset = queryset.annotate(
+            is_prefixed=Case(
+                When(name__istartswith=part_of_name.lower(), then=True),
+                default=False,
+                output_field=BinaryField(),
+            ),
+        )
+        queryset = queryset.order_by("-is_prefixed", "name")
+    return queryset
+
+
 class ReportSummaryPrefixView(APIView):
     authentication_classes = (GovAuthentication,)
 
@@ -14,20 +36,9 @@ class ReportSummaryPrefixView(APIView):
         """
         Returns report summary prefixes
         """
-        name = self.request.GET.get("name")
-        prefixes = ReportSummaryPrefix.objects.all()
-
-        if name:
-            prefixes = prefixes.filter(name__icontains=name)
-            prefixes = prefixes.annotate(
-                is_prefixed=Case(
-                    When(name__istartswith=name.lower(), then=True),
-                    default=False,
-                    output_field=BinaryField(),
-                ),
-            )
-            prefixes = prefixes.order_by("-is_prefixed", "name")
-
+        part_of_name = self.request.GET.get("name")
+        model_class = ReportSummaryPrefix
+        prefixes = filtered_ordered_queryset(model_class, part_of_name)
         prefix_serializer = ReportSummaryPrefixSerializer(prefixes, many=True)
         return JsonResponse(data={"report_summary_prefixes": prefix_serializer.data})
 
@@ -39,19 +50,8 @@ class ReportSummarySubjectView(APIView):
         """
         Returns report summary subjects
         """
-        name = self.request.GET.get("name")
-        subjects = ReportSummarySubject.objects.all()
-
-        if name:
-            subjects = subjects.filter(name__icontains=name)
-            subjects = subjects.annotate(
-                is_prefixed=Case(
-                    When(name__istartswith=name.lower(), then=True),
-                    default=False,
-                    output_field=BinaryField(),
-                ),
-            )
-            subjects = subjects.order_by("-is_prefixed", "name")
-
+        part_of_name = self.request.GET.get("name")
+        model_class = ReportSummarySubject
+        subjects = filtered_ordered_queryset(model_class, part_of_name)
         subject_serializer = ReportSummarySubjectSerializer(subjects, many=True)
         return JsonResponse(data={"report_summary_subjects": subject_serializer.data})

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -1,57 +1,41 @@
-from django.db.models import BinaryField, Case, When
 from django.http import JsonResponse
 from rest_framework.views import APIView
 
 from api.core.authentication import GovAuthentication
+from api.staticdata.report_summaries.helpers import filtered_ordered_queryset
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
 from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
-
-
-def filtered_ordered_queryset(model_class, part_of_name):
-    """
-    Creates a queryset to get rows for the model where the
-    'name' column contains the part_of_name parameter. The results
-    are sorted so that entries where the name is prefixed by
-    the part_of_name appear higher in the rankings and
-    alphabetically after that.
-    """
-    queryset = model_class.objects.all()
-    if part_of_name:
-        queryset = queryset.filter(name__icontains=part_of_name)
-        queryset = queryset.annotate(
-            is_prefixed=Case(
-                When(name__istartswith=part_of_name.lower(), then=True),
-                default=False,
-                output_field=BinaryField(),
-            ),
-        )
-        queryset = queryset.order_by("-is_prefixed", "name")
-    return queryset
 
 
 class ReportSummaryPrefixView(APIView):
     authentication_classes = (GovAuthentication,)
 
+    def get_queryset(self):
+        part_of_name = self.request.GET.get("name")
+        model_class = ReportSummaryPrefix
+        prefixes = filtered_ordered_queryset(model_class, part_of_name)
+        return prefixes
+
     def get(self, request):
         """
         Returns report summary prefixes
         """
-        part_of_name = self.request.GET.get("name")
-        model_class = ReportSummaryPrefix
-        prefixes = filtered_ordered_queryset(model_class, part_of_name)
-        prefix_serializer = ReportSummaryPrefixSerializer(prefixes, many=True)
+        prefix_serializer = ReportSummaryPrefixSerializer(self.get_queryset(), many=True)
         return JsonResponse(data={"report_summary_prefixes": prefix_serializer.data})
 
 
 class ReportSummarySubjectView(APIView):
     authentication_classes = (GovAuthentication,)
 
+    def get_queryset(self):
+        part_of_name = self.request.GET.get("name")
+        model_class = ReportSummarySubject
+        prefixes = filtered_ordered_queryset(model_class, part_of_name)
+        return prefixes
+
     def get(self, request):
         """
         Returns report summary subjects
         """
-        part_of_name = self.request.GET.get("name")
-        model_class = ReportSummarySubject
-        subjects = filtered_ordered_queryset(model_class, part_of_name)
-        subject_serializer = ReportSummarySubjectSerializer(subjects, many=True)
+        subject_serializer = ReportSummarySubjectSerializer(self.get_queryset(), many=True)
         return JsonResponse(data={"report_summary_subjects": subject_serializer.data})


### PR DESCRIPTION
This PR adds name filtering to the report_summary prefix and subject endpoints.

Ordering is by prefixed results first and then alphabetically.