### PR TITLE
 LTD-3654-pull-mentions-data 

### DIFF
--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -306,6 +306,11 @@ class CaseNoteMentionsSerializer(serializers.ModelSerializer):
     user = PrimaryKeyRelatedSerializerField(
         queryset=GovUser.objects.all(), serializer=GovUserViewSerializer, required=False
     )
+    case_note_user = PrimaryKeyRelatedSerializerField(
+        queryset=BaseUser.objects.all(), source="case_note.user", serializer=BaseUserViewSerializer, required=False
+    )
+    is_urgent = serializers.BooleanField(source="case_note.is_urgent", required=False)
+    case_note_text = serializers.CharField(source="case_note.text", required=False)
 
     class Meta:
         model = CaseNoteMentions
@@ -314,6 +319,10 @@ class CaseNoteMentionsSerializer(serializers.ModelSerializer):
             "team",
             "is_accessed",
             "user",
+            "created_at",
+            "case_note_user",
+            "is_urgent",
+            "case_note_text",
         )
 
 

--- a/api/cases/tests/test_case_notes.py
+++ b/api/cases/tests/test_case_notes.py
@@ -20,7 +20,6 @@ class CaseNotesGovCreateTests(DataTestClient):
 
     def test_create_case_note_successful(self):
         response = self.client.post(self.url, data=self.data, **self.gov_headers)
-
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(CaseNote.objects.count(), 1)
         self.assertEqual(CaseNote.objects.get().text, self.data.get("text"))
@@ -167,3 +166,22 @@ class CaseNotesViewTests(DataTestClient):
 
         response = self.client.get(reverse("cases:activity", kwargs={"pk": case.id}), **self.gov_headers)
         self.assertIn(text, str(response.json()))
+
+
+class CaseNoteMentionsViewTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.case = self.create_clc_query("Query", self.organisation)
+        self.url = reverse("cases:case_note_mentions", kwargs={"pk": self.case.id})
+
+    def test_view_case_mentions_successful(self):
+
+        case_note = self.create_case_note(self.case, "Hairpin Turns", self.gov_user.baseuser_ptr)
+        self.other_user = self.create_gov_user("test@gmail.com", self.team)  # /PS-IGNORE
+        self.create_case_note_mention(case_note, self.other_user)
+        response = self.client.get(self.url, **self.gov_headers)
+        result = response.json()
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["user"]["id"], str(self.other_user.baseuser_ptr.id))
+        self.assertEqual(result["results"][0]["case_note_user"]["id"], str(self.gov_user.baseuser_ptr.id))

--- a/api/cases/tests/test_case_notes.py
+++ b/api/cases/tests/test_case_notes.py
@@ -42,14 +42,14 @@ class CaseNotesGovCreateTests(DataTestClient):
         self.data["mentions"] = mentions
         response = self.client.post(self.url, data=self.data, **self.gov_headers)
 
-        assert response.status_code == status.HTTP_201_CREATED
-        assert CaseNote.objects.count() == 1
-        assert CaseNote.objects.get().text == self.data.get("text")
-        assert CaseNote.objects.get().is_visible_to_exporter is False
-        assert CaseNote.objects.get().is_urgent is True
-        assert CaseNoteMentions.objects.count() == 2
-        assert response.json()["case_note"]["mentions"][0]["user"]["id"] == mentions[0]["user"]
-        assert response.json()["case_note"]["mentions"][1]["user"]["id"] == mentions[1]["user"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(CaseNote.objects.count(), 1)
+        self.assertEqual(CaseNote.objects.get().text, self.data.get("text"))
+        self.assertEqual(CaseNote.objects.get().is_visible_to_exporter, False)
+        self.assertEqual(CaseNote.objects.get().is_urgent, True)
+        self.assertEqual(CaseNoteMentions.objects.count(), 2)
+        self.assertEqual(response.json()["case_note"]["mentions"][0]["user"]["id"], mentions[0]["user"])
+        self.assertEqual(response.json()["case_note"]["mentions"][1]["user"]["id"], mentions[1]["user"])
 
     def test_create_case_note_with_mentions_unsuccessful(self):
 
@@ -188,6 +188,9 @@ class CaseNoteMentionsViewTests(DataTestClient):
         response = self.client.get(self.url, **self.gov_headers)
         result = response.json()
 
-        assert result["count"] == 1
-        assert result["results"][0]["user"]["id"] == str(self.other_user.baseuser_ptr.id)
-        assert result["results"][0]["case_note_user"]["id"] == str(self.gov_user.baseuser_ptr.id)
+        self.assertEqual(result["count"], 1)
+
+        self.assertEqual(result["results"][0]["user"]["id"], str(self.other_user.baseuser_ptr.id))
+        self.assertEqual(result["results"][0]["case_note_user"]["id"], str(self.gov_user.baseuser_ptr.id))
+        self.assertEqual(result["results"][0]["case_note_text"], case_note.text)
+        self.assertEqual(result["results"][0]["is_urgent"], case_note.is_urgent)

--- a/api/cases/tests/test_case_notes.py
+++ b/api/cases/tests/test_case_notes.py
@@ -29,21 +29,27 @@ class CaseNotesGovCreateTests(DataTestClient):
 
         self.data["is_urgent"] = True
         self.other_user = self.create_gov_user("test@gmail.com", self.team)  # /PS-IGNORE
+        self.other_user_2 = self.create_gov_user("test2@gmail.com", self.team)  # /PS-IGNORE
+
         mentions = [
             {
                 "user": str(self.other_user.baseuser_ptr.id),
-            }
+            },
+            {
+                "user": str(self.other_user_2.baseuser_ptr.id),
+            },
         ]
         self.data["mentions"] = mentions
         response = self.client.post(self.url, data=self.data, **self.gov_headers)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(CaseNote.objects.count(), 1)
-        self.assertEqual(CaseNote.objects.get().text, self.data.get("text"))
-        self.assertEqual(CaseNote.objects.get().is_visible_to_exporter, False)
-        self.assertEqual(CaseNote.objects.get().is_urgent, True)
-        self.assertEqual(CaseNoteMentions.objects.count(), 1)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert CaseNote.objects.count() == 1
+        assert CaseNote.objects.get().text == self.data.get("text")
+        assert CaseNote.objects.get().is_visible_to_exporter is False
+        assert CaseNote.objects.get().is_urgent is True
+        assert CaseNoteMentions.objects.count() == 2
         assert response.json()["case_note"]["mentions"][0]["user"]["id"] == mentions[0]["user"]
+        assert response.json()["case_note"]["mentions"][1]["user"]["id"] == mentions[1]["user"]
 
     def test_create_case_note_with_mentions_unsuccessful(self):
 
@@ -182,6 +188,6 @@ class CaseNoteMentionsViewTests(DataTestClient):
         response = self.client.get(self.url, **self.gov_headers)
         result = response.json()
 
-        self.assertEqual(result["count"], 1)
-        self.assertEqual(result["results"][0]["user"]["id"], str(self.other_user.baseuser_ptr.id))
-        self.assertEqual(result["results"][0]["case_note_user"]["id"], str(self.gov_user.baseuser_ptr.id))
+        assert result["count"] == 1
+        assert result["results"][0]["user"]["id"] == str(self.other_user.baseuser_ptr.id)
+        assert result["results"][0]["case_note_user"]["id"] == str(self.gov_user.baseuser_ptr.id)

--- a/api/cases/urls.py
+++ b/api/cases/urls.py
@@ -101,4 +101,5 @@ urlpatterns = [
     ),
     # Good precedents
     path("<uuid:pk>/good-precedents/", views.GoodOnPrecedentList.as_view(), name="good_precedents"),
+    path("<uuid:pk>/case-note-mentions/", views.CaseNoteMentionList.as_view(), name="case_note_mentions"),
 ]

--- a/api/cases/urls.py
+++ b/api/cases/urls.py
@@ -101,5 +101,5 @@ urlpatterns = [
     ),
     # Good precedents
     path("<uuid:pk>/good-precedents/", views.GoodOnPrecedentList.as_view(), name="good_precedents"),
-    path("<uuid:pk>/case-note-mentions/", views.CaseNoteMentionList.as_view(), name="case_note_mentions"),
+    path("<uuid:pk>/case-note-mentions/", case_notes.CaseNoteMentionList.as_view(), name="case_note_mentions"),
 ]

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -22,7 +22,6 @@ class CaseNoteList(APIView):
         """Gets all case notes."""
         is_user_exporter = hasattr(request.user, "exporteruser")
         case_notes = get_case_notes_from_case(pk, only_show_notes_visible_to_exporter=is_user_exporter)
-
         if is_user_exporter:
             delete_exporter_notifications(
                 user=request.user.exporteruser,
@@ -46,9 +45,9 @@ class CaseNoteList(APIView):
         mentions_data = data.pop("mentions", None)
         data["case"] = str(case.id)
         data["user"] = str(request.user.pk)
+
         serializer = self.serializer(data=data)
         returned_data = {}
-
         if serializer.is_valid():
             serializer.save()
             returned_data = serializer.data

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -85,7 +85,9 @@ class CaseNoteMentionList(ListAPIView):
     def get_queryset(self):
         return (
             CaseNoteMentions.objects.select_related(
-                "case_note", "user", "case_note__user", "case_note__text", "case_note__is_urgent"
+                "case_note",
+                "user",
+                "case_note__user",
             )
             .filter(case_note__case_id=self.kwargs["pk"])
             .order_by("-created_at")

--- a/api/cases/views/search/activity.py
+++ b/api/cases/views/search/activity.py
@@ -26,7 +26,6 @@ class CaseActivityView(APIView):
         # Delete notifications related to audits
         if isinstance(request.user, GovUser):
             delete_gov_user_notifications(request.user, [obj["id"] for obj in data])
-
         return JsonResponse(data={"activity": data}, status=status.HTTP_200_OK)
 
 

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -48,6 +48,7 @@ from api.cases.models import (
     GoodCountryDecision,
     CaseAssignment,
     CaseReviewDate,
+    CaseNoteMentions,
 )
 from api.cases.notify import (
     notify_exporter_licence_issued,
@@ -67,6 +68,7 @@ from api.cases.serializers import (
     EcjuQueryExporterRespondSerializer,
     EcjuQueryDocumentCreateSerializer,
     EcjuQueryDocumentViewSerializer,
+    CaseNoteMentionsSerializer,
 )
 from api.cases.service import get_destinations
 from api.compliance.helpers import generate_compliance_site_case
@@ -1162,3 +1164,11 @@ class GoodOnPrecedentList(ListAPIView):
                 "control_list_entries",
             )
         )
+
+
+class CaseNoteMentionList(ListAPIView):
+    authentication_classes = (GovAuthentication,)
+    serializer_class = CaseNoteMentionsSerializer
+
+    def get_queryset(self):
+        return CaseNoteMentions.objects.filter(case_note__case_id=self.kwargs["pk"]).order_by("-created_at")

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -48,7 +48,6 @@ from api.cases.models import (
     GoodCountryDecision,
     CaseAssignment,
     CaseReviewDate,
-    CaseNoteMentions,
 )
 from api.cases.notify import (
     notify_exporter_licence_issued,
@@ -68,7 +67,6 @@ from api.cases.serializers import (
     EcjuQueryExporterRespondSerializer,
     EcjuQueryDocumentCreateSerializer,
     EcjuQueryDocumentViewSerializer,
-    CaseNoteMentionsSerializer,
 )
 from api.cases.service import get_destinations
 from api.compliance.helpers import generate_compliance_site_case
@@ -1164,11 +1162,3 @@ class GoodOnPrecedentList(ListAPIView):
                 "control_list_entries",
             )
         )
-
-
-class CaseNoteMentionList(ListAPIView):
-    authentication_classes = (GovAuthentication,)
-    serializer_class = CaseNoteMentionsSerializer
-
-    def get_queryset(self):
-        return CaseNoteMentions.objects.filter(case_note__case_id=self.kwargs["pk"]).order_by("-created_at")

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -44,6 +44,7 @@ from api.cases.models import (
     EcjuQuery,
     CaseType,
     Advice,
+    CaseNoteMentions,
 )
 from api.cases.tasks import get_application_target_sla
 from django.conf import settings
@@ -288,6 +289,12 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
         case_note = CaseNote(case=case, text=text, user=user, is_visible_to_exporter=is_visible_to_exporter)
         case_note.save()
         return case_note
+
+    @staticmethod
+    def create_case_note_mention(case_note: CaseNote, user: GovUser):
+        case_note_mention = CaseNoteMentions(case_note=case_note, user=user)
+        case_note_mention.save()
+        return case_note_mention
 
     @staticmethod
     def create_queue(name: str, team: Team):


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-3654

This API call has been linked with the notes and timelines screen. 

The mentions portion will pull the mentions on a screen and display as per requirements. We could have used the same data shape as the Audit Table but I believe this is fundamentally wrong and a bit of a hack. Hence a new API call to pull real data from the source table. 