### PR TITLE
LTD-3481: Update CaseStatusEnum to evaluate status choices at runtime

### DIFF
--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -58,8 +58,6 @@ class CaseStatusEnum:
         WITHDRAWN,
         OGD_ADVICE,
         OGD_CONSOLIDATION,
-        FINAL_REVIEW_COUNTERSIGN,
-        FINAL_REVIEW_SECOND_COUNTERSIGN,
     ]
 
     _major_editable_statuses = [APPLICANT_EDITING, DRAFT]
@@ -73,15 +71,6 @@ class CaseStatusEnum:
     compliance_site_statuses = [OPEN, CLOSED]
 
     compliance_visit_statuses = [OPEN, UNDER_INTERNAL_REVIEW, RETURN_TO_INSPECTOR, AWAITING_EXPORTER_RESPONSE, CLOSED]
-
-    _lu_countersign_statuses = (
-        [
-            (FINAL_REVIEW_COUNTERSIGN, "final review countersign"),
-            (FINAL_REVIEW_SECOND_COUNTERSIGN, "final review second countersign"),
-        ]
-        if settings.FEATURE_COUNTERSIGN_ROUTING_ENABLED
-        else []
-    )
 
     choices = [
         (APPEAL_FINAL_REVIEW, "Appeal final review"),
@@ -115,7 +104,7 @@ class CaseStatusEnum:
         (WITHDRAWN, "Withdrawn"),
         (OGD_ADVICE, "OGD Advice"),
         (OGD_CONSOLIDATION, "OGD Consolidation"),
-    ] + _lu_countersign_statuses
+    ]
 
     priority = {
         SUBMITTED: 1,
@@ -154,22 +143,48 @@ class CaseStatusEnum:
     }
 
     @classmethod
+    def get_choices(cls):
+        lu_countersign_statuses = []
+        if settings.FEATURE_COUNTERSIGN_ROUTING_ENABLED:
+            lu_countersign_statuses.extend(
+                [
+                    (cls.FINAL_REVIEW_COUNTERSIGN, "final review countersign"),
+                    (cls.FINAL_REVIEW_SECOND_COUNTERSIGN, "final review second countersign"),
+                ]
+            )
+
+        return cls.choices + lu_countersign_statuses
+
+    @classmethod
+    def get_read_only_choices(cls):
+        lu_countersign_statuses = []
+        if settings.FEATURE_COUNTERSIGN_ROUTING_ENABLED:
+            lu_countersign_statuses.extend(
+                [
+                    cls.FINAL_REVIEW_COUNTERSIGN,
+                    cls.FINAL_REVIEW_SECOND_COUNTERSIGN,
+                ]
+            )
+
+        return cls._read_only_statuses + lu_countersign_statuses
+
+    @classmethod
     def get_text(cls, status):
         # All available statuses and DRAFT (System only status)
-        for k, v in [*cls.choices, (cls.DRAFT, "Draft")]:
+        for k, v in [*cls.get_choices(), (cls.DRAFT, "Draft")]:
             if status == k:
                 return v
 
     @classmethod
     def get_value(cls, status):
         # All available statuses and DRAFT (System only status)
-        for k, v in [*cls.choices, (cls.DRAFT, "Draft")]:
+        for k, v in [*cls.get_choices(), (cls.DRAFT, "Draft")]:
             if status == v:
                 return k
 
     @classmethod
     def is_read_only(cls, status):
-        return status in cls._read_only_statuses
+        return status in cls.get_read_only_choices()
 
     @classmethod
     def is_terminal(cls, status):
@@ -181,7 +196,7 @@ class CaseStatusEnum:
 
     @classmethod
     def read_only_statuses(cls):
-        return cls._read_only_statuses
+        return cls.get_read_only_choices()
 
     @classmethod
     def major_editable_statuses(cls):
@@ -202,7 +217,7 @@ class CaseStatusEnum:
 
     @classmethod
     def all(cls):
-        return [k for k, _ in [*cls.choices, (cls.DRAFT, "Draft")]]
+        return [k for k, _ in [*cls.get_choices(), (cls.DRAFT, "Draft")]]
 
 
 class CaseStatusIdEnum:

--- a/api/staticdata/statuses/tests/test_statuses.py
+++ b/api/staticdata/statuses/tests/test_statuses.py
@@ -19,14 +19,16 @@ class TestCaseStatus:
         editable_case_status = get_case_status_by_status(status)
         assert editable_case_status.is_read_only is False
 
-    @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
-    def test_read_only_status_contains_lu_countersign_statuses(self):
-        statuses = get_case_statuses(read_only=True)
-        assert CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses
-        assert CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses
+    @parameterized.expand([(True,), (False,)])
+    def test_read_only_status_contains_lu_countersign_statuses(self, flag_status):
+        with override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=flag_status):
+            statuses = get_case_statuses(read_only=True)
+            assert (CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses) is flag_status
+            assert (CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses) is flag_status
 
-    @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
-    def test_all_status_contains_lu_countersign_statuses(self):
-        statuses = CaseStatusEnum.all()
-        assert CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses
-        assert CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses
+    @parameterized.expand([(True,), (False,)])
+    def test_all_status_contains_lu_countersign_statuses(self, flag_status):
+        with override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=flag_status):
+            statuses = CaseStatusEnum.all()
+            assert (CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses) is flag_status
+            assert (CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses) is flag_status

--- a/api/staticdata/statuses/tests/test_statuses.py
+++ b/api/staticdata/statuses/tests/test_statuses.py
@@ -1,6 +1,8 @@
 import pytest
+from django.test import override_settings
 from parameterized import parameterized
 
+from api.staticdata.statuses.enums import CaseStatusEnum
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from api.applications.libraries.case_status_helpers import get_case_statuses
 
@@ -16,3 +18,15 @@ class TestCaseStatus:
     def test_editable_case_statuses(self, status):
         editable_case_status = get_case_status_by_status(status)
         assert editable_case_status.is_read_only is False
+
+    @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
+    def test_read_only_status_contains_lu_countersign_statuses(self):
+        statuses = get_case_statuses(read_only=True)
+        assert CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses
+        assert CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses
+
+    @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
+    def test_all_status_contains_lu_countersign_statuses(self):
+        statuses = CaseStatusEnum.all()
+        assert CaseStatusEnum.FINAL_REVIEW_COUNTERSIGN in statuses
+        assert CaseStatusEnum.FINAL_REVIEW_SECOND_COUNTERSIGN in statuses


### PR DESCRIPTION
## Change description

The new statuses introduced for LU Countersigning are behind a feature flag so we need to evaluate these at runtime (when running tests) otherwise they don't get picked up and tests fail.
