### PR TITLE
Added end-users / ult-end-users to the case payload

### DIFF
--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -318,7 +318,7 @@ class CaseManager(models.Manager):
                 "queues__team",
                 Prefetch(
                     "baseapplication__parties",
-                    to_attr="enduser_parties",
+                    to_attr="end_user_parties",
                     queryset=PartyOnApplication.objects.select_related("party").filter(
                         deleted_at__isnull=True,
                         party__type__in=["end_user", "ultimate_end_user"],

--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -307,6 +307,7 @@ class CaseManager(models.Manager):
                 "case_assignments__queue",
                 "queues",
                 "queues__team",
+                "baseapplication__parties__party",
             )
         )
 

--- a/api/cases/managers.py
+++ b/api/cases/managers.py
@@ -3,7 +3,14 @@ from typing import List
 
 from compat import get_model
 from django.db import models, transaction
-from django.db.models import Q, Case, When, BinaryField, Sum
+from django.db.models import (
+    BinaryField,
+    Case,
+    Prefetch,
+    Q,
+    Sum,
+    When,
+)
 from django.utils import timezone
 
 from api.cases.enums import AdviceLevel, CaseTypeEnum
@@ -296,6 +303,8 @@ class CaseManager(models.Manager):
         """
         Search for a user's available cases given a set of search parameters.
         """
+        from api.applications.models import PartyOnApplication
+
         case_qs = (
             self.submitted()
             .select_related("status", "case_type", "case_officer", "case_officer__baseuser_ptr", "baseapplication")
@@ -307,7 +316,14 @@ class CaseManager(models.Manager):
                 "case_assignments__queue",
                 "queues",
                 "queues__team",
-                "baseapplication__parties__party",
+                Prefetch(
+                    "baseapplication__parties",
+                    to_attr="enduser_parties",
+                    queryset=PartyOnApplication.objects.select_related("party").filter(
+                        deleted_at__isnull=True,
+                        party__type__in=["end_user", "ultimate_end_user"],
+                    ),
+                ),
             )
         )
 

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -181,19 +181,15 @@ class CaseListSerializer(serializers.Serializer):
             return ""
 
     def get_endusers(self, instance):
-        parties = (
-            instance.baseapplication.parties.filter(
-                party__type__in=["end_user", "ultimate_end_user"], deleted_at__isnull=True
+        endusers = []
+        for party_on_application in instance.baseapplication.enduser_parties:
+            endusers.append(
+                {
+                    "name": party_on_application.party.name,
+                    "type": party_on_application.party.type,
+                }
             )
-            .select_related("party")
-            .prefetch_related(
-                "party__name",
-                "party__type",
-            )
-            .values("party__name", "party__type")
-        )
-
-        return [{"name": party["party__name"], "type": party["party__type"]} for party in parties]
+        return endusers
 
 
 class GoodOnApplicationSummarySerializer(serializers.Serializer):

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -128,7 +128,7 @@ class CaseListSerializer(serializers.Serializer):
     has_open_queries = serializers.BooleanField()
     case_officer = serializers.SerializerMethodField()
     intended_end_use = serializers.SerializerMethodField()
-    endusers = serializers.SerializerMethodField()
+    end_users = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         self.team = kwargs.pop("team", None)
@@ -178,11 +178,11 @@ class CaseListSerializer(serializers.Serializer):
         except BaseApplication.DoesNotExist:
             return ""
 
-    def get_endusers(self, instance):
-        if hasattr(instance, "baseapplication") and hasattr(instance.baseapplication, "enduser_parties"):
+    def get_end_users(self, instance):
+        if hasattr(instance, "baseapplication") and hasattr(instance.baseapplication, "end_user_parties"):
             return [
                 {"name": party_on_app.party.name, "type": party_on_app.party.type}
-                for party_on_app in instance.baseapplication.enduser_parties
+                for party_on_app in instance.baseapplication.end_user_parties
             ]
         return []
 

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -179,12 +179,16 @@ class CaseListSerializer(serializers.Serializer):
             return ""
 
     def get_end_users(self, instance):
-        if hasattr(instance, "baseapplication") and hasattr(instance.baseapplication, "end_user_parties"):
-            return [
-                {"name": party_on_app.party.name, "type": party_on_app.party.type}
-                for party_on_app in instance.baseapplication.end_user_parties
-            ]
-        return []
+        if not self.has_end_users(instance):
+            return []
+
+        return [
+            {"name": party_on_app.party.name, "type": party_on_app.party.type}
+            for party_on_app in instance.baseapplication.end_user_parties
+        ]
+
+    def has_end_users(self, instance):
+        return hasattr(instance, "baseapplication") and hasattr(instance.baseapplication, "end_user_parties")
 
 
 class GoodOnApplicationSummarySerializer(serializers.Serializer):

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -1,14 +1,11 @@
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils import timezone
-
-from api.applications.mixins.serializers import PartiesSerializerMixin
-from api.cases.service import retrieve_latest_activity
 from rest_framework import serializers
 
 from api.applications.libraries.get_applications import get_application
-from api.applications.serializers.advice import AdviceViewSerializer, CountersignDecisionAdviceViewSerializer
 from api.applications.models import BaseApplication
+from api.applications.serializers.advice import AdviceViewSerializer, CountersignDecisionAdviceViewSerializer
 from api.audit_trail.models import Audit
 from api.cases.enums import (
     CaseTypeTypeEnum,
@@ -34,6 +31,7 @@ from api.cases.models import (
     CaseType,
     CaseReviewDate,
 )
+from api.cases.service import retrieve_latest_activity
 from api.compliance.models import ComplianceSiteCase, ComplianceVisitCase
 from api.compliance.serializers.ComplianceSiteCaseSerializers import ComplianceSiteViewSerializer
 from api.compliance.serializers.ComplianceVisitCaseSerializers import ComplianceVisitSerializer
@@ -43,6 +41,7 @@ from api.goodstype.models import GoodsType
 from api.gov_users.serializers import GovUserSimpleSerializer
 from api.licences.helpers import get_open_general_export_licence_case
 from api.queries.serializers import QueryViewSerializer
+from api.queues.constants import ALL_CASES_QUEUE_ID
 from api.queues.models import Queue
 from api.queues.serializers import QueueListSerializer
 from api.staticdata.countries.models import Country
@@ -57,7 +56,6 @@ from api.users.serializers import (
     ExporterUserViewSerializer,
     ExporterUserSimpleSerializer,
 )
-from api.queues.constants import ALL_CASES_QUEUE_ID
 from lite_content.lite_api import strings
 
 

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -181,15 +181,12 @@ class CaseListSerializer(serializers.Serializer):
             return ""
 
     def get_endusers(self, instance):
-        endusers = []
-        for party_on_application in instance.baseapplication.enduser_parties:
-            endusers.append(
-                {
-                    "name": party_on_application.party.name,
-                    "type": party_on_application.party.type,
-                }
-            )
-        return endusers
+        if hasattr(instance, "baseapplication") and hasattr(instance.baseapplication, "enduser_parties"):
+            return [
+                {"name": party_on_app.party.name, "type": party_on_app.party.type}
+                for party_on_app in instance.baseapplication.enduser_parties
+            ]
+        return []
 
 
 class GoodOnApplicationSummarySerializer(serializers.Serializer):

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -121,8 +121,8 @@ class FilterAndSortTests(DataTestClient):
         ult_end_user = {"name": "Ult End User", "type": "ultimate_end_user"}
 
         for case in cases_with_users:
-            self.assertTrue(end_user in case["endusers"])
-            self.assertTrue(ult_end_user in case["endusers"])
+            self.assertIn(end_user, case["endusers"])
+            self.assertIn(ult_end_user, case["endusers"])
 
     def test_get_app_type_cases(self):
         """

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -105,9 +105,7 @@ class FilterAndSortTests(DataTestClient):
 
     def test_get_cases_returns_all_cases_with_enduser_and_ultimate_enduser_data(self):
         """
-        Given multiple Cases exist with different statuses and case-types
-        When a user requests to view all Cases with no filter
-        Then all Cases are returned
+        Check that the case data includes end user and ultimate end user information.
         """
         response = self.client.get(self.url, **self.gov_headers)
         response_data = response.json()["results"]

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -54,7 +54,9 @@ class FilterAndSortTests(DataTestClient):
 
         self.application_cases = []
         for app_status in statuses:
-            case = self.create_standard_application_case(self.organisation, "Example Application")
+            case = self.create_standard_application_case(
+                self.organisation, "Example Application", ultimate_end_users=True
+            )
             case.status = get_case_status_by_status(app_status)
             case.save()
             self.queue.cases.add(case)

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -101,6 +101,27 @@ class FilterAndSortTests(DataTestClient):
             response_data["filters"]["gov_users"],
         )
 
+    def test_get_cases_returns_all_cases_with_enduser_and_ultimate_enduser_data(self):
+        """
+        Given multiple Cases exist with different statuses and case-types
+        When a user requests to view all Cases with no filter
+        Then all Cases are returned
+        """
+        response = self.client.get(self.url, **self.gov_headers)
+        response_data = response.json()["results"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        cases_with_users = [case for case in response_data["cases"] if case["endusers"]]
+        # All the non clc cases should have users.
+        self.assertEqual(len(cases_with_users), 3)
+        end_user = {"name": "End User", "type": "end_user"}
+        ult_end_user = {"name": "Ult End User", "type": "ultimate_end_user"}
+
+        for case in cases_with_users:
+            self.assertTrue(end_user in case["endusers"])
+            self.assertTrue(ult_end_user in case["endusers"])
+
     def test_get_app_type_cases(self):
         """
         Given multiple Cases exist with different statuses and case-types

--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -103,7 +103,7 @@ class FilterAndSortTests(DataTestClient):
             response_data["filters"]["gov_users"],
         )
 
-    def test_get_cases_returns_all_cases_with_enduser_and_ultimate_enduser_data(self):
+    def test_get_cases_returns_all_cases_with_end_user_and_ultimate_end_user_data(self):
         """
         Check that the case data includes end user and ultimate end user information.
         """
@@ -112,15 +112,15 @@ class FilterAndSortTests(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        cases_with_users = [case for case in response_data["cases"] if case["endusers"]]
+        cases_with_users = [case for case in response_data["cases"] if case["end_users"]]
         # All the non clc cases should have users.
         self.assertEqual(len(cases_with_users), 3)
         end_user = {"name": "End User", "type": "end_user"}
         ult_end_user = {"name": "Ult End User", "type": "ultimate_end_user"}
 
         for case in cases_with_users:
-            self.assertIn(end_user, case["endusers"])
-            self.assertIn(ult_end_user, case["endusers"])
+            self.assertIn(end_user, case["end_users"])
+            self.assertIn(ult_end_user, case["end_users"])
 
     def test_get_app_type_cases(self):
         """

--- a/api/flags/tests/test_case_view_flag_ordering.py
+++ b/api/flags/tests/test_case_view_flag_ordering.py
@@ -26,7 +26,7 @@ class FlagsOrderingOnCaseViewTests(DataTestClient):
                     )
                     flags.append(flag)
 
-        case = self.create_standard_application_case(organisation=self.organisation)
+        case = self.create_standard_application_case(organisation=self.organisation, ultimate_end_users=False)
         case.flags.set([flag for flag in flags if flag.level == FlagLevels.CASE])
 
         good = GoodOnApplication.objects.get(application=case).good

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -710,6 +710,7 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
         reference_name="Standard Draft",
         safe_document=True,
         parties=True,
+        ultimate_end_users=False,
         site=True,
         case_type_id=CaseTypeEnum.SIEL.id,
         add_a_good=True,
@@ -770,7 +771,8 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
 
         if parties:
             self.create_party("End User", organisation, PartyType.END_USER, application)
-            self.create_party("Ult End User", organisation, PartyType.ULTIMATE_END_USER, application)
+            if ultimate_end_users:
+                self.create_party("Ult End User", organisation, PartyType.ULTIMATE_END_USER, application)
             self.create_party("Consignee", organisation, PartyType.CONSIGNEE, application)
             self.create_party("Third party", organisation, PartyType.THIRD_PARTY, application)
             # Set the application party documents
@@ -885,7 +887,7 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
         good_kwargs=None,
     ):
         application = self.create_draft_standard_application(
-            organisation, reference_name, safe_document, num_products=0
+            organisation, reference_name, safe_document, num_products=0, ultimate_end_users=True
         )
         if not good_kwargs:
             good_kwargs = {}
@@ -904,13 +906,6 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
             is_good_incorporated=True,
         ).save()
 
-        self.ultimate_end_user = self.create_party(
-            "Ultimate End User",
-            organisation,
-            PartyType.ULTIMATE_END_USER,
-            application,
-            country_code=destination_country_code,
-        )
         self.create_document_for_party(application.ultimate_end_users.first().party, safe=safe_document)
 
         return application
@@ -1002,6 +997,7 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
         organisation: Organisation,
         reference_name="Standard Application Case",
         parties=True,
+        ultimate_end_users=False,
         site=True,
         user=None,
         num_products=1,
@@ -1014,6 +1010,7 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
             organisation,
             reference_name,
             parties=parties,
+            ultimate_end_users=ultimate_end_users,
             site=site,
             user=user,
             num_products=num_products,

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -770,6 +770,7 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
 
         if parties:
             self.create_party("End User", organisation, PartyType.END_USER, application)
+            self.create_party("Ult End User", organisation, PartyType.ULTIMATE_END_USER, application)
             self.create_party("Consignee", organisation, PartyType.CONSIGNEE, application)
             self.create_party("Third party", organisation, PartyType.THIRD_PARTY, application)
             # Set the application party documents


### PR DESCRIPTION
### Aim

Added end-users / ult-end-users to the case payload

This is to enable the frontend to display the end-users in a configurable column in the queue display.

[LTD-3960](https://uktrade.atlassian.net/browse/LTD-3960)


[LTD-3960]: https://uktrade.atlassian.net/browse/LTD-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ