### PR TITLE
 LTD-3741-api-call-new-mentions 

### DIFF
--- a/api/cases/tests/test_case_notes.py
+++ b/api/cases/tests/test_case_notes.py
@@ -330,3 +330,18 @@ class UserCaseNoteMentionsViewTests(DataTestClient):
         response = self.client.put(url, data=update_data, **self.gov_headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_view_user_case_mentions_new_count(self):
+
+        url = reverse("cases:user_case_note_mentions_new_count")
+        self.create_case_note_mention(self.case_note, self.gov_user)
+        self.create_case_note_mention(self.case_note, self.other_user)
+        self.create_case_note_mention(self.case_note_other, self.gov_user)
+
+        old_mention = self.create_case_note_mention(self.case_note, self.other_user)
+        old_mention.is_accessed = True
+        old_mention.save()
+
+        response = self.client.get(url, **self.gov_headers)
+
+        self.assertEqual(response.json()["count"], 2)

--- a/api/cases/urls.py
+++ b/api/cases/urls.py
@@ -104,5 +104,10 @@ urlpatterns = [
     # Mentions
     path("<uuid:pk>/case-note-mentions/", case_notes.CaseNoteMentionList.as_view(), name="case_note_mentions_list"),
     path("user-case-note-mentions/", case_notes.UserCaseNoteMention.as_view(), name="user_case_note_mentions"),
+    path(
+        "user-case-note-mentions-new-count/",
+        case_notes.UserCaseNoteMentionsNewCount.as_view(),
+        name="user_case_note_mentions_new_count",
+    ),
     path("case-note-mentions/", case_notes.CaseNoteMentionsView.as_view(), name="case_note_mentions"),
 ]

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -153,3 +153,23 @@ class UserCaseNoteMention(APIView):
         serializer = self.serializer_class(qs, many=True)
 
         return JsonResponse(data={"mentions": serializer.data})
+
+
+class UserCaseNoteMentionsNewCount(APIView):
+    authentication_classes = (GovAuthentication,)
+
+    def get(self, request):
+        """Gets count of all new mentions for user."""
+        qs = (
+            CaseNoteMentions.objects.select_related(
+                "case_note",
+                "user",
+                "case_note__user",
+                "case_note__user__govuser__team",
+                "case_note__case",
+            )
+            .filter(user_id=request.user.pk)
+            .filter(is_accessed=False)
+        )
+
+        return JsonResponse(data={"count": qs.count()})

--- a/api/cases/views/case_notes.py
+++ b/api/cases/views/case_notes.py
@@ -160,16 +160,6 @@ class UserCaseNoteMentionsNewCount(APIView):
 
     def get(self, request):
         """Gets count of all new mentions for user."""
-        qs = (
-            CaseNoteMentions.objects.select_related(
-                "case_note",
-                "user",
-                "case_note__user",
-                "case_note__user__govuser__team",
-                "case_note__case",
-            )
-            .filter(user_id=request.user.pk)
-            .filter(is_accessed=False)
-        )
+        qs = CaseNoteMentions.objects.filter(user_id=request.user.pk, is_accessed=False)
 
         return JsonResponse(data={"count": qs.count()})


### PR DESCRIPTION
A count of new mentions for a user is required in the UI menu.
Hence a light weight API call just to get a count.  I did think about making this more generic or extend one of the other review for filtering. But figured this is used so often and is imperative to the application functioning it's worth having it's own API call. 