### PR TITLE
Ltd 3262 report summary

### DIFF
--- a/api/goods/tests/test_control_codes.py
+++ b/api/goods/tests/test_control_codes.py
@@ -358,6 +358,13 @@ class GoodsVerifiedTestsStandardApplication(DataTestClient):
                 "Sniper Rifles (3)",
                 "components for Sniper Rifles (3)",
             ),
+            (
+                "subject but no report_summary and empty string prefix",
+                None,
+                "",
+                "Sniper Rifles (3)",
+                "Sniper Rifles (3)",
+            ),
         ]
     )
     def test_report_summary_replaced_by_prefix_and_summary(
@@ -387,8 +394,8 @@ class GoodsVerifiedTestsStandardApplication(DataTestClient):
             "is_precedent": False,
             "is_good_controlled": True,
             "end_use_control": [],
-            "report_summary_prefix": rs_prefix.id if rs_prefix else None,
-            "report_summary_subject": rs_subject.id if rs_subject else None,
+            "report_summary_prefix": rs_prefix.id if rs_prefix else rs_prefix,
+            "report_summary_subject": rs_subject.id if rs_subject else rs_subject,
             "comment": "report summary update test",
             "regime_entries": [],
         }

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -80,21 +80,19 @@ GOOD_ON_APP_BAD_REPORT_SUMMARY_SUBJECT = "Select a valid report summary subject"
 
 def get_new_report_summary_data(request):
     data = request.data
-    summary = data.get("report_summary", None)
+    summary = data.get("report_summary")
     rs_subject, rs_prefix = None, None
 
-    subject_id = data.get("report_summary_subject", None)
-    prefix_id = data.get("report_summary_prefix", None)
-
-    if subject_id is not None:
+    subject_id = data.get("report_summary_subject")
+    if subject_id:
         try:
             rs_subject = ReportSummarySubject.objects.get(id=subject_id)
         except ReportSummarySubject.DoesNotExist:
             raise ValidationError(GOOD_ON_APP_BAD_REPORT_SUMMARY_SUBJECT)
-
         summary = rs_subject.name
 
-    if prefix_id is not None:
+    prefix_id = data.get("report_summary_prefix")
+    if prefix_id:
         try:
             rs_prefix = ReportSummaryPrefix.objects.get(id=prefix_id)
         except ReportSummaryPrefix.DoesNotExist:

--- a/api/staticdata/report_summaries/tests/factories.py
+++ b/api/staticdata/report_summaries/tests/factories.py
@@ -1,0 +1,21 @@
+import factory
+
+from ..models import (
+    ReportSummaryPrefix,
+    ReportSummarySubject,
+)
+
+
+class ReportSummaryPrefixFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ReportSummaryPrefix
+
+    name = factory.Faker("word")
+
+
+class ReportSummarySubjectFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ReportSummarySubject
+
+    code_level = 1
+    name = factory.Faker("word")

--- a/api/staticdata/report_summaries/tests/test_views.py
+++ b/api/staticdata/report_summaries/tests/test_views.py
@@ -7,7 +7,7 @@ from test_helpers.clients import DataTestClient
 
 def prefixes_url(name_filter=None):
     query = f"?name={name_filter}" if name_filter else ""
-    return reverse("staticdata:report_summaries:prefix") + query
+    return reverse("staticdata:report_summaries:prefixes") + query
 
 
 class ReportSummaryPrefixesWithNoFilterReturnsEverythingTests(DataTestClient):
@@ -76,7 +76,7 @@ class ReportSummaryPrefixesWithNoFilterReturnsEverythingTests(DataTestClient):
 
 def subjects_url(name_filter=None):
     query = f"?name={name_filter}" if name_filter else ""
-    return reverse("staticdata:report_summaries:subject") + query
+    return reverse("staticdata:report_summaries:subjects") + query
 
 
 class ReportSummarySubjectsTests(DataTestClient):

--- a/api/staticdata/report_summaries/tests/test_views.py
+++ b/api/staticdata/report_summaries/tests/test_views.py
@@ -4,6 +4,11 @@ from rest_framework.reverse import reverse
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
 from test_helpers.clients import DataTestClient
 
+from .factories import (
+    ReportSummaryPrefixFactory,
+    ReportSummarySubjectFactory,
+)
+
 
 def prefixes_url(name_filter=None):
     query = f"?name={name_filter}" if name_filter else ""
@@ -127,3 +132,71 @@ class ReportSummarySubjectsTests(DataTestClient):
         self.assertEqual(len(subjects), len(expected_results))
 
         self.assertEqual(subjects, expected_results)
+
+
+class ReportSummarySubjectDetailTests(DataTestClient):
+    def test_report_summary_subject_object_not_found(self):
+        url = reverse(
+            "staticdata:report_summaries:subject",
+            kwargs={
+                "pk": "fe1059fd-d756-42a6-bd1b-84d83396e3f9",
+            },
+        )
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_report_summary_subject_object_found(self):
+        report_summary_subject = ReportSummarySubjectFactory.create()
+        url = reverse(
+            "staticdata:report_summaries:subject",
+            kwargs={
+                "pk": report_summary_subject.pk,
+            },
+        )
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "report_summary_subject": {
+                    "id": str(report_summary_subject.pk),
+                    "name": report_summary_subject.name,
+                }
+            },
+        )
+
+
+class ReportSummaryPrefixDetailTests(DataTestClient):
+    def test_report_summary_prefix_object_not_found(self):
+        url = reverse(
+            "staticdata:report_summaries:prefix",
+            kwargs={
+                "pk": "fe1059fd-d756-42a6-bd1b-84d83396e3f9",
+            },
+        )
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_report_summary_prefix_object_found(self):
+        report_summary_prefix = ReportSummaryPrefixFactory.create()
+        url = reverse(
+            "staticdata:report_summaries:prefix",
+            kwargs={
+                "pk": report_summary_prefix.pk,
+            },
+        )
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "report_summary_prefix": {
+                    "id": str(report_summary_prefix.pk),
+                    "name": report_summary_prefix.name,
+                }
+            },
+        )

--- a/api/staticdata/report_summaries/urls.py
+++ b/api/staticdata/report_summaries/urls.py
@@ -6,6 +6,6 @@ from . import views
 app_name = "report_summaries"
 
 urlpatterns = [
-    path("prefixes/", views.ReportSummaryPrefixView.as_view(), name="prefix"),
-    path("subjects/", views.ReportSummarySubjectView.as_view(), name="subject"),
+    path("prefixes/", views.ReportSummaryPrefixesListView.as_view(), name="prefixes"),
+    path("subjects/", views.ReportSummarySubjectsListView.as_view(), name="subjects"),
 ]

--- a/api/staticdata/report_summaries/urls.py
+++ b/api/staticdata/report_summaries/urls.py
@@ -7,5 +7,7 @@ app_name = "report_summaries"
 
 urlpatterns = [
     path("prefixes/", views.ReportSummaryPrefixesListView.as_view(), name="prefixes"),
+    path("prefixes/<uuid:pk>/", views.ReportSummaryPrefixDetailView.as_view(), name="prefix"),
     path("subjects/", views.ReportSummarySubjectsListView.as_view(), name="subjects"),
+    path("subjects/<uuid:pk>/", views.ReportSummarySubjectDetailView.as_view(), name="subject"),
 ]

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -1,4 +1,6 @@
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+
 from rest_framework.views import APIView
 
 from api.core.authentication import GovAuthentication
@@ -22,6 +24,15 @@ class ReportSummaryPrefixesListView(APIView):
         return JsonResponse(data={"report_summary_prefixes": prefix_serializer.data})
 
 
+class ReportSummaryPrefixDetailView(APIView):
+    authentication_classes = (GovAuthentication,)
+
+    def get(self, request, pk):
+        prefix = get_object_or_404(ReportSummaryPrefix, pk=pk)
+        serializer = ReportSummaryPrefixSerializer(prefix)
+        return JsonResponse(data={"report_summary_prefix": serializer.data})
+
+
 class ReportSummarySubjectsListView(APIView):
     authentication_classes = (GovAuthentication,)
 
@@ -35,3 +46,12 @@ class ReportSummarySubjectsListView(APIView):
         """
         subject_serializer = ReportSummarySubjectSerializer(self.get_queryset(), many=True)
         return JsonResponse(data={"report_summary_subjects": subject_serializer.data})
+
+
+class ReportSummarySubjectDetailView(APIView):
+    authentication_classes = (GovAuthentication,)
+
+    def get(self, request, pk):
+        subject = get_object_or_404(ReportSummarySubject, pk=pk)
+        serializer = ReportSummarySubjectSerializer(subject)
+        return JsonResponse(data={"report_summary_subject": serializer.data})

--- a/api/staticdata/report_summaries/views.py
+++ b/api/staticdata/report_summaries/views.py
@@ -7,7 +7,7 @@ from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSu
 from api.staticdata.report_summaries.serializers import ReportSummaryPrefixSerializer, ReportSummarySubjectSerializer
 
 
-class ReportSummaryPrefixView(APIView):
+class ReportSummaryPrefixesListView(APIView):
     authentication_classes = (GovAuthentication,)
 
     def get_queryset(self):
@@ -22,7 +22,7 @@ class ReportSummaryPrefixView(APIView):
         return JsonResponse(data={"report_summary_prefixes": prefix_serializer.data})
 
 
-class ReportSummarySubjectView(APIView):
+class ReportSummarySubjectsListView(APIView):
     authentication_classes = (GovAuthentication,)
 
     def get_queryset(self):


### PR DESCRIPTION
This adds two new endpoints to get details for the report summary objects.

This is so that it can be used on the frontend to check whether an id for a report summary object exists, this is used to validate the data in the assessment form.

There are also some changes here to fix a bug where a blank report summary prefix could be sent through and that would result in an error.