### PR TITLE
Only turn on SSO if admin is also turned on

### DIFF
--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -431,7 +431,7 @@ if DEBUG and "django_extensions" in sys.modules:
 
 # SSO config
 FEATURE_STAFF_SSO_ENABLED = env.bool("FEATURE_STAFF_SSO_ENABLED", False)
-if FEATURE_STAFF_SSO_ENABLED:
+if FEATURE_STAFF_SSO_ENABLED and ADMIN_ENABLED:
     INSTALLED_APPS.append("authbroker_client")
     AUTHENTICATION_BACKENDS = [
         "django.contrib.auth.backends.ModelBackend",


### PR DESCRIPTION
### Aim

Stop Sentry alerts complaining about an unfound admin route.

This will ensure that SSO is only switched on if admin is switched on as well (the only reason to turn on SSO would be for Django admin anyway).

[LTD-3902](https://uktrade.atlassian.net/browse/LTD-3902)


[LTD-3902]: https://uktrade.atlassian.net/browse/LTD-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ