### PR TITLE
LTD-3549: Consider NLR advice type when checking for countersignatures

### DIFF
--- a/api/applications/tests/test_finalise_application.py
+++ b/api/applications/tests/test_finalise_application.py
@@ -536,6 +536,14 @@ class FinaliseApplicationTests(DataTestClient):
                 ),
             ],
             [
+                AdviceType.NO_LICENCE_REQUIRED,
+                (CountersignOrder.FIRST_COUNTERSIGN,),
+                (
+                    {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
+                ),
+            ],
+            [
                 AdviceType.APPROVE,
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
@@ -547,6 +555,16 @@ class FinaliseApplicationTests(DataTestClient):
             ],
             [
                 AdviceType.PROVISO,
+                (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
+                (
+                    {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
+                    {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
+                ),
+            ],
+            [
+                AdviceType.NO_LICENCE_REQUIRED,
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},

--- a/api/applications/views/helpers/advice.py
+++ b/api/applications/views/helpers/advice.py
@@ -112,7 +112,11 @@ def ensure_lu_countersign_complete(application):
             case=case,
             advice__user__team=lu_team,
             advice__level=AdviceLevel.FINAL,
-            advice__type__in=[AdviceType.APPROVE, AdviceType.PROVISO],
+            advice__type__in=[
+                AdviceType.APPROVE,
+                AdviceType.PROVISO,
+                AdviceType.NO_LICENCE_REQUIRED,
+            ],
         )
         if not (countersign_advice and all(advice.outcome_accepted for advice in countersign_advice)):
             raise CounterSignatureIncompleteError(
@@ -180,7 +184,11 @@ def mark_lu_rejected_countersignatures_as_invalid(case):
             outcome_accepted=False,
             advice__user__team=lu_team,
             advice__level=AdviceLevel.FINAL,
-            advice__type__in=[AdviceType.APPROVE, AdviceType.PROVISO],
+            advice__type__in=[
+                AdviceType.APPROVE,
+                AdviceType.PROVISO,
+                AdviceType.NO_LICENCE_REQUIRED,
+            ],
         )
         if countersign_advice.exists():
             countersign_orders_to_invalidate.append(order)
@@ -202,6 +210,10 @@ def mark_lu_rejected_countersignatures_as_invalid(case):
             case=case,
             advice__user__team=lu_team,
             advice__level=AdviceLevel.FINAL,
-            advice__type__in=[AdviceType.APPROVE, AdviceType.PROVISO],
+            advice__type__in=[
+                AdviceType.APPROVE,
+                AdviceType.PROVISO,
+                AdviceType.NO_LICENCE_REQUIRED,
+            ],
         )
         countersign_advice.update(valid=False)


### PR DESCRIPTION
### Aim

When LU first consolidates their advice before sending for countersigning they consolidate advice for NLR products also (if that Case has NLR products). However when checking for Countersignatures are complete or not at the time of finalising, we are not including advice type for NLR.

Update tests.

[LTD-3549](https://uktrade.atlassian.net/browse/LTD-3549)
