### PR TITLE
 LTD-3699-is-new-reset 

### DIFF
--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -372,6 +372,13 @@ class CaseDetailSerializer(serializers.ModelSerializer):
             pass
 
 
+class CaseNoteMentionsListSerializer(serializers.ListSerializer):
+    def update(self, instances, validated_data):
+        instance_map = {index: instance for index, instance in enumerate(instances)}
+        result = [self.child.update(instance_map[index], data) for index, data in enumerate(validated_data)]
+        return result
+
+
 class CaseNoteMentionsSerializer(serializers.ModelSerializer):
     """
     Serializes case notes mentions
@@ -398,7 +405,9 @@ class CaseNoteMentionsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CaseNoteMentions
+        list_serializer_class = CaseNoteMentionsListSerializer
         fields = (
+            "id",
             "case_note",
             "team",
             "is_accessed",

--- a/api/cases/tests/test_case_notes.py
+++ b/api/cases/tests/test_case_notes.py
@@ -266,24 +266,27 @@ class UserCaseNoteMentionsViewTests(DataTestClient):
 
         case_note_mention = self.create_case_note_mention(self.case_note, self.gov_user)
         case_note_mention_2 = self.create_case_note_mention(self.case_note, self.gov_user)
+        case_note_mention_2.is_accessed = True
+        case_note_mention_2.save()
+
         self.assertEqual(case_note_mention.is_accessed, False)
-        self.assertEqual(case_note_mention_2.is_accessed, False)
+        self.assertEqual(case_note_mention_2.is_accessed, True)
 
         url = reverse("cases:case_note_mentions")
         update_data = [
             {"id": case_note_mention.pk, "is_accessed": True},
-            {"id": case_note_mention_2.pk, "is_accessed": True},
+            {"id": case_note_mention_2.pk, "is_accessed": False},
         ]
 
         response = self.client.put(url, data=update_data, **self.gov_headers)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         case_note_mention.refresh_from_db()
         case_note_mention_2.refresh_from_db()
 
         self.assertEqual(case_note_mention.is_accessed, True)
-        self.assertEqual(case_note_mention_2.is_accessed, True)
+        self.assertEqual(case_note_mention_2.is_accessed, False)
 
     def test_view_user_case_mentions_update_bad_data(self):
         url = reverse("cases:case_note_mentions")

--- a/api/cases/urls.py
+++ b/api/cases/urls.py
@@ -102,6 +102,7 @@ urlpatterns = [
     # Good precedents
     path("<uuid:pk>/good-precedents/", views.GoodOnPrecedentList.as_view(), name="good_precedents"),
     # Mentions
-    path("<uuid:pk>/case-note-mentions/", case_notes.CaseNoteMentionList.as_view(), name="case_note_mentions"),
+    path("<uuid:pk>/case-note-mentions/", case_notes.CaseNoteMentionList.as_view(), name="case_note_mentions_list"),
     path("user-case-note-mentions/", case_notes.UserCaseNoteMention.as_view(), name="user_case_note_mentions"),
+    path("case-note-mentions/", case_notes.CaseNoteMentionsView.as_view(), name="case_note_mentions"),
 ]

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -116,7 +116,7 @@ class CaseNoteMentionsView(APIView):
             serializer.save()
             return JsonResponse(
                 data={"mentions": serializer.data},
-                status=status.HTTP_201_CREATED,
+                status=status.HTTP_200_OK,
             )
         return JsonResponse(data={"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -2,14 +2,13 @@ from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.generics import ListAPIView
-from rest_framework.exceptions import ValidationError
 
 from api.audit_trail import service
 from api.audit_trail.enums import AuditType
 from api.cases.libraries.get_case import get_case
 from api.cases.libraries.get_case_note import get_case_notes_from_case
 from api.cases.libraries.delete_notifications import delete_exporter_notifications
-from api.cases.serializers import CaseNoteSerializer, CaseNoteMentionsSerializer, CaseNoteMentionsListSerializer
+from api.cases.serializers import CaseNoteSerializer, CaseNoteMentionsSerializer
 from api.core.authentication import SharedAuthentication, GovAuthentication
 from lite_content.lite_api import strings
 from api.organisations.libraries.get_organisation import get_request_user_organisation_id


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-3699

This adds a new end point which allows bulk update of case note mentions. 
Predominantly used to update the is_accessed flag. This is extending a new view ideally the get and patch could be in a single view. However the get is making use of the DRF ListAPIView and the new can't be mixed. 

I will add in a jira to collapse these into a single view. 