### PR TITLE
Retain denial reasons after advice has been countersigned

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -486,6 +486,14 @@ class Advice(TimestampableModel):
 
         super(Advice, self).save(*args, **kwargs)
 
+        # We retain the denial reasons from the previous object because we're effectively really doing an edit here by
+        # removing the previous advice and create a new one in its place, however we lose the many-to-many relationship
+        # the old object had so we reinstate it here.
+        # This may look like it would overwrite the denial reasons that were set currently if you were editing this
+        # object but if you were editing the denial reasons you'd first have to save this object and _then_ set the
+        # denial reasons afterwards, so in that case this just gets overwritten anyway.
+        # We do this after the save method as this object needs to have its id in place so we can create these
+        # many-to-many objects.
         if denial_reasons:
             self.denial_reasons.set(denial_reasons)
 

--- a/api/cases/tests/test_create_advice.py
+++ b/api/cases/tests/test_create_advice.py
@@ -448,7 +448,9 @@ class CountersignAdviceTests(DataTestClient):
         response = self.client.put(self.url, **self.gov_headers, data=data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        advice.refresh_from_db()
+        # The old advice object would have been deleted so we get the new one that was created and check that the
+        # denial reasons were copied over
+        advice = Advice.objects.get()
         self.assertQuerysetEqual(
             advice.denial_reasons.all(),
             [DenialReason.objects.get(id="7")],

--- a/api/cases/tests/test_create_advice.py
+++ b/api/cases/tests/test_create_advice.py
@@ -9,10 +9,15 @@ from uuid import uuid4
 from api.audit_trail.enums import AuditType
 from api.audit_trail.models import Audit
 from api.audit_trail.serializers import AuditSerializer
-from api.cases.enums import AdviceType, CountersignOrder
+from api.cases.enums import (
+    AdviceLevel,
+    AdviceType,
+    CountersignOrder,
+)
 from api.cases.models import Advice, CountersignAdvice
 from api.cases.tests.factories import CountersignAdviceFactory
 from api.core.constants import GovPermissions, Roles
+from api.staticdata.denial_reasons.models import DenialReason
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from api.teams.enums import TeamIdEnum
@@ -421,6 +426,33 @@ class CountersignAdviceTests(DataTestClient):
         audit_qs = Audit.objects.filter(verb=AuditType.COUNTERSIGN_ADVICE)
         self.assertEqual(audit_qs.count(), 1)
         self.assertEqual(audit_qs.first().actor, self.gov_user)
+
+    def test_countersigning_retains_denial_reasons(self):
+        advice = Advice.objects.create(
+            user=self.gov_user,
+            case=self.case,
+            note="Advice",
+            level=AdviceLevel.USER,
+            type=AdviceType.REFUSE,
+        )
+        advice.denial_reasons.set([DenialReason.objects.get(id="7")])
+
+        data = [
+            {
+                "id": advice.id,
+                "countersigned_by": self.gov_user.baseuser_ptr.id,
+                "comments": "Agree with recommendation",
+            }
+        ]
+
+        response = self.client.put(self.url, **self.gov_headers, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        advice.refresh_from_db()
+        self.assertQuerysetEqual(
+            advice.denial_reasons.all(),
+            [DenialReason.objects.get(id="7")],
+        )
 
 
 class CountersignAdviceWithDecisionTests(DataTestClient):


### PR DESCRIPTION
### Aim

Stop denial reasons from being deleted.

[LTD-4030](https://uktrade.atlassian.net/browse/LTD-4030)


[LTD-4030]: https://uktrade.atlassian.net/browse/LTD-4030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ