### PR TITLE
[LTD-3799] Queue view parties filters

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -213,6 +213,9 @@ class CaseQuerySet(models.QuerySet):
 
         return self
 
+    def exclude_denial_matches(self):
+        return self.exclude(baseapplication__denial_matches__denial__is_revoked=False)
+
 
 class CaseManager(models.Manager):
     """
@@ -264,6 +267,7 @@ class CaseManager(models.Manager):
         assigned_queues=None,
         export_type=None,
         goods_starting_point=None,
+        exclude_denial_matches=None,
         **kwargs,
     ):
         """
@@ -414,6 +418,9 @@ class CaseManager(models.Manager):
                 case_qs = case_qs.order_by("sla_days")
             else:
                 case_qs = case_qs.order_by("-sla_days")
+
+        if exclude_denial_matches:
+            case_qs = case_qs.exclude_denial_matches()
 
         return case_qs.distinct()
 

--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -216,6 +216,9 @@ class CaseQuerySet(models.QuerySet):
     def exclude_denial_matches(self):
         return self.exclude(baseapplication__denial_matches__denial__is_revoked=False)
 
+    def exclude_sanction_matches(self):
+        return self.exclude(baseapplication__parties__sanction_matches__is_revoked=False)
+
 
 class CaseManager(models.Manager):
     """
@@ -268,6 +271,7 @@ class CaseManager(models.Manager):
         export_type=None,
         goods_starting_point=None,
         exclude_denial_matches=None,
+        exclude_sanction_matches=None,
         **kwargs,
     ):
         """
@@ -421,6 +425,9 @@ class CaseManager(models.Manager):
 
         if exclude_denial_matches:
             case_qs = case_qs.exclude_denial_matches()
+
+        if exclude_sanction_matches:
+            case_qs = case_qs.exclude_sanction_matches()
 
         return case_qs.distinct()
 

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -8,10 +8,11 @@ from rest_framework import status
 from api.audit_trail.models import Audit
 from api.audit_trail.enums import AuditType
 from api.applications.tests.factories import (
-    GoodOnApplicationFactory,
-    StandardApplicationFactory,
     DenialMatchOnApplicationFactory,
     DenialMatchFactory,
+    GoodOnApplicationFactory,
+    StandardApplicationFactory,
+    SanctionMatchFactory,
 )
 from api.cases.enums import CaseTypeEnum
 from api.cases.models import Case, CaseAssignment, EcjuQuery, CaseType
@@ -513,6 +514,31 @@ class FilterAndSortTests(DataTestClient):
         )
         case = Case.objects.get(id=application.id)
         url = f'{reverse("cases:search")}?exclude_denial_matches=True&case_reference={case.reference_code}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 0)
+
+    def test_get_cases_filter_exclude_sanction_matches_no_sanction_match_cases(self):
+        application = self.application_cases[0]
+        case = Case.objects.get(id=application.id)
+        url = f'{reverse("cases:search")}?exclude_sanction_matches=True&case_reference={case.reference_code}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(application.id))
+
+    def test_get_cases_filter_exclude_sanction_matches_sanction_match_excluded(self):
+
+        application = self.application_cases[0]
+        sanction_match = SanctionMatchFactory(
+            party_on_application=application.parties.first(), flag_uuid=Flag.objects.first().id, is_revoked=False
+        )
+        case = Case.objects.get(id=application.id)
+        url = f'{reverse("cases:search")}?exclude_sanction_matches=True&case_reference={case.reference_code}'
         response = self.client.get(url, **self.gov_headers)
         response_data = response.json()["results"]["cases"]
 

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -493,6 +493,32 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(len(response_data), 1)
         self.assertTrue(response_data[0]["id"], str(application.id))
 
+    def test_get_cases_filter_exclude_denial_matches_no_denial_match_cases(self):
+        application = self.application_cases[0]
+        case = Case.objects.get(id=application.id)
+        url = f'{reverse("cases:search")}?exclude_denial_matches=True&case_reference={case.reference_code}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(application.id))
+
+    def test_get_cases_filter_exclude_denial_matches_denial_match_excluded(self):
+
+        application = self.application_cases[0]
+        denial = DenialMatchFactory()
+        denial_on_application = DenialMatchOnApplicationFactory(
+            application=application, category="exact", denial=denial
+        )
+        case = Case.objects.get(id=application.id)
+        url = f'{reverse("cases:search")}?exclude_denial_matches=True&case_reference={case.reference_code}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 0)
+
 
 class UpdatedCasesQueueTests(DataTestClient):
     def setUp(self):


### PR DESCRIPTION
### Aim

Add support for filtering case search results by two extra fields;
- `exclude_denial_matches` - exclude cases which have denial matches.
- `exclude_sanction_matches` - exclude cases which have sanction matches.

[LTD-3799](https://uktrade.atlassian.net/browse/LTD-3799)


[LTD-3799]: https://uktrade.atlassian.net/browse/LTD-3799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ