### PR TITLE
[LTD-3899] Add support for filtering by multiple countries in case search API

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -127,6 +127,12 @@ class CaseQuerySet(models.QuerySet):
             | Q(baseapplication__openapplication__application_countries__country_id=country_id)
         )
 
+    def with_countries(self, country_ids):
+        return self.filter(
+            Q(baseapplication__parties__party__country_id__in=country_ids)
+            | Q(baseapplication__openapplication__application_countries__country_id__in=country_ids)
+        )
+
     def with_advice(self, advice_type, level):
         return self.filter(advice__type=advice_type, advice__level=level)
 
@@ -250,6 +256,7 @@ class CaseManager(models.Manager):
         regime_entry=None,
         flags=None,
         country=None,
+        countries=None,
         team_advice_type=None,
         final_advice_type=None,
         min_sla_days_remaining=None,
@@ -365,6 +372,9 @@ class CaseManager(models.Manager):
 
         if country:
             case_qs = case_qs.with_country(country)
+
+        if countries:
+            case_qs = case_qs.with_countries(countries)
 
         if team_advice_type:
             case_qs = case_qs.with_advice(team_advice_type, AdviceLevel.TEAM)

--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -122,16 +122,10 @@ class CaseQuerySet(models.QuerySet):
         return self.filter(id__in=case_ids)
 
     def with_country(self, country_id):
-        return self.filter(
-            Q(baseapplication__parties__party__country_id=country_id)
-            | Q(baseapplication__openapplication__application_countries__country_id=country_id)
-        )
+        return self.filter(Q(baseapplication__parties__party__country_id=country_id))
 
     def with_countries(self, country_ids):
-        return self.filter(
-            Q(baseapplication__parties__party__country_id__in=country_ids)
-            | Q(baseapplication__openapplication__application_countries__country_id__in=country_ids)
-        )
+        return self.filter(Q(baseapplication__parties__party__country_id__in=country_ids))
 
     def with_advice(self, advice_type, level):
         return self.filter(advice__type=advice_type, advice__level=level)

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -13,6 +13,7 @@ from api.applications.tests.factories import (
     GoodOnApplicationFactory,
     StandardApplicationFactory,
     SanctionMatchFactory,
+    PartyOnApplicationFactory,
 )
 from api.cases.enums import CaseTypeEnum
 from api.cases.models import Case, CaseAssignment, EcjuQuery, CaseType
@@ -577,6 +578,58 @@ class FilterAndSortTests(DataTestClient):
         )
         case = Case.objects.get(id=application.id)
         url = f'{reverse("cases:search")}?exclude_sanction_matches=True&case_reference={case.reference_code}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 0)
+
+    @parameterized.expand(
+        [
+            (["NI", "GB"], []),
+            (["NI", "GB"], ["GB"]),
+            (["NI", "GB"], ["NI"]),
+            (["NI", "GB"], ["NI", "GB"]),
+            (["NI", "GB"], ["NI", "GB", "US"]),
+        ]
+    )
+    def test_get_cases_filter_by_countries_match(self, countries_on_application, filter_countries):
+        application = self.application_cases[0]
+        for country in countries_on_application:
+            PartyOnApplicationFactory(application=application, party__country_id=country)
+        case = Case.objects.get(id=application.id)
+
+        params = [f"case_reference={case.reference_code}"]
+        for country in filter_countries:
+            params.append(f"countries={country}")
+        params_raw = "&".join(params)
+
+        url = f'{reverse("cases:search")}?{params_raw}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(application.id))
+
+    @parameterized.expand(
+        [
+            (["NI", "GB"], ["US"]),
+            (["NI", "GB"], ["US", "FR"]),
+        ]
+    )
+    def test_get_cases_filter_by_countries_no_match(self, countries_on_application, filter_countries):
+        application = self.application_cases[0]
+        for country in countries_on_application:
+            PartyOnApplicationFactory(application=application, party__country_id=country)
+        case = Case.objects.get(id=application.id)
+
+        params = [f"case_reference={case.reference_code}"]
+        for country in filter_countries:
+            params.append(f"countries={country}")
+        params_raw = "&".join(params)
+
+        url = f'{reverse("cases:search")}?{params_raw}'
         response = self.client.get(url, **self.gov_headers)
         response_data = response.json()["results"]["cases"]
 

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -636,6 +636,46 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response_data), 0)
 
+    @parameterized.expand(
+        [
+            (["NI", "GB"], ""),
+            (["NI", "GB"], "GB"),
+            (["NI", "GB"], "NI"),
+        ]
+    )
+    def test_get_cases_filter_by_country_match(self, countries_on_application, filter_country):
+        application = self.application_cases[0]
+        for country in countries_on_application:
+            PartyOnApplicationFactory(application=application, party__country_id=country)
+        case = Case.objects.get(id=application.id)
+
+        url = f'{reverse("cases:search")}?case_reference={case.reference_code}&country={filter_country}'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 1)
+        self.assertTrue(response_data[0]["id"], str(application.id))
+
+    @parameterized.expand(
+        [
+            (["NI", "GB"], "US"),
+            (["NI", "GB"], "FR"),
+        ]
+    )
+    def test_get_cases_filter_by_country_no_match(self, countries_on_application, filter_country):
+        application = self.application_cases[0]
+        for country in countries_on_application:
+            PartyOnApplicationFactory(application=application, party__country_id=country)
+        case = Case.objects.get(id=application.id)
+
+        url = f'{reverse("cases:search")}?case_reference={case.reference_code}&country={filter_country}"'
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]["cases"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response_data), 0)
+
 
 class UpdatedCasesQueueTests(DataTestClient):
     def setUp(self):

--- a/api/cases/tests/test_case_search_advanced.py
+++ b/api/cases/tests/test_case_search_advanced.py
@@ -196,26 +196,6 @@ class FilterAndSortTests(DataTestClient):
         self.assertEqual(qs_3.count(), 1)
         self.assertEqual(qs_3.first().pk, application_4.pk)
 
-    def test_filter_by_country(self):
-        """
-        What qualifies as a country on a case?
-        """
-        country_1 = CountryFactory(id="GB")
-        country_2 = CountryFactory(id="SP")
-        country_on_application = CountryOnApplicationFactory(country=country_1)
-        country_on_application = CountryOnApplicationFactory(
-            application=country_on_application.application, country=country_1
-        )
-        party_on_application = PartyOnApplicationFactory(party=PartyFactory(country=country_2))
-
-        qs_1 = Case.objects.search(country=country_1)
-        qs_2 = Case.objects.search(country=country_2)
-
-        self.assertEqual(qs_1.count(), 1)
-        self.assertEqual(qs_2.count(), 1)
-        self.assertEqual(qs_1.first().pk, country_on_application.application.pk)
-        self.assertEqual(qs_2.first().pk, party_on_application.application.pk)
-
     def test_filter_by_team_advice(self):
         application = StandardApplicationFactory()
         good = GoodFactory(organisation=application.organisation)

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -158,5 +158,6 @@ class CasesSearchView(generics.ListAPIView):
         filters["submitted_to"] = make_date_from_params("submitted_to", filters)
         filters["finalised_from"] = make_date_from_params("finalised_from", filters)
         filters["finalised_to"] = make_date_from_params("finalised_to", filters)
+        filters["countries"] = request.GET.getlist("countries", [])
 
         return filters


### PR DESCRIPTION
### Aim

Add support for filtering by one or more countries to case search API. 

[LTD-3899](https://uktrade.atlassian.net/browse/LTD-3899)


[LTD-3899]: https://uktrade.atlassian.net/browse/LTD-3899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ