### PR TITLE
LTD-3305: remove `UNDER_REVIEW` from read only statuses

### DIFF
--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -50,7 +50,6 @@ class CaseStatusEnum:
         FINALISED,
         REGISTERED,
         REOPENED_DUE_TO_ORG_CHANGES,
-        UNDER_REVIEW,
         UNDER_ECJU_REVIEW,
         UNDER_FINAL_REVIEW,
         REVOKED,


### PR DESCRIPTION
### Aim

We want to allow exporter users to edit cases when they are under review, because this is when officers can ask them to make changes.

This is covered by already existing tests in https://github.com/uktrade/lite-api/blob/f4b7f9d3552bcc94375697cbb0967336049f227c/api/applications/tests/test_edit_application.py 


[LTD-](https://uktrade.atlassian.net/browse/LTD-)
