### PR TITLE
Set Django admin to be toggled via env variables

### DIFF
--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -47,7 +47,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY")
 DEBUG = env("DEBUG")
 
 # Please use this to Enable/Disable the Admin site
-ADMIN_ENABLED = True
+ADMIN_ENABLED = env("ADMIN_ENABLED", default=False)
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=[])
 

--- a/api/core/tests/test_views.py
+++ b/api/core/tests/test_views.py
@@ -1,23 +1,35 @@
-from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import override_settings, TestCase
 from django.urls import reverse
 
-from django.contrib.auth import get_user_model
+from test_helpers.helpers import reload_urlconf
+
 
 User = get_user_model()
 
 
+@override_settings(ADMIN_ENABLED=True)
 class FlagsUpdateTest(TestCase):
-    def test_login_anonymous_user(self):
+    @override_settings(FEATURE_STAFF_SSO_ENABLED=False)
+    def test_login_anonymous_user_sso_disabled(self):
+        reload_urlconf()
         # when an anonymous user accesses login
         response = self.client.get(reverse("admin:login"))
 
-        if settings.FEATURE_STAFF_SSO_ENABLED:
-            # then they are sent to the staff sso login
-            self.assertRedirects(response, reverse("authbroker_client:login"), fetch_redirect_response=False)
-        else:
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(response, "admin/login.html")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "admin/login.html")
+
+    @override_settings(
+        FEATURE_STAFF_SSO_ENABLED=True,
+        AUTHBROKER_URL="http://example.com/authbroker/",
+    )
+    def test_login_anonymous_user_sso_enabled(self):
+        reload_urlconf()
+        # when an anonymous user accesses login
+        response = self.client.get(reverse("admin:login"))
+
+        # then they are sent to the staff sso login
+        self.assertRedirects(response, reverse("authbroker_client:login"), fetch_redirect_response=False)
 
     @override_settings(ALLOWED_ADMIN_EMAILS=[])
     def test_login_authenticated_user_permission_denied(self):

--- a/test_helpers/helpers.py
+++ b/test_helpers/helpers.py
@@ -1,5 +1,11 @@
-from django.db import IntegrityError
+import sys
+
+from importlib import import_module, reload
+
 from faker import Faker
+
+from django.conf import settings
+from django.urls import clear_url_caches
 
 from api.core.constants import Roles
 from api.flags.enums import SystemFlags
@@ -56,3 +62,12 @@ def node_by_id(items: list, id):
             return item
 
     raise KeyError(f"ID '{id}' not found in list")
+
+
+def reload_urlconf(urlconfs=[settings.ROOT_URLCONF]):
+    clear_url_caches()
+    for urlconf in urlconfs:
+        if urlconf in sys.modules:
+            reload(sys.modules[urlconf])
+        else:
+            import_module(urlconf)


### PR DESCRIPTION
### Aim

Disable Django admin by default. This is to ensure that it's not switched on for environments it shouldn't be whilst retaining the ability for it to be toggled on as required such as for local development.

[LTD-3762](https://uktrade.atlassian.net/browse/LTD-3762)


[LTD-3762]: https://uktrade.atlassian.net/browse/LTD-3762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ