### PR TITLE
LTD-3499: Remove warnings on update about denial reasons

### DIFF
--- a/api/applications/serializers/advice.py
+++ b/api/applications/serializers/advice.py
@@ -166,22 +166,6 @@ class AdviceCreateSerializer(serializers.ModelSerializer):
                 self.initial_data[i]["footnote"] = None
                 self.initial_data[i]["footnote_required"] = None
 
-    def update(self, instance, validated_data):
-        previous_denial_reasons = list(instance.denial_reasons.values_list("pk", flat=True))
-
-        instance = super().update(instance, validated_data)
-
-        if not instance.denial_reasons.exists():
-            denial_reasons_logger.warning(
-                "Updating advice object with no denial reasons: %s (%s) - %s",
-                instance,
-                instance.pk,
-                previous_denial_reasons,
-                exc_info=True,
-            )
-
-        return instance
-
 
 class CountersignAdviceListSerializer(serializers.ListSerializer):
     def update(self, instances, validated_data):


### PR DESCRIPTION
## Change description

There was a situation where we believed that denial reasons were getting deleted and warning logs were added in few places. This was one such instance.

A new put method is going to be added to actually update Advice objects and this warning will be triggered with each update which is not very useful hence removing this.

[LTD-3499](https://uktrade.atlassian.net/browse/LTD-3499)


[LTD-3499]: https://uktrade.atlassian.net/browse/LTD-3499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ