### PR TITLE
LTD-3028-Adds-property

### DIFF
--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -72,7 +72,7 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(len(all_cases), len(response_data["cases"]))
         self.assertEqual(
             [
-                {"id": str(user.pk), "full_name": f"{user.first_name} {user.last_name}"}
+                {"full_name": f"{user.first_name} {user.last_name}", "id": str(user.pk), "pending": user.pending}
                 for user in GovUser.objects.filter(status=UserStatuses.ACTIVE)
             ],
             response_data["filters"]["gov_users"],

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -3,8 +3,7 @@ from typing import List, Dict
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Count, F, Q, Value, OuterRef
-from django.db.models.functions import Concat
+from django.db.models import Count, F, Q, OuterRef
 from django.utils import timezone
 
 from api.applications.models import HmrcQuery, PartyOnApplication
@@ -37,7 +36,7 @@ def get_gov_users_list():
             "id": i.baseuser_ptr.id,
             "pending": i.pending,
         }
-        for i in GovUser.objects.all()
+        for i in GovUser.objects.filter(status=UserStatuses.ACTIVE)
     ]
 
 

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -31,11 +31,14 @@ def get_case_type_type_list() -> List[Dict]:
 
 
 def get_gov_users_list():
-    return (
-        GovUser.objects.filter(status=UserStatuses.ACTIVE)
-        .annotate(full_name=Concat("baseuser_ptr__first_name", Value(" "), "baseuser_ptr__last_name"))
-        .values("full_name", id=F("baseuser_ptr_id"))
-    )
+    return [
+        {
+            "full_name": i.baseuser_ptr.first_name + " " + i.baseuser_ptr.last_name,
+            "id": i.baseuser_ptr.id,
+            "pending": i.pending,
+        }
+        for i in GovUser.objects.all()
+    ]
 
 
 def get_advice_types_list():

--- a/api/gov_users/serializers.py
+++ b/api/gov_users/serializers.py
@@ -72,6 +72,7 @@ class GovUserListSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=GovUserStatuses.choices)
     team = TeamReadOnlySerializer()
     role_name = serializers.CharField(source="role.name")
+    pending = serializers.BooleanField()
 
 
 class GovUserViewSerializer(serializers.ModelSerializer):

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -430,17 +430,11 @@ class OrganisationUserListSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source="baseuser_ptr_id")
     role_name = serializers.CharField(read_only=True)
     status = serializers.CharField(read_only=True)
+    pending = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = ExporterUser
-        fields = (
-            "id",
-            "first_name",
-            "last_name",
-            "email",
-            "role_name",
-            "status",
-        )
+        fields = ("id", "first_name", "last_name", "email", "role_name", "status", "pending")
 
 
 class CommercialOrganisationUserListSerializer(OrganisationUserListSerializer):

--- a/api/organisations/tests/test_sites.py
+++ b/api/organisations/tests/test_sites.py
@@ -65,6 +65,7 @@ class OrganisationSitesTests(DataTestClient):
                     "first_name": user.first_name,
                     "last_name": user.last_name,
                     "email": user.email,
+                    "pending": False,
                 }
             ],
         )
@@ -76,6 +77,7 @@ class OrganisationSitesTests(DataTestClient):
                     "first_name": self.exporter_user.first_name,
                     "last_name": self.exporter_user.last_name,
                     "email": self.exporter_user.email,
+                    "pending": False,
                 }
             ],
         )

--- a/api/organisations/views/users.py
+++ b/api/organisations/views/users.py
@@ -1,7 +1,7 @@
 import operator
 from functools import reduce
 
-from django.db.models import Q, F
+from django.db.models import Q, F, ExpressionWrapper, BooleanField
 from django.http import JsonResponse
 from rest_framework import status, generics
 from rest_framework.exceptions import PermissionDenied
@@ -57,7 +57,7 @@ class UsersList(generics.ListCreateAPIView):
         if _status:
             query.append(Q(relationship__status=UserStatuses.from_string(_status)))
 
-        values = ("baseuser_ptr_id", "first_name", "last_name", "email", "status", "role_name")
+        values = ("baseuser_ptr_id", "first_name", "last_name", "email", "status", "role_name", "pending")
         if (
             organisation.type == OrganisationType.COMMERCIAL
             or organisation.type == OrganisationType.HMRC
@@ -76,6 +76,7 @@ class UsersList(generics.ListCreateAPIView):
                 status=F("relationship__status"),
                 role_name=F("relationship__role__name"),
                 phone_number=F("baseuser_ptr__phone_number"),
+                pending=ExpressionWrapper(Q(baseuser_ptr__first_name=""), output_field=BooleanField()),
             )
             .values(*values)
         )

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -221,6 +221,12 @@ class GovUser(models.Model, BaseUserCompatMixin):
         user_permissions = self.role.permissions.values_list("id", flat=True)
         return permission.name in user_permissions
 
+    @property
+    def pending(self):
+        if self.baseuser_ptr.first_name:
+            return False
+        return True
+
 
 class UserOrganisationRelationship(TimestampableModel):
     user = models.ForeignKey(ExporterUser, on_delete=models.CASCADE)

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -97,6 +97,12 @@ class BaseUser(AbstractUser, TimestampableModel):
     def send_notification(self, **kwargs):
         pass
 
+    @property
+    def pending(self):
+        if self.first_name:
+            return False
+        return True
+
 
 class BaseNotification(models.Model):
     user = models.ForeignKey(BaseUser, on_delete=models.CASCADE, null=False)
@@ -145,6 +151,10 @@ class BaseUserCompatMixin:
     @property
     def is_anonymous(self):
         return self.baseuser_ptr.is_anonymous
+
+    @property
+    def pending(self):
+        return self.baseuser_ptr.pending
 
     def save(self, *args, **kwargs):
         if not self.baseuser_ptr.type:
@@ -220,12 +230,6 @@ class GovUser(models.Model, BaseUserCompatMixin):
     def has_permission(self, permission):
         user_permissions = self.role.permissions.values_list("id", flat=True)
         return permission.name in user_permissions
-
-    @property
-    def pending(self):
-        if self.baseuser_ptr.first_name:
-            return False
-        return True
 
 
 class UserOrganisationRelationship(TimestampableModel):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -176,12 +176,7 @@ class ExporterUserSimpleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ExporterUser
-        fields = (
-            "id",
-            "first_name",
-            "last_name",
-            "email",
-        )
+        fields = ("id", "first_name", "last_name", "email", "pending")
 
 
 class UserOrganisationRelationshipSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Part 1
- add pending @property to model/serializer/endpoints based off of user.firstname
- swap out logic on frontend to use new pending field

Part 2
- swap out pending @property to be an actual DB field that’s updated when user first logs in

Related ticket to the FE:
https://github.com/uktrade/lite-frontend/pull/1101

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/LTD-3028
- [x] Jira ticket has the correct status.

### Reviewing help

- [ ] Explains how to test locally, including how to set up appropriate data

### Housekeeping

- [ ] Added all new environment variables to Vault.
- [ ] Cleaned up old feature flags
- [ ] Upgraded any vulnerable dependencies.
- [ ] I have updated security dependencies
- [ ] Python requirements have been re-compiled.
- [ ] Frontend assets have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)