### PR TITLE
Add support for filtering case search by goods_starting_point

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -91,6 +91,9 @@ class CaseQuerySet(models.QuerySet):
     def with_sla_days_elapsed(self, sla_days_elapsed):
         return self.filter(sla_days=sla_days_elapsed)
 
+    def with_goods_starting_point(self, goods_starting_point):
+        return self.filter(baseapplication__standardapplication__goods_starting_point=goods_starting_point)
+
     def with_exporter_site_address(self, exporter_site_address):
         return self.filter(
             Q(baseapplication__application_sites__site__address__address_line_1__icontains=exporter_site_address)
@@ -260,6 +263,7 @@ class CaseManager(models.Manager):
         my_cases=None,
         assigned_queues=None,
         export_type=None,
+        goods_starting_point=None,
         **kwargs,
     ):
         """
@@ -337,6 +341,9 @@ class CaseManager(models.Manager):
 
         if exporter_site_address:
             case_qs = case_qs.with_exporter_site_address(exporter_site_address)
+
+        if goods_starting_point:
+            case_qs = case_qs.with_goods_starting_point(goods_starting_point)
 
         if control_list_entry:
             case_qs = case_qs.with_control_list_entry(control_list_entry)

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -478,12 +478,14 @@ class FilterAndSortTests(DataTestClient):
         response_data = response.json()["results"]["cases"]
         self.assertEqual(len(response_data), 0)
 
-    def test_get_cases_filter_by_goods_starting_point_present_on_application(self):
+    @parameterized.expand(["NI", "GB"])
+    def test_get_cases_filter_by_goods_starting_point_present_on_application(self, starting_point):
         application = self.application_cases[0]
-        application.goods_starting_point = "NI"
+        application.goods_starting_point = starting_point
         application.save()
+        case = Case.objects.get(id=application.id)
 
-        url = f'{reverse("cases:search")}?goods_starting_point=NI'
+        url = f'{reverse("cases:search")}?goods_starting_point={starting_point}&case_reference={case.reference_code}'
         response = self.client.get(url, **self.gov_headers)
         response_data = response.json()["results"]["cases"]
 

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -472,6 +472,25 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response_data), 0)
 
+    def test_get_cases_filter_by_goods_starting_point_not_in_case(self):
+        url = f'{reverse("cases:search")}?goods_starting_point=NI'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+        self.assertEqual(len(response_data), 0)
+
+    def test_get_cases_filter_by_goods_starting_point_present_on_application(self):
+        application = self.application_cases[0]
+        application.goods_starting_point = "NI"
+        application.save()
+
+        url = f'{reverse("cases:search")}?goods_starting_point=NI'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(application.id))
+
 
 class UpdatedCasesQueueTests(DataTestClient):
     def setUp(self):


### PR DESCRIPTION
### Aim

Add capability to cases search endpoint for filtering by ~~`organisation_site_country`~~ `goods_starting_point`