### PR TITLE
[LTD-4056] Endpoint to send generated case documents to exporters 

### DIFF
--- a/api/cases/generated_documents/tests/factories.py
+++ b/api/cases/generated_documents/tests/factories.py
@@ -1,0 +1,15 @@
+import factory
+
+from api.cases.generated_documents.models import GeneratedCaseDocument
+from api.cases.tests.factories import CaseSIELFactory
+
+
+class GeneratedCaseDocumentFactory(factory.django.DjangoModelFactory):
+    case = factory.SubFactory(CaseSIELFactory)
+    name = factory.Faker("word")
+    s3_key = factory.Faker("slug")
+    safe = True
+    visible_to_exporter = False
+
+    class Meta:
+        model = GeneratedCaseDocument

--- a/api/cases/generated_documents/tests/test_views.py
+++ b/api/cases/generated_documents/tests/test_views.py
@@ -1,0 +1,65 @@
+from _pytest.monkeypatch import MonkeyPatch
+import uuid
+from unittest import mock
+
+from rest_framework.reverse import reverse
+
+from test_helpers.clients import DataTestClient
+from api.cases.generated_documents.tests.factories import GeneratedCaseDocumentFactory
+from api.cases.generated_documents import views
+from api.letter_templates.models import LetterTemplate
+
+
+class GeneratedDocumentSendTests(DataTestClient):
+    def setUp(self):
+        super().setUp()
+        self.case = self.create_standard_application_case(self.organisation)
+
+    def test_post_generated_document_missing(self):
+
+        url = reverse(
+            "cases:generated_documents:send_generated_document",
+            kwargs={"document_pk": uuid.uuid4(), "pk": self.case.id},
+        )
+        response = self.client.post(url, **self.gov_headers)
+        assert response.status_code == 404
+
+    def test_post_no_notification(self):
+        generated_document = GeneratedCaseDocumentFactory(
+            template=LetterTemplate.objects.first(),
+            case=self.case,
+            visible_to_exporter=False,
+        )
+
+        url = reverse(
+            "cases:generated_documents:send_generated_document",
+            kwargs={"document_pk": generated_document.id, "pk": self.case.id},
+        )
+        response = self.client.post(url, **self.gov_headers)
+        assert response.status_code == 200
+        assert response.json() == {"notification_sent": False}
+        generated_document.refresh_from_db()
+        assert generated_document.visible_to_exporter == True
+
+    def test_post_with_notification(self):
+        mocked_notify_function = mock.Mock()
+        MonkeyPatch().setitem(views.NOTIFICATION_FUNCTIONS, "inform_letter", mocked_notify_function)
+
+        generated_document = GeneratedCaseDocumentFactory(
+            template=LetterTemplate.objects.first(),
+            case=self.case,
+            visible_to_exporter=False,
+        )
+        generated_document.template.layout.filename = "inform_letter"
+        generated_document.template.layout.save()
+
+        url = reverse(
+            "cases:generated_documents:send_generated_document",
+            kwargs={"document_pk": generated_document.id, "pk": self.case.id},
+        )
+        response = self.client.post(url, **self.gov_headers)
+        assert response.status_code == 200
+        assert response.json() == {"notification_sent": True}
+        generated_document.refresh_from_db()
+        assert generated_document.visible_to_exporter == True
+        mocked_notify_function.assert_called_with(self.case.get_case())

--- a/api/cases/generated_documents/urls.py
+++ b/api/cases/generated_documents/urls.py
@@ -7,5 +7,6 @@ app_name = "generated_documents"
 urlpatterns = [
     path("", views.GeneratedDocuments.as_view(), name="generated_documents"),
     path("<uuid:dpk>/", views.GeneratedDocument.as_view(), name="generated_document"),
+    path("<uuid:document_pk>/send/", views.GeneratedDocumentSend.as_view(), name="send_generated_document"),
     path("preview/", views.GeneratedDocumentPreview.as_view(), name="preview"),
 ]

--- a/api/cases/notify.py
+++ b/api/cases/notify.py
@@ -9,6 +9,7 @@ from gov_notify.payloads import (
     ExporterLicenceRefused,
     ExporterNoLicenceRequired,
     ExporterLicenceRevoked,
+    ExporterInformLetter,
 )
 from gov_notify.service import send_email
 
@@ -123,3 +124,14 @@ def notify_exporter_no_licence_required(case):
             "exporter_frontend_url": get_exporter_frontend_url("/"),
         },
     )
+
+
+def notify_exporter_inform_letter(case):
+    case = case.get_case()
+    exporter = case.submitted_by
+    payload = ExporterInformLetter(
+        user_first_name=exporter.first_name,
+        application_reference=case.reference_code,
+        exporter_frontend_url=get_exporter_frontend_url("/"),
+    )
+    send_email(exporter.email, TemplateType.EXPORTER_INFORM_LETTER, payload)

--- a/api/cases/tests/test_notify.py
+++ b/api/cases/tests/test_notify.py
@@ -6,6 +6,7 @@ from api.cases.notify import (
     notify_exporter_licence_refused,
     notify_exporter_no_licence_required,
     notify_exporter_licence_revoked,
+    notify_exporter_inform_letter,
 )
 from api.licences.tests.factories import LicenceFactory
 from api.users.tests.factories import ExporterUserFactory
@@ -16,6 +17,7 @@ from gov_notify.payloads import (
     ExporterLicenceRefused,
     ExporterLicenceRevoked,
     ExporterNoLicenceRequired,
+    ExporterInformLetter,
 )
 from test_helpers.clients import DataTestClient
 
@@ -106,6 +108,22 @@ class NotifyTests(DataTestClient):
         mock_send_email.assert_called_with(
             application.submitted_by.email,
             TemplateType.EXPORTER_ECJU_QUERY,
+            expected_payload,
+        )
+        assert mock_send_email.called == 1
+
+    @mock.patch("api.cases.notify.send_email")
+    def test_notify_exporter_inform_letter(self, mock_send_email):
+        notify_exporter_inform_letter(self.case)
+
+        expected_payload = ExporterInformLetter(
+            user_first_name=self.case.submitted_by.first_name,
+            application_reference=self.case.reference_code,
+            exporter_frontend_url="https://exporter.lite.service.localhost.uktrade.digital/",
+        )
+        mock_send_email.assert_called_with(
+            self.case.submitted_by.email,
+            TemplateType.EXPORTER_INFORM_LETTER,
             expected_payload,
         )
         assert mock_send_email.called == 1

--- a/gov_notify/enums.py
+++ b/gov_notify/enums.py
@@ -14,6 +14,7 @@ class TemplateType(Enum):
     EXPORTER_CASE_OPENED_FOR_EDITING = "exporter_editing"
     EXPORTER_ECJU_QUERY = "exporter_ecju_query"
     EXPORTER_NO_LICENCE_REQUIRED = "exporter_no_licence_required"
+    EXPORTER_INFORM_LETTER = "exporter_inform_letter"
     CASEWORKER_COUNTERSIGN_CASE_RETURN = "caseworker_countersign_case_return"
 
     @property
@@ -34,5 +35,6 @@ class TemplateType(Enum):
             self.CASEWORKER_REGISTERED_NEW_ORG: "d835dba3-ca85-4a27-b257-e31a17f0e61d",
             self.EXPORTER_CASE_OPENED_FOR_EDITING: "73121bc2-2f03-4c66-8e88-61a156c05559",
             self.EXPORTER_NO_LICENCE_REQUIRED: "d84d1843-882c-440e-9cd4-84972ba612e6",
+            self.EXPORTER_INFORM_LETTER: "7b63296f-af08-46bf-961e-19bdde93761c",
             self.CASEWORKER_COUNTERSIGN_CASE_RETURN: "4d418015-cd7c-498f-a972-72e7ec4468cc",
         }[self]

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -98,6 +98,13 @@ class ExporterNoLicenceRequired(EmailData):
 
 
 @dataclass(frozen=True)
+class ExporterInformLetter(EmailData):
+    user_first_name: str
+    application_reference: str
+    exporter_frontend_url: str
+
+
+@dataclass(frozen=True)
 class CaseWorkerCountersignCaseReturn(EmailData):
     case_reference: str
     countersigned_user_name: str

--- a/gov_notify/tests/test_enums.py
+++ b/gov_notify/tests/test_enums.py
@@ -18,6 +18,7 @@ class TemplateTypeTests(APITestCase):
             (TemplateType.EXPORTER_CASE_OPENED_FOR_EDITING, "73121bc2-2f03-4c66-8e88-61a156c05559"),
             (TemplateType.EXPORTER_NO_LICENCE_REQUIRED, "d84d1843-882c-440e-9cd4-84972ba612e6"),
             (TemplateType.CASEWORKER_COUNTERSIGN_CASE_RETURN, "4d418015-cd7c-498f-a972-72e7ec4468cc"),
+            (TemplateType.EXPORTER_INFORM_LETTER, "7b63296f-af08-46bf-961e-19bdde93761c"),
         ]
     )
     def test_template_id(self, template_type, expected_template_id):

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -86,6 +86,14 @@ class DataclassTests(APITestCase):
                 },
             ),
             (
+                payloads.ExporterInformLetter,
+                {
+                    "application_reference": "testref",
+                    "user_first_name": "testname",
+                    "exporter_frontend_url": "https://some.domain/foo",
+                },
+            ),
+            (
                 payloads.CaseWorkerNewRegistration,
                 {
                     "organisation_name": "testref",


### PR DESCRIPTION
### Aim

Add API endpoint for sending generated case documents to exporters; the endpoint marks a document as `visible_to_exporter=True` and sends a notification if a notification would be applicable for the given template.  For now, only generated docs from the "inform_letter" template will result in a notification - but we can extend this as we use this endpoint for more documents in the future.

[LTD-4056](https://uktrade.atlassian.net/browse/LTD-4056)


[LTD-4056]: https://uktrade.atlassian.net/browse/LTD-4056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ