### PR TITLE
[LTD-3626] Add goods/denials/queries/end use to cases search response

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -262,7 +262,7 @@ class CaseManager(models.Manager):
         """
         case_qs = (
             self.submitted()
-            .select_related("status", "case_type")
+            .select_related("status", "case_type", "baseapplication")
             .prefetch_related(
                 "case_assignments",
                 "case_assignments__user",

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 
 from api.applications.libraries.get_applications import get_application
 from api.applications.serializers.advice import AdviceViewSerializer, CountersignDecisionAdviceViewSerializer
+from api.applications.models import BaseApplication
 from api.audit_trail.models import Audit
 from api.cases.enums import (
     CaseTypeTypeEnum,
@@ -124,6 +125,7 @@ class CaseListSerializer(serializers.Serializer):
     next_review_date = serializers.DateField()
     has_open_queries = serializers.BooleanField()
     case_officer = serializers.SerializerMethodField()
+    intended_end_use = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         self.team = kwargs.pop("team", None)
@@ -163,6 +165,12 @@ class CaseListSerializer(serializers.Serializer):
                 "last_name": instance.case_officer.last_name,
                 "email": instance.case_officer.email,
             }
+
+    def get_intended_end_use(self, instance):
+        try:
+            return instance.baseapplication.intended_end_use or ""
+        except BaseApplication.DoesNotExist:
+            return ""
 
 
 class CaseCopyOfSerializer(serializers.ModelSerializer):

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -189,7 +189,12 @@ class GoodOnApplicationSummarySerializer(serializers.Serializer):
         return [regime_entry.name for regime_entry in instance.regime_entries.all()]
 
 
-class DenialSummarySerializer(serializers.Serializer):
+class DenialMatchOnApplicationSummarySerializer(serializers.Serializer):
+    """
+    Serializer for a DenialMatchOnApplication and fields from the related Denial
+    record.
+    """
+
     name = serializers.CharField(source="denial.name")
     reference = serializers.CharField(source="denial.reference")
     category = serializers.CharField()

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -173,6 +173,48 @@ class CaseListSerializer(serializers.Serializer):
             return ""
 
 
+class GoodOnApplicationSummarySerializer(serializers.Serializer):
+    name = serializers.CharField()
+    cles = serializers.SerializerMethodField()
+    report_summary_subject = serializers.CharField(source="report_summary_subject.name", default=None)
+    report_summary_prefix = serializers.CharField(source="report_summary_prefix.name", default=None)
+    quantity = serializers.DecimalField(max_digits=None, decimal_places=2)
+    value = serializers.DecimalField(max_digits=None, decimal_places=2)
+    regimes = serializers.SerializerMethodField()
+
+    def get_cles(self, instance):
+        return [cle.rating for cle in instance.control_list_entries.all()]
+
+    def get_regimes(self, instance):
+        return [regime_entry.name for regime_entry in instance.regime_entries.all()]
+
+
+class DenialSummarySerializer(serializers.Serializer):
+    name = serializers.CharField(source="denial.name")
+    reference = serializers.CharField(source="denial.reference")
+    category = serializers.CharField()
+    address = serializers.CharField(source="denial.address")
+
+
+class ECJUQuerySummarySerializer(serializers.Serializer):
+    question = serializers.CharField()
+    response = serializers.CharField()
+    raised_by_user = serializers.SerializerMethodField()
+    responded_by_user = serializers.SerializerMethodField()
+    query_type = serializers.CharField()
+
+    def _user_name(self, user):
+        if not user:
+            return None
+        return f"{user.first_name} {user.last_name}" if (user.first_name and user.last_name) else user.email
+
+    def get_raised_by_user(self, instance):
+        return self._user_name(instance.raised_by_user)
+
+    def get_responded_by_user(self, instance):
+        return self._user_name(instance.responded_by_user)
+
+
 class CaseCopyOfSerializer(serializers.ModelSerializer):
     class Meta:
         model = Case

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -28,6 +28,7 @@ from api.queues.tests.factories import QueueFactory
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.staticdata.control_list_entries.models import ControlListEntry
 from api.staticdata.regimes.models import RegimeEntry
+from api.staticdata.report_summaries.tests.factories import ReportSummaryPrefixFactory, ReportSummarySubjectFactory
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from api.users.tests.factories import GovUserFactory
 from test_helpers.clients import DataTestClient
@@ -647,6 +648,8 @@ class SearchAPITest(DataTestClient):
         self.denial_on_application = DenialMatchOnApplicationFactory(
             application=self.application, category="exact", denial=self.denial
         )
+        prefix = ReportSummaryPrefixFactory()
+        subject = ReportSummarySubjectFactory()
         self.good = GoodFactory(organisation=self.case.organisation)
         self.good_on_application = GoodOnApplicationFactory(
             application=self.application,
@@ -654,6 +657,8 @@ class SearchAPITest(DataTestClient):
             is_good_controlled=True,
             quantity=10,
             value=20,
+            report_summary_subject=subject,
+            report_summary_prefix=prefix,
         )
         self.good_on_application.control_list_entries.add(ControlListEntry.objects.first())
         self.good_on_application.regime_entries.add(RegimeEntry.objects.first())
@@ -728,10 +733,10 @@ class SearchAPITest(DataTestClient):
                 {
                     "name": self.good_on_application.name,
                     "cles": [self.good_on_application.control_list_entries.all()[0].rating],
-                    "report_summary_subject": None,
-                    "report_summary_prefix": None,
-                    "quantity": self.good_on_application.quantity,
-                    "value": self.good_on_application.value,
+                    "report_summary_subject": self.good_on_application.report_summary_subject.name,
+                    "report_summary_prefix": self.good_on_application.report_summary_prefix.name,
+                    "quantity": "10.00",
+                    "value": "20.00",
                     "regimes": [self.good_on_application.regime_entries.all()[0].name],
                 }
             ],

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -235,7 +235,7 @@ def populate_denials(case_map):
     )
     for doa in doas:
         case = case_map[str(doa.application_id)]
-        serializer = cases_serializers.DenialSummarySerializer(doa)
+        serializer = cases_serializers.DenialMatchOnApplicationSummarySerializer(doa)
         case["denials"].append(serializer.data)
     return list(case_map.values())
 

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -12,6 +12,7 @@ from api.applications.models import HmrcQuery, PartyOnApplication, GoodOnApplica
 from api.audit_trail.models import Audit
 from api.audit_trail.serializers import AuditSerializer
 from api.cases.enums import CaseTypeEnum, CaseTypeSubTypeEnum, AdviceType
+from api.cases import serializers as cases_serializers
 from api.cases.models import Case, EcjuQuery
 from api.common.dates import working_days_in_range, number_of_days_since, working_hours_in_range
 from api.flags.serializers import CaseListFlagSerializer
@@ -216,16 +217,8 @@ def populate_good_details(case_map):
     )
     for goa in goas:
         case = case_map[str(goa.application_id)]
-        good = {
-            "name": goa.name,
-            "cles": [cle.rating for cle in goa.control_list_entries.all()],
-            "report_summary_subject": goa.report_summary_subject.name if goa.report_summary_subject else None,
-            "report_summary_prefix": goa.report_summary_prefix.name if goa.report_summary_prefix else None,
-            "quantity": goa.quantity,
-            "value": goa.value,
-            "regimes": [regime_entry.name for regime_entry in goa.regime_entries.all()],
-        }
-        case["goods"].append(good)
+        serializer = cases_serializers.GoodOnApplicationSummarySerializer(goa)
+        case["goods"].append(serializer.data)
     return list(case_map.values())
 
 
@@ -242,13 +235,8 @@ def populate_denials(case_map):
     )
     for doa in doas:
         case = case_map[str(doa.application_id)]
-        denial = {
-            "name": doa.denial.name,
-            "reference": doa.denial.reference,
-            "category": doa.category,
-            "address": doa.denial.address,
-        }
-        case["denials"].append(denial)
+        serializer = cases_serializers.DenialSummarySerializer(doa)
+        case["denials"].append(serializer.data)
     return list(case_map.values())
 
 
@@ -268,18 +256,8 @@ def populate_ecju_queries(case_map):
     )
     for query in queries:
         case = case_map[str(query.case_id)]
-        query = {
-            "question": query.question,
-            "response": query.response,
-            "raised_by_user": f"{query.raised_by_user.first_name} {query.raised_by_user.last_name}"
-            if query.raised_by_user
-            else None,
-            "responded_by_user": f"{query.responded_by_user.first_name} {query.responded_by_user.last_name}"
-            if query.responded_by_user
-            else None,
-            "query_type": query.query_type,
-        }
-        case["ecju_queries"].append(query)
+        serializer = cases_serializers.ECJUQuerySummarySerializer(query)
+        case["ecju_queries"].append(serializer.data)
     return list(case_map.values())
 
 

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -8,11 +8,11 @@ from django.db.models.functions import Concat
 from django.utils import timezone
 from api.staticdata.countries.serializers import CountrySerializer
 
-from api.applications.models import HmrcQuery, PartyOnApplication
+from api.applications.models import HmrcQuery, PartyOnApplication, GoodOnApplication, DenialMatchOnApplication
 from api.audit_trail.models import Audit
 from api.audit_trail.serializers import AuditSerializer
 from api.cases.enums import CaseTypeEnum, CaseTypeSubTypeEnum, AdviceType
-from api.cases.models import Case
+from api.cases.models import Case, EcjuQuery
 from api.common.dates import working_days_in_range, number_of_days_since, working_hours_in_range
 from api.flags.serializers import CaseListFlagSerializer
 from api.organisations.models import Organisation
@@ -196,6 +196,91 @@ def populate_destinations(case_map):
         data = serializer.data
         case = case_map[str(poa.application_id)]
         case["destinations"].append({"country": data})
+
+
+def populate_good_details(case_map):
+    for case in case_map.values():
+        case["goods"] = []
+
+    goas = (
+        GoodOnApplication.objects.select_related(
+            "report_summary_subject",
+            "report_summary_prefix",
+            "good",
+        )
+        .prefetch_related(
+            "control_list_entries",
+            "regime_entries",
+        )
+        .filter(application__in=list(case_map.keys()))
+    )
+    for goa in goas:
+        case = case_map[str(goa.application_id)]
+        good = {
+            "name": goa.name,
+            "cles": [cle.rating for cle in goa.control_list_entries.all()],
+            "report_summary_subject": goa.report_summary_subject.name if goa.report_summary_subject else None,
+            "report_summary_prefix": goa.report_summary_prefix.name if goa.report_summary_prefix else None,
+            "quantity": goa.quantity,
+            "value": goa.value,
+            "regimes": [regime_entry.name for regime_entry in goa.regime_entries.all()],
+        }
+        case["goods"].append(good)
+    return list(case_map.values())
+
+
+def populate_denials(case_map):
+    for case in case_map.values():
+        case["denials"] = []
+
+    doas = (
+        DenialMatchOnApplication.objects.select_related(
+            "denial",
+        )
+        .prefetch_related()
+        .filter(application__in=list(case_map.keys()))
+    )
+    for doa in doas:
+        case = case_map[str(doa.application_id)]
+        denial = {
+            "name": doa.denial.name,
+            "reference": doa.denial.reference,
+            "category": doa.category,
+            "address": doa.denial.address,
+        }
+        case["denials"].append(denial)
+    return list(case_map.values())
+
+
+def populate_ecju_queries(case_map):
+    for case in case_map.values():
+        case["ecju_queries"] = []
+
+    queries = (
+        EcjuQuery.objects.select_related(
+            "raised_by_user",
+            "responded_by_user",
+            "raised_by_user__baseuser_ptr",
+            "responded_by_user__baseuser_ptr",
+        )
+        .prefetch_related()
+        .filter(case_id__in=list(case_map.keys()))
+    )
+    for query in queries:
+        case = case_map[str(query.case_id)]
+        query = {
+            "question": query.question,
+            "response": query.response,
+            "raised_by_user": f"{query.raised_by_user.first_name} {query.raised_by_user.last_name}"
+            if query.raised_by_user
+            else None,
+            "responded_by_user": f"{query.responded_by_user.first_name} {query.responded_by_user.last_name}"
+            if query.responded_by_user
+            else None,
+            "query_type": query.query_type,
+        }
+        case["ecju_queries"].append(query)
+    return list(case_map.values())
 
 
 def populate_activity_updates(case_map):

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -78,6 +78,9 @@ class CasesSearchView(generics.ListAPIView):
         service.get_hmrc_sla_hours(cases)
         service.populate_activity_updates(case_map)
         service.populate_destinations(case_map)
+        service.populate_good_details(case_map)
+        service.populate_denials(case_map)
+        service.populate_ecju_queries(case_map)
 
         # Get queue from system & my queues.
         # If this fails (i.e. I'm on a non team queue) fetch the queue data


### PR DESCRIPTION
### Aim

This change adds the following fields to the cases search response;
- `goods` - details of the goods present on the case
- `denials` - details of denial matches for the case
- `ecju_queries` - details of ECJU queries present on the case
- `intended_end_use` - the intended end use picked out from the case's related application model

This is used in the companion frontend PR: https://github.com/uktrade/lite-frontend/pull/1255

[LTD-3626](https://uktrade.atlassian.net/browse/LTD-3626)


[LTD-3626]: https://uktrade.atlassian.net/browse/LTD-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ