### PR TITLE
Use correct country code for Spain to avoid duplicated country

### DIFF
--- a/api/staticdata/countries/factories.py
+++ b/api/staticdata/countries/factories.py
@@ -4,7 +4,7 @@ from api.staticdata.countries.models import Country
 
 
 class CountryFactory(factory.django.DjangoModelFactory):
-    id = factory.Iterator(["UK", "IT", "SP"])
+    id = factory.Iterator(["UK", "IT", "ES"])
     name = factory.Iterator(["United Kingdom", "Italy", "Spain"])
     is_eu = False
     type = factory.Iterator(["1", "2", "3"])


### PR DESCRIPTION
There were some cases in our BDD scenarios which used Spain as a country, however this factory would sometimes go and generate a second Spain object in the database due to the fact that the country code for Spain was incorrect and the database would end up with two countries with the name Spain.

This now uses the correct country code for Spain in the factory so that only one Spain object exists.