### PR TITLE
Rename Senior countersign flag

### DIFF
--- a/api/applications/tests/test_finalise_application.py
+++ b/api/applications/tests/test_finalise_application.py
@@ -323,7 +323,7 @@ class FinaliseApplicationTests(DataTestClient):
     @parameterized.expand(
         [
             FlagsEnum.LU_COUNTER_REQUIRED,
-            FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED,
+            FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED,
             FlagsEnum.MANPADS,
             FlagsEnum.AP_LANDMINE,
         ]
@@ -383,7 +383,7 @@ class FinaliseApplicationTests(DataTestClient):
                 ),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -395,7 +395,7 @@ class FinaliseApplicationTests(DataTestClient):
                 ),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -463,7 +463,7 @@ class FinaliseApplicationTests(DataTestClient):
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -542,7 +542,7 @@ class FinaliseApplicationTests(DataTestClient):
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -552,7 +552,7 @@ class FinaliseApplicationTests(DataTestClient):
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -562,7 +562,7 @@ class FinaliseApplicationTests(DataTestClient):
                 (CountersignOrder.FIRST_COUNTERSIGN, CountersignOrder.SECOND_COUNTERSIGN),
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -619,7 +619,7 @@ class FinaliseApplicationTests(DataTestClient):
         # Assert Countersign flags removed from the Case
         expected_flags_to_remove = [FlagsEnum.LU_COUNTER_REQUIRED]
         if CountersignOrder.SECOND_COUNTERSIGN in required_countersign:
-            expected_flags_to_remove.append(FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED)
+            expected_flags_to_remove.append(FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED)
         for flag_id in expected_flags_to_remove:
             flag = Flag.objects.get(id=flag_id)
             self.assertNotIn(flag, case.parameter_set())

--- a/api/applications/views/helpers/advice.py
+++ b/api/applications/views/helpers/advice.py
@@ -30,7 +30,7 @@ def lu_countersigning_flags_all():
     return Flag.objects.filter(
         id__in=[
             FlagsEnum.LU_COUNTER_REQUIRED,
-            FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED,
+            FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED,
             FlagsEnum.MANPADS,
             FlagsEnum.AP_LANDMINE,
         ],
@@ -41,7 +41,7 @@ def lu_countersigning_flags_all():
 def lu_sr_mgr_countersigning_flags():
     return Flag.objects.filter(
         id__in=[
-            FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED,
+            FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED,
             FlagsEnum.MANPADS,
         ],
         status=FlagStatuses.ACTIVE,
@@ -107,7 +107,7 @@ def ensure_lu_countersign_complete(application):
     countersign_process_flags = Flag.objects.filter(
         id__in=[
             FlagsEnum.LU_COUNTER_REQUIRED,
-            FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED,
+            FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED,
         ],
         status=FlagStatuses.ACTIVE,
     )

--- a/api/cases/tests/test_edit_advice.py
+++ b/api/cases/tests/test_edit_advice.py
@@ -289,7 +289,7 @@ class AdviceUpdateCountersignInvalidateTests(DataTestClient):
                 # from the beginning when it comes back again
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -303,7 +303,7 @@ class AdviceUpdateCountersignInvalidateTests(DataTestClient):
                 # 3. Both manager accepts - nothings needs invalidating in this case
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),
@@ -397,7 +397,7 @@ class AdviceUpdateCountersignInvalidateTests(DataTestClient):
             [
                 (
                     {"id": FlagsEnum.LU_COUNTER_REQUIRED, "level": FlagLevels.DESTINATION},
-                    {"id": FlagsEnum.LU_SENIOR_MANAGER_CHECK_REQUIRED, "level": FlagLevels.DESTINATION},
+                    {"id": FlagsEnum.LU_SENIOR_COUNTERSIGN_REQUIRED, "level": FlagLevels.DESTINATION},
                     {"id": FlagsEnum.AP_LANDMINE, "level": FlagLevels.CASE},
                     {"id": FlagsEnum.MANPADS, "level": FlagLevels.CASE},
                 ),


### PR DESCRIPTION
### Aim
Rename the senior countersign flag. 

NOTE: This cannot me merged until the corresponding lite_routing PR is merged and the sha updated in this PR.

[LTD-3163](https://uktrade.atlassian.net/browse/LTD-3163)


[LTD-3163]: https://uktrade.atlassian.net/browse/LTD-3163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ