### PR TITLE
unit tests to cover `CaseStatus` and `CaseStatusEnum`

### DIFF
--- a/api/staticdata/statuses/tests/test_statuses.py
+++ b/api/staticdata/statuses/tests/test_statuses.py
@@ -1,0 +1,18 @@
+import pytest
+from parameterized import parameterized
+
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+from api.applications.libraries.case_status_helpers import get_case_statuses
+
+
+@pytest.mark.django_db
+class TestCaseStatus:
+    @parameterized.expand(get_case_statuses(read_only=True))
+    def test_read_only_case_statuses(self, status):
+        read_only_case_status = get_case_status_by_status(status)
+        assert read_only_case_status.is_read_only is True
+
+    @parameterized.expand(get_case_statuses(read_only=False))
+    def test_editable_case_statuses(self, status):
+        editable_case_status = get_case_status_by_status(status)
+        assert editable_case_status.is_read_only is False


### PR DESCRIPTION
### Aim

we recently wanted to change the `under_review` status to read only, and
assumed that it was just a matter of changing the CaseStatusEnum, but it
turned out to need a migration on the CaseStatus model.

There are tests in `test_edit_application` that provide more integration
testing for both `read_only` and `editable` cases, but these make sure
that the Enum will always match what's on the database.

[LTD-](https://uktrade.atlassian.net/browse/LTD-)
