### PR TITLE
LTD-3686: Ignore deleted parties when determining Case parameter_set

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -209,7 +209,7 @@ class Case(TimestampableModel):
 
         parameter_set = set(self.flags.all()) | {self.case_type} | set(self.organisation.flags.all())
 
-        for poa in PartyOnApplication.objects.filter(application=self.id):
+        for poa in PartyOnApplication.objects.filter(application=self.id, deleted_at__isnull=True):
             parameter_set = (
                 parameter_set | {poa.party.country} | set(poa.party.flags.all()) | set(poa.party.country.flags.all())
             )

--- a/api/cases/tests/test_get_case.py
+++ b/api/cases/tests/test_get_case.py
@@ -2,8 +2,9 @@ from django.urls import reverse
 from parameterized import parameterized
 from rest_framework import status
 
-from api.applications.models import CountryOnApplication
+from api.applications.models import CountryOnApplication, PartyOnApplication
 from api.cases.enums import CaseTypeEnum
+from api.cases.models import Case
 from api.cases.tests.factories import CaseAssignmentFactory, FinalAdviceFactory, CountersignAdviceFactory
 from api.flags.enums import SystemFlags
 from api.flags.models import Flag
@@ -12,6 +13,8 @@ from api.parties.enums import PartyType
 from api.staticdata.countries.helpers import get_country
 from api.staticdata.trade_control.enums import TradeControlActivity, TradeControlProductCategory
 from test_helpers.clients import DataTestClient
+
+from lite_routing.routing_rules_internal.enums import FlagsEnum
 
 
 class CaseGetTests(DataTestClient):
@@ -272,3 +275,16 @@ class CaseGetTests(DataTestClient):
             ordered_ultimate_end_users,
             [str(first_ueu.id), str(second_ueu.id), str(fourth_ueu.id), str(third_ueu.id)],
         )
+
+    def test_case_parameter_set_ignores_deleted_parties(self):
+        application = self.submit_application(self.standard_application)
+        case = Case.objects.get(id=application.id)
+
+        end_user = PartyOnApplication.objects.get(application=application, party__type=PartyType.END_USER)
+        end_user.party.flags.add(Flag.objects.get(id=FlagsEnum.AUSTRALIA_GROUP_CW))
+        consignee = PartyOnApplication.objects.get(application=application, party__type=PartyType.END_USER)
+        consignee.party.flags.add(Flag.objects.get(id=FlagsEnum.LU_COUNTER_REQUIRED))
+        self.assertIn(Flag.objects.get(id=FlagsEnum.LU_COUNTER_REQUIRED), case.parameter_set())
+
+        consignee.delete()
+        self.assertNotIn(Flag.objects.get(id=FlagsEnum.LU_COUNTER_REQUIRED), case.parameter_set())


### PR DESCRIPTION
### Aim

Case parameter_set() is used to check for countersigning flags and if they are present we ensure necessary countersignatures are present when the case is finalised. However it currently doesn't ignore any deleted parties on the application. If that party destination is the only one that needs countersigning then can block finalising even though that party is deleted.

Ignore deleted parties as they are no longer valid on the application.
