### PR TITLE
Add seed command to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,3 +29,8 @@ start-e2e:
 
 stop-e2e:
 	$(docker-base) down --remove-orphans
+
+seed:
+	./manage.py seedrolepermissions
+	./manage.py seedinternalusers
+	./manage.py seedexporterusers


### PR DESCRIPTION
This change allows developers to run the seed commands used when setting up the db from the makefile using `make seed`. 