### PR TITLE
Update BDD tests output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ common_env_vars: &common_env_vars
 image_python: &image_python
   image: cimg/python:3.7.15
 
+image_python_node: &image_python_node
+  image: cimg/python:3.7.15-node
 
 image_postgres: &image_postgres
   image: circleci/postgres:11
@@ -150,7 +152,7 @@ jobs:
 
   lite_routing_bdd_tests:
     docker:
-      - <<: *image_python
+      - <<: *image_python_node
       - <<: *image_postgres
       - <<: *image_elasticsearch
       - <<: *image_redis
@@ -161,13 +163,26 @@ jobs:
     steps:
       - setup
       - run:
-          name: Run lite_routing tests
+          name: Install cucumber reporter package
+          command: npm install multiple-cucumber-html-reporter
+      - run:
+          name: Create report directories
           command: |
             mkdir test_results
-            pipenv run pytest --gherkin-terminal-reporter -vv lite_routing/routing_rules_internal/tests/bdd --junitxml=test_results/output.xml
+            mkdir cucumber_results
+            mkdir cucumber_html
+      - run:
+          name: Run lite_routing tests
+          command: pipenv run pytest --gherkin-terminal-reporter -vv lite_routing/routing_rules_internal/tests/bdd --junitxml=test_results/output.xml --cucumberjson=cucumber_results/cuc.json
+      - run:
+          name: Generate html cucumber report
+          command: node generate_cucumber_report.js
+          when: always
       - upload_code_coverage
       - store_test_results:
           path: test_results
+      - store_artifacts:
+          path: cucumber_html
 
   elastic_search_tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,11 @@ jobs:
       - run:
           name: Run lite_routing tests
           command: |
-            pipenv run pytest --gherkin-terminal-reporter -vv lite_routing/routing_rules_internal/tests/bdd
+            mkdir test_results
+            pipenv run pytest --gherkin-terminal-reporter -vv lite_routing/routing_rules_internal/tests/bdd --junitxml=test_results/output.xml
       - upload_code_coverage
+      - store_test_results:
+          path: test_results
 
   elastic_search_tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - run:
           name: Run lite_routing tests
           command: |
-            pipenv run pytest lite_routing/routing_rules_internal/tests/bdd
+            pipenv run pytest --gherkin-terminal-reporter -vv lite_routing/routing_rules_internal/tests/bdd
       - upload_code_coverage
 
   elastic_search_tests:

--- a/generate_cucumber_report.js
+++ b/generate_cucumber_report.js
@@ -1,0 +1,21 @@
+const report = require("multiple-cucumber-html-reporter");
+
+report.generate({
+  jsonDir: "./cucumber_results/",
+  reportPath: "./cucumber_html/",
+  metadata: {
+    browser: {
+      name: "N/A",
+      version: "N/A",
+    },
+    device: "CircleCI",
+    platform: {
+      name: "N/A",
+      version: "N/A",
+    },
+  },
+  customData: {
+    title: "Routing BDD",
+    data: [],
+  },
+});


### PR DESCRIPTION
### Aim

This gives us better reporting of what failed when the routing BDD tests fail.

This does the following:

  - Outputs the full scenario in the logs on CircleCI
  - Uploads xunit test results to CircleCI to tell us exactly what failed
  - Produces a HTML report that will show us exactly what scenarios failed and what steps failed

This is mostly all helping in regards to reporting on CircleCI, however when running locally we can use the same gherkin reporter to give us a better representation as to what's failing.

I've not made the gherkin reporter the default in anyway as I feel it should be up to the developer themselves to choose to run this if they so wish.

[LTD-3454](https://uktrade.atlassian.net/browse/LTD-3454)


[LTD-3454]: https://uktrade.atlassian.net/browse/LTD-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ