### PR TITLE
fix-django-docker-caching-issue 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.7-slim
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 RUN apt-get update --fix-missing
 RUN apt-get install -y libpq-dev gcc \


### PR DESCRIPTION
When running docker on my machine I have to rebuild the containers for any changes to take effect.
This prevents that issue by no caching settings for python. 