### PR TITLE
Add test for getting a copied cases details

### DIFF
--- a/api/cases/tests/test_get_case.py
+++ b/api/cases/tests/test_get_case.py
@@ -19,6 +19,28 @@ class CaseGetTests(DataTestClient):
         super().setUp()
         self.standard_application = self.create_draft_standard_application(self.organisation)
 
+    def test_case_endpoint_responds_ok(self):
+        case = self.submit_application(self.standard_application)
+        url = reverse("cases:case", kwargs={"pk": case.id})
+
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_case_copy_of_another_case_endpoint_responds_ok(self):
+        self.submit_application(self.standard_application)
+
+        copied_case = self.create_draft_standard_application(self.organisation)
+        copied_case.copy_of = self.standard_application
+        copied_case.save()
+        self.submit_application(copied_case)
+
+        url = reverse("cases:case", kwargs={"pk": copied_case.id})
+
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_case_returns_expected_third_party(self):
         """
         Given a case with a third party exists

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -125,7 +125,6 @@ class CaseDetail(APIView):
                 "queues",
                 "copy_of",
                 "copy_of__status",
-                "copy_of__status__status",
             ],
             select_related=[
                 "case_type",


### PR DESCRIPTION
### Aim

This fixes a production issue where the case details page isn't loading when an application is a copy of another.

There is a prefetch related call that can't actually be prefetch related and so I've removed it.

[LTD-3637](https://uktrade.atlassian.net/browse/LTD-3637)


[LTD-3637]: https://uktrade.atlassian.net/browse/LTD-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ