### PR TITLE
Denials pagination

### DIFF
--- a/api/external_data/serializers.py
+++ b/api/external_data/serializers.py
@@ -102,9 +102,25 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
 
 
 class DenialSearchSerializer(DocumentSerializer):
+    entity_type = serializers.SerializerMethodField()
+
     class Meta:
         document = documents.DenialDocumentType
-        fields = ("denied_name",)
+        fields = (
+            "id",
+            "address",
+            "country",
+            "end_use",
+            "item_description",
+            "item_list_codes",
+            "name",
+            "notifying_government",
+            "reference",
+            "regime_reg_ref",
+        )
+
+    def get_entity_type(self, obj):
+        return get_denial_entity_type(obj.data.to_dict())
 
 
 class SanctionMatchSerializer(serializers.ModelSerializer):

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -9,8 +9,8 @@ from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from django.conf import settings
 
 from api.core.authentication import GovAuthentication
+from api.conf.pagination import MaxPageNumberPagination
 from api.external_data import documents, models, serializers
-from api.external_data.helpers import get_denial_entity_type
 
 
 class DenialViewSet(viewsets.ModelViewSet):
@@ -39,6 +39,7 @@ class DenialSearchView(DocumentViewSet):
     document = documents.DenialDocumentType
     serializer_class = serializers.DenialSearchSerializer
     authentication_classes = (GovAuthentication,)
+    pagination_class = MaxPageNumberPagination
     lookup_field = "id"
     filter_backends = [
         filter_backends.SearchFilterBackend,
@@ -52,13 +53,6 @@ class DenialSearchView(DocumentViewSet):
             "field": "country.raw",
         }
     }
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        results = queryset.execute().to_dict()
-        for denial in results["hits"]["hits"]:
-            denial["_source"]["entity_type"] = get_denial_entity_type(denial["_source"]["data"])
-        return Response(results)
 
     def filter_queryset(self, queryset):
         queryset = queryset.filter("term", is_revoked=False)


### PR DESCRIPTION
## aim

[Ticket](https://uktrade.atlassian.net/jira/software/c/projects/LTD/boards/204?modal=detail&selectedIssue=LTD-3294) 

The Denials search was only returning the first 10 results, this adds pagination to the view. 
~~The lite-routing test needs to be skipped first: https://github.com/uktrade/lite-routing/pull/131 ✅~~
~~The lite-routing test needs to temporarily accept both types of json results https://github.com/uktrade/lite-routing/pull/133 ✅~~
this lite routing test fix needs merging https://github.com/uktrade/lite-routing/pull/134/files ✅  
Then the SHA needs to be updated: https://github.com/uktrade/lite-api/pull/1304 ✅    
Then this PR merged ✖️ 
And frontend merged: https://github.com/uktrade/lite-frontend/pull/1095 ✖️ 
Then the test needs to be fixed: https://github.com/uktrade/lite-routing/pull/129/files  ✖️ 
And SHA updated again  ✖️ 


* although  `MaxPageNumberPagination` is set as the default class in settings, I've had to specify it here, maybe to override for the `DocumentViewSet`? We need to use that class because the frontend relies on the keys returned. 
* moved the `entity_type` key method to the Serializer
* this change would break any code relying on the old response format from the `let` method, but as far as I can see it's only be called once on the frontend, and we will change that. 