### PR TITLE
[LTD-3827] Add case search filter for max_total_value

### DIFF
--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -473,6 +473,44 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response_data), 0)
 
+    def test_get_cases_filter_by_max_total_value_no_results(self):
+        case = self.application_cases[0]
+        good = case.baseapplication.goods.first()
+        good.value = 200
+        good.save()
+        url = f'{reverse("cases:search")}?reference_code={case.reference_code}&max_total_value=199'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 0)
+
+    def test_get_cases_filter_by_max_total_value_match(self):
+        case = self.application_cases[0]
+        good = case.baseapplication.goods.first()
+        good.value = 200
+        good.save()
+        url = f'{reverse("cases:search")}?case_reference={case.reference_code}&max_total_value=201'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(case.id))
+
+    def test_get_cases_filter_by_max_total_value_bad_decimal(self):
+        case = self.application_cases[0]
+        good = case.baseapplication.goods.first()
+        good.value = 200
+        good.save()
+        url = f'{reverse("cases:search")}?case_reference={case.reference_code}&max_total_value=foo'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(case.id))
+
     def test_get_cases_filter_by_goods_starting_point_not_in_case(self):
         url = f'{reverse("cases:search")}?goods_starting_point=NI'
         response = self.client.get(url, **self.gov_headers)

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -1,3 +1,5 @@
+from decimal import Decimal, InvalidOperation
+
 import django
 from django.db.models import F, When, DateField, Exists, OuterRef
 from django.http import HttpResponse
@@ -141,6 +143,12 @@ class CasesSearchView(generics.ListAPIView):
         selected_tab = request.GET.get("selected_tab")
         if selected_tab and selected_tab in search_tabs:
             filters[selected_tab] = True
+
+        if "max_total_value" in filters:
+            try:
+                filters["max_total_value"] = Decimal(filters["max_total_value"])
+            except (InvalidOperation, TypeError):
+                del filters["max_total_value"]
 
         filters["flags"] = request.GET.getlist("flags", [])
         filters["regime_entry"] = [regime for regime in request.GET.getlist("regime_entry", []) if regime]


### PR DESCRIPTION
### Aim

Add support for `max_total_value` filter in case search API; enabling callers to get cases who's goods amount to less than this total value.

[LTD-3827](https://uktrade.atlassian.net/browse/LTD-3827)


[LTD-3827]: https://uktrade.atlassian.net/browse/LTD-3827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ