### PR TITLE
Ensure linting checks run against lite-routing PRs

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: /vendor,/.venv,/staticdata/management,**/test_*.py,/staticdata/countries/test.py
+exclude: /vendor,/.venv,/staticdata/management,**/test_*.py,/staticdata/countries/test.py,**/conftest.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,22 +244,7 @@ jobs:
     docker:
       - <<: *image_python
     steps:
-      - checkout
-      - run:
-          name: Git Submodule Checkout
-          command: |
-            git submodule sync
-            git submodule update --init
-      - restore_cache:
-          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-      - install_os_libraries
-      - run:
-          name: Install Dependencies
-          command: pipenv sync --dev
-      - save_cache:
-          paths:
-            - ./venv
-          key: dependencies-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - setup
       - run:
           name: Prospector
           command: pipenv run prospector -W pylint -W pep257 -W mccabe


### PR DESCRIPTION
### Aim

This change does two things;
- Ensures that lite-routing PRs run linting checks properly.  Previously the linting step would not check out the custom lite-routing branch, this has been swapped to use `setup` (which checks out the custom lite-routing branch) like other steps.
- Stops bandit checking `conftest.py` - bandit is a tool for security assurance and should not be run against test code.

