### PR TITLE
Proviso audit

### DIFF
--- a/api/audit_trail/formatters.py
+++ b/api/audit_trail/formatters.py
@@ -286,11 +286,15 @@ def generate_decision_letter(**payload):
     return f"invalid decision {decision} for this event."
 
 
-def create_lu_advice(firstname, lastname, advice_type):  # /PS-IGNORE
+def create_lu_advice(firstname, lastname, advice_type, **payload):  # /PS-IGNORE
+    if advice_type == AdviceType.PROVISO:
+        return f"{firstname} {lastname} added a licence condition."  # /PS-IGNORE
     return f"{firstname} {lastname} added a recommendation to {advice_type}."  # /PS-IGNORE
 
 
 def update_lu_advice(firstname, lastname, advice_type, **payload):  # /PS-IGNORE
+    if advice_type == AdviceType.PROVISO:
+        return f"{firstname} {lastname} edited a licence condition."  # /PS-IGNORE
     advice_type_noun = {AdviceType.APPROVE: "approval", AdviceType.REFUSE: "refusal"}[advice_type]
     return f"{firstname} {lastname} edited their {advice_type_noun} reason."  # /PS-IGNORE
 

--- a/api/audit_trail/tests/test_formatters.py
+++ b/api/audit_trail/tests/test_formatters.py
@@ -470,7 +470,8 @@ class FormattersTest(DataTestClient):
     @parameterized.expand(
         [
             ("Test", "User", AdviceType.APPROVE, "Test User added a recommendation to approve."),
-            ("Test", "User", AdviceType.REFUSE, "Test User added a recommendation to refuse."),
+            ("Dark", "Knight", AdviceType.REFUSE, "Dark Knight added a recommendation to refuse."),
+            ("Robin", "Hood", AdviceType.PROVISO, "Robin Hood added a licence condition."),
         ]
     )
     def test_create_lu_advice(self, first, last, advice_status, expected_text):
@@ -481,6 +482,7 @@ class FormattersTest(DataTestClient):
         [
             ("Test", "User", AdviceType.APPROVE, "Test User edited their approval reason."),
             ("Dark", "Knight", AdviceType.REFUSE, "Dark Knight edited their refusal reason."),
+            ("Robin", "Hood", AdviceType.PROVISO, "Robin Hood edited a licence condition."),
         ]
     )
     def test_update_lu_advice(self, first, last, advice_status, expected_text):


### PR DESCRIPTION
### Aim
Licence conditions (Proviso advice) should be audited. Audit messages should be as per the designs in the ticket and "additional text" to display in the timeline should be the proviso text.

[LTD-3485](https://uktrade.atlassian.net/browse/LTD-3485)


[LTD-3485]: https://uktrade.atlassian.net/browse/LTD-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ