### PR TITLE
Ltd 3453 output logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,16 @@ jobs:
     steps:
       - setup
       - run:
+          name: Create report directories
+          command: |
+            mkdir test_results
+      - run:
           name: Run tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing -k "not seeding and not elasticsearch and not performance"
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing -k "not seeding and not elasticsearch and not performance" --junitxml=test_results/output.xml
       - upload_code_coverage
+      - store_test_results:
+          path: test_results
 
   seeding_tests:
     docker:
@@ -127,10 +133,16 @@ jobs:
     steps:
       - setup
       - run:
+          name: Create report directories
+          command: |
+            mkdir test_results
+      - run:
           name: Run seeding tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k seeding
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k seeding --junitxml=test_results/output.xml
       - upload_code_coverage
+      - store_test_results:
+          path: test_results
 
   lite_routing_tests:
     docker:
@@ -145,10 +157,16 @@ jobs:
     steps:
       - setup
       - run:
+          name: Create report directories
+          command: |
+            mkdir test_results
+      - run:
           name: Run lite_routing tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing/routing_rules_internal/tests/bdd lite_routing
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing/routing_rules_internal/tests/bdd lite_routing --junitxml=test_results/output.xml
       - upload_code_coverage
+      - store_test_results:
+          path: test_results
 
   lite_routing_bdd_tests:
     docker:
@@ -196,10 +214,16 @@ jobs:
     steps:
       - setup
       - run:
+          name: Create report directories
+          command: |
+            mkdir test_results
+      - run:
           name: Run elasticsearch tests
           command: |
-            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k elasticsearch
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k elasticsearch --junitxml=test_results/output.xml
       - upload_code_coverage
+      - store_test_results:
+          path: test_results
 
   check_migrations:
     docker:

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -345,28 +345,25 @@ GOOD_ON_APPLICATION_COPY_LOGGER = "good_on_application_copy_logger"
 GOOD_OVERVIEW_PUT_DELETION_LOGGER = "good_overview_put_deletion_logger"
 
 
-if "test" not in sys.argv:
-    LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "simple": {"format": "{asctime} {levelname} {message}", "style": "{"},
-            "ecs_formatter": {"()": ECSFormatter},
-        },
-        "handlers": {
-            "stdout": {"class": "logging.StreamHandler", "formatter": "simple"},
-            "ecs": {"class": "logging.StreamHandler", "formatter": "ecs_formatter"},
-            "sentry": {"class": "sentry_sdk.integrations.logging.EventHandler"},
-        },
-        "root": {"handlers": ["stdout", "ecs"], "level": env("LOG_LEVEL").upper()},
-        "loggers": {
-            DENIAL_REASONS_DELETION_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
-            GOOD_ON_APPLICATION_COPY_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
-            GOOD_OVERVIEW_PUT_DELETION_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
-        },
-    }
-else:
-    LOGGING = {"version": 1, "disable_existing_loggers": True}
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {"format": "{asctime} {levelname} {message}", "style": "{"},
+        "ecs_formatter": {"()": ECSFormatter},
+    },
+    "handlers": {
+        "stdout": {"class": "logging.StreamHandler", "formatter": "simple"},
+        "ecs": {"class": "logging.StreamHandler", "formatter": "ecs_formatter"},
+        "sentry": {"class": "sentry_sdk.integrations.logging.EventHandler"},
+    },
+    "root": {"handlers": ["stdout", "ecs"], "level": env("LOG_LEVEL").upper()},
+    "loggers": {
+        DENIAL_REASONS_DELETION_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
+        GOOD_ON_APPLICATION_COPY_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
+        GOOD_OVERVIEW_PUT_DELETION_LOGGER: {"handlers": ["sentry"], "level": logging.WARNING},
+    },
+}
 
 # Sentry
 if env.str("SENTRY_DSN", ""):

--- a/api/conf/settings_test.py
+++ b/api/conf/settings_test.py
@@ -4,3 +4,5 @@ from api.conf.settings import *
 ELASTICSEARCH_SANCTION_INDEX_ALIAS = "sanctions-alias-test"
 
 LOGGING = {"version": 1, "disable_existing_loggers": True}
+
+SUPPRESS_TEST_OUTPUT = True

--- a/api/conf/settings_test.py
+++ b/api/conf/settings_test.py
@@ -2,3 +2,5 @@ from api.conf.settings import *
 
 
 ELASTICSEARCH_SANCTION_INDEX_ALIAS = "sanctions-alias-test"
+
+LOGGING = {"version": 1, "disable_existing_loggers": True}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = api.conf.settings_test
 addopts =
-  -k "not seeding and not elasticsearch and not performance"
+  -k "not seeding and not elasticsearch and not performance" -p no:warnings
 env =
 	ELASTICSEARCH_SANCTION_INDEX_ALIAS=sanctions-alias-test
 	ELASTICSEARCH_DENIALS_INDEX_ALIAS=denials-alias-test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = api.conf.settings_test
 addopts =
-  -k "not seeding and not elasticsearch and not performance" -p no:warnings -p no:logging
+  -k "not seeding and not elasticsearch and not performance" -p no:warnings -p no:logging -s
 env =
 	ELASTICSEARCH_SANCTION_INDEX_ALIAS=sanctions-alias-test
 	ELASTICSEARCH_DENIALS_INDEX_ALIAS=denials-alias-test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = api.conf.settings_test
 addopts =
-  -k "not seeding and not elasticsearch and not performance" -p no:warnings
+  -k "not seeding and not elasticsearch and not performance" -p no:warnings -p no:logging
 env =
 	ELASTICSEARCH_SANCTION_INDEX_ALIAS=sanctions-alias-test
 	ELASTICSEARCH_DENIALS_INDEX_ALIAS=denials-alias-test


### PR DESCRIPTION
### Aim

Update the default configuration when running tests to make output less verbose. This is especially important when a test fails so that the information about the error is the easiest thing to find.

This turns off most of the default logging and capturing that was occurring when we were running the tests.

The following has been changed:

  - disable capturing and outputting warnings during tests
  - disable capturing and outputting stdin/stdout during tests
  - disable all loggers during tests
  - suppress output of seeding commands

[LTD-3453](https://uktrade.atlassian.net/browse/LTD-3453)


[LTD-3453]: https://uktrade.atlassian.net/browse/LTD-3453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ