### PR TITLE
Case search - Report summary support

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -170,6 +170,13 @@ class CaseQuerySet(models.QuerySet):
             | Q(baseapplication__goods_type__report_summary__icontains=goods_related_description)
         )
 
+    def with_report_summary_subject_or_prefix(self, search_string):
+        return self.filter(
+            Q(baseapplication__goods__report_summary_subject__name__icontains=search_string)
+            | Q(baseapplication__goods__report_summary_prefix__name__icontains=search_string)
+            | Q(baseapplication__goods__report_summary__icontains=search_string)
+        )
+
     def with_nca_applicable(self):
         return self.filter(baseapplication__goods__is_nca_applicable=True)
 
@@ -274,6 +281,7 @@ class CaseManager(models.Manager):
         exclude_denial_matches=None,
         exclude_sanction_matches=None,
         max_total_value=None,
+        report_summary=None,
         **kwargs,
     ):
         """
@@ -408,6 +416,9 @@ class CaseManager(models.Manager):
 
         if my_cases:
             case_qs = case_qs.only_my_cases(user)
+
+        if report_summary:
+            case_qs = case_qs.with_report_summary_subject_or_prefix(report_summary)
 
         if is_work_queue:
             case_qs = case_qs.annotate(

--- a/api/goods/tests/factories.py
+++ b/api/goods/tests/factories.py
@@ -22,6 +22,9 @@ class GoodFactory(factory.django.DjangoModelFactory):
     information_security_details = None
     modified_military_use_details = None
     component_details = None
+    report_summary_prefix = None
+    report_summary_subject = None
+    report_summary = None
 
     class Meta:
         model = models.Good


### PR DESCRIPTION
### Aim

Allow cases to be searched by text contained in either report summary prefix or subject for goods on that case.

[LTD-3831](https://uktrade.atlassian.net/browse/LTD-3831)


[LTD-3831]: https://uktrade.atlassian.net/browse/LTD-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ