### PR TITLE
[LTD-3936] Ensure that cases search API assignment filter considers current queue

### DIFF
--- a/api/cases/helpers.py
+++ b/api/cases/helpers.py
@@ -3,10 +3,14 @@ from api.staticdata.statuses.enums import CaseStatusEnum
 from api.users.models import GovUser, GovNotification
 
 
-def get_assigned_to_user_case_ids(user: GovUser):
+def get_assigned_to_user_case_ids(user: GovUser, queue_id=None):
     from api.cases.models import CaseAssignment
 
-    return CaseAssignment.objects.filter(user=user).values_list("case__id", flat=True)
+    filters = {"user": user}
+    if queue_id:
+        filters["queue_id"] = queue_id
+
+    return CaseAssignment.objects.filter(**filters).values_list("case__id", flat=True)
 
 
 def get_assigned_as_case_officer_case_ids(user: GovUser):


### PR DESCRIPTION
### Aim

Ensure that "assignment" filter for case search API takes in to account the queue filter parameter.  This means that assignment filtering will be scoped to assignments which are for the filtered queue; with the exception of the "all cases" queue as it makes sense to look at **all** case allocation records for that queue.

[LTD-3936](https://uktrade.atlassian.net/browse/LTD-3936)


[LTD-3936]: https://uktrade.atlassian.net/browse/LTD-3936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ