### PR TITLE
Create LU TeamIdEnum in lite-api

### DIFF
--- a/api/teams/enums.py
+++ b/api/teams/enums.py
@@ -1,0 +1,2 @@
+class TeamIdEnum:
+    LICENSING_UNIT = "58e77e47-42c8-499f-a58d-94f94541f8c6"


### PR DESCRIPTION
This is a subtask of the work in this PR: https://github.com/uktrade/lite-routing/pull/162

[LTD-3500](https://uktrade.atlassian.net/browse/LTD-3500)

[LTD-3500]: https://uktrade.atlassian.net/browse/LTD-3500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ