### PR TITLE
Duplicate name fix uat

### DIFF
--- a/api/audit_trail/formatters.py
+++ b/api/audit_trail/formatters.py
@@ -288,13 +288,13 @@ def generate_decision_letter(**payload):
 
 def create_lu_advice(advice_type, **payload):  # /PS-IGNORE
     if advice_type == AdviceType.PROVISO:
-        return f" added a licence condition."  # /PS-IGNORE
+        return " added a licence condition."  # /PS-IGNORE
     return f" added a recommendation to {advice_type}."  # /PS-IGNORE
 
 
 def update_lu_advice(advice_type, **payload):  # /PS-IGNORE
     if advice_type == AdviceType.PROVISO:
-        return f" edited a licence condition."  # /PS-IGNORE
+        return " edited a licence condition."  # /PS-IGNORE
     advice_type_noun = {AdviceType.APPROVE: "approval", AdviceType.REFUSE: "refusal"}[advice_type]
     return f" edited their {advice_type_noun} reason."  # /PS-IGNORE
 

--- a/api/audit_trail/formatters.py
+++ b/api/audit_trail/formatters.py
@@ -286,21 +286,21 @@ def generate_decision_letter(**payload):
     return f"invalid decision {decision} for this event."
 
 
-def create_lu_advice(firstname, lastname, advice_type, **payload):  # /PS-IGNORE
+def create_lu_advice(advice_type, **payload):  # /PS-IGNORE
     if advice_type == AdviceType.PROVISO:
-        return f"{firstname} {lastname} added a licence condition."  # /PS-IGNORE
-    return f"{firstname} {lastname} added a recommendation to {advice_type}."  # /PS-IGNORE
+        return f" added a licence condition."  # /PS-IGNORE
+    return f" added a recommendation to {advice_type}."  # /PS-IGNORE
 
 
-def update_lu_advice(firstname, lastname, advice_type, **payload):  # /PS-IGNORE
+def update_lu_advice(advice_type, **payload):  # /PS-IGNORE
     if advice_type == AdviceType.PROVISO:
-        return f"{firstname} {lastname} edited a licence condition."  # /PS-IGNORE
+        return f" edited a licence condition."  # /PS-IGNORE
     advice_type_noun = {AdviceType.APPROVE: "approval", AdviceType.REFUSE: "refusal"}[advice_type]
-    return f"{firstname} {lastname} edited their {advice_type_noun} reason."  # /PS-IGNORE
+    return f" edited their {advice_type_noun} reason."  # /PS-IGNORE
 
 
-def lu_countersign_advice(firstname, lastname, department, order, countersign_accepted, **payload):  # /PS-IGNORE
+def lu_countersign_advice(department, order, countersign_accepted, **payload):  # /PS-IGNORE
     senior_text = "senior " if order == CountersignOrder.SECOND_COUNTERSIGN else ""
     if countersign_accepted:
-        return f"{firstname} {lastname} {senior_text}countersigned all {department} recommendations."  # /PS-IGNORE
-    return f"{firstname} {lastname} declined to {senior_text}countersign {department} recommendations."  # /PS-IGNORE
+        return f" {senior_text}countersigned all {department} recommendations."  # /PS-IGNORE
+    return f" declined to {senior_text}countersign {department} recommendations."  # /PS-IGNORE

--- a/api/audit_trail/formatters.py
+++ b/api/audit_trail/formatters.py
@@ -286,21 +286,21 @@ def generate_decision_letter(**payload):
     return f"invalid decision {decision} for this event."
 
 
-def create_lu_advice(advice_type, **payload):  # /PS-IGNORE
+def create_lu_advice(advice_type, **payload):
     if advice_type == AdviceType.PROVISO:
-        return " added a licence condition."  # /PS-IGNORE
-    return f" added a recommendation to {advice_type}."  # /PS-IGNORE
+        return " added a licence condition."
+    return f" added a recommendation to {advice_type}."
 
 
-def update_lu_advice(advice_type, **payload):  # /PS-IGNORE
+def update_lu_advice(advice_type, **payload):
     if advice_type == AdviceType.PROVISO:
-        return " edited a licence condition."  # /PS-IGNORE
+        return " edited a licence condition."
     advice_type_noun = {AdviceType.APPROVE: "approval", AdviceType.REFUSE: "refusal"}[advice_type]
-    return f" edited their {advice_type_noun} reason."  # /PS-IGNORE
+    return f" edited their {advice_type_noun} reason."
 
 
-def lu_countersign_advice(department, order, countersign_accepted, **payload):  # /PS-IGNORE
+def lu_countersign_advice(department, order, countersign_accepted, **payload):
     senior_text = "senior " if order == CountersignOrder.SECOND_COUNTERSIGN else ""
     if countersign_accepted:
-        return f" {senior_text}countersigned all {department} recommendations."  # /PS-IGNORE
-    return f" declined to {senior_text}countersign {department} recommendations."  # /PS-IGNORE
+        return f" {senior_text}countersigned all {department} recommendations."
+    return f" declined to {senior_text}countersign {department} recommendations."

--- a/api/audit_trail/tests/test_formatters.py
+++ b/api/audit_trail/tests/test_formatters.py
@@ -469,42 +469,38 @@ class FormattersTest(DataTestClient):
 
     @parameterized.expand(
         [
-            ("Test", "User", AdviceType.APPROVE, "Test User added a recommendation to approve."),
-            ("Dark", "Knight", AdviceType.REFUSE, "Dark Knight added a recommendation to refuse."),
-            ("Robin", "Hood", AdviceType.PROVISO, "Robin Hood added a licence condition."),
+            (AdviceType.APPROVE, " added a recommendation to approve."),
+            (AdviceType.REFUSE, " added a recommendation to refuse."),
+            (AdviceType.PROVISO, " added a licence condition."),
         ]
     )
-    def test_create_lu_advice(self, first, last, advice_status, expected_text):
-        result = formatters.create_lu_advice(first, last, advice_status)
+    def test_create_lu_advice(self, advice_status, expected_text):
+        result = formatters.create_lu_advice(advice_status)
         assert result == expected_text
 
     @parameterized.expand(
         [
-            ("Test", "User", AdviceType.APPROVE, "Test User edited their approval reason."),
-            ("Dark", "Knight", AdviceType.REFUSE, "Dark Knight edited their refusal reason."),
-            ("Robin", "Hood", AdviceType.PROVISO, "Robin Hood edited a licence condition."),
+            (AdviceType.APPROVE, " edited their approval reason."),
+            (AdviceType.REFUSE, " edited their refusal reason."),
+            (AdviceType.PROVISO, " edited a licence condition."),
         ]
     )
-    def test_update_lu_advice(self, first, last, advice_status, expected_text):
-        result = formatters.update_lu_advice(
-            first, last, advice_status, other_param="ignore_other_params"
-        )  # /PS-IGNORE
+    def test_update_lu_advice(self, advice_status, expected_text):
+        result = formatters.update_lu_advice(advice_status, other_param="ignore_other_params")  # /PS-IGNORE
         assert result == expected_text
 
     @parameterized.expand(
         [
-            ("Test", "User", "DIT", 1, True, "Test User countersigned all DIT recommendations."),
-            ("Sweeney", "Todd", "MOD", 1, True, "Sweeney Todd countersigned all MOD recommendations."),
-            ("Black", "Beard", "DIT", 1, False, "Black Beard declined to countersign DIT recommendations."),
-            ("Calico", "Jack", "MOD", 1, False, "Calico Jack declined to countersign MOD recommendations."),
-            ("Test", "User", "DIT", 2, True, "Test User senior countersigned all DIT recommendations."),
-            ("Sweeney", "Todd", "MOD", 2, True, "Sweeney Todd senior countersigned all MOD recommendations."),
-            ("Black", "Beard", "DIT", 2, False, "Black Beard declined to senior countersign DIT recommendations."),
-            ("Calico", "Jack", "MOD", 2, False, "Calico Jack declined to senior countersign MOD recommendations."),
+            ("DIT", 1, True, " countersigned all DIT recommendations."),
+            ("MOD", 1, True, " countersigned all MOD recommendations."),
+            ("DIT", 1, False, " declined to countersign DIT recommendations."),
+            ("MOD", 1, False, " declined to countersign MOD recommendations."),
+            ("DIT", 2, True, " senior countersigned all DIT recommendations."),
+            ("MOD", 2, True, " senior countersigned all MOD recommendations."),
+            ("DIT", 2, False, " declined to senior countersign DIT recommendations."),
+            ("MOD", 2, False, " declined to senior countersign MOD recommendations."),
         ]
     )
-    def test_lu_countersign_advice(self, first, last, dept, order, countersign_accepted, expected_text):
-        result = formatters.lu_countersign_advice(
-            first, last, dept, order, countersign_accepted, other_param="ignore_other_params"
-        )
+    def test_lu_countersign_advice(self, dept, order, countersign_accepted, expected_text):
+        result = formatters.lu_countersign_advice(dept, order, countersign_accepted, other_param="ignore_other_params")
         assert result == expected_text

--- a/api/cases/tests/test_create_advice.py
+++ b/api/cases/tests/test_create_advice.py
@@ -228,9 +228,9 @@ class CreateCaseAdviceTests(DataTestClient):
 
     @parameterized.expand(
         [
-            [AdviceType.APPROVE, "John Smith added a recommendation to approve."],
-            [AdviceType.REFUSE, "John Smith added a recommendation to refuse."],
-            [AdviceType.PROVISO, "John Smith added a licence condition."],
+            [AdviceType.APPROVE, " added a recommendation to approve."],
+            [AdviceType.REFUSE, " added a recommendation to refuse."],
+            [AdviceType.PROVISO, " added a licence condition."],
         ]
     )
     @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
@@ -275,9 +275,9 @@ class CreateCaseAdviceTests(DataTestClient):
 
     @parameterized.expand(
         [
-            [AdviceType.APPROVE, "John Smith edited their approval reason."],
-            [AdviceType.REFUSE, "John Smith edited their refusal reason."],
-            [AdviceType.PROVISO, "John Smith edited a licence condition."],
+            [AdviceType.APPROVE, " edited their approval reason."],
+            [AdviceType.REFUSE, " edited their refusal reason."],
+            [AdviceType.PROVISO, " edited a licence condition."],
         ]
     )
     @override_settings(FEATURE_COUNTERSIGN_ROUTING_ENABLED=True)
@@ -491,28 +491,28 @@ class CountersignAdviceWithDecisionTests(DataTestClient):
                 CountersignOrder.FIRST_COUNTERSIGN,
                 True,
                 "Accepted reason",
-                "John Smith countersigned all DIT recommendations.",
+                " countersigned all DIT recommendations.",
             ],
             [
                 None,
                 CountersignOrder.FIRST_COUNTERSIGN,
                 False,
                 "Refused reason",
-                "John Smith declined to countersign department recommendations.",
+                " declined to countersign department recommendations.",
             ],
             [
                 None,
                 CountersignOrder.SECOND_COUNTERSIGN,
                 True,
                 "Senior accepted reason",
-                "John Smith senior countersigned all department recommendations.",
+                " senior countersigned all department recommendations.",
             ],
             [
                 "MOD",
                 CountersignOrder.SECOND_COUNTERSIGN,
                 False,
                 "Senior refused reason",
-                "John Smith declined to senior countersign MOD recommendations.",
+                " declined to senior countersign MOD recommendations.",
             ],
         ]
     )


### PR DESCRIPTION
### Aim

Duplicate names were appearing in the audit logs. This is caused by the name in the template as well as being automatically prepended to messages in the timeline view.

[LTD-3485](https://uktrade.atlassian.net/browse/LTD-3485)

[LTD-3485]: https://uktrade.atlassian.net/browse/LTD-3485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ