### PR TITLE
Tests: sort DISALLOWED_STATUSES to make pytest-xdist happy.

### DIFF
--- a/api/applications/tests/test_update_serial_numbers.py
+++ b/api/applications/tests/test_update_serial_numbers.py
@@ -17,7 +17,8 @@ class GoodOnApplicationUpdateSerialNumbers(DataTestClient):
         CaseStatusEnum.SUBMITTED,
         CaseStatusEnum.FINALISED,
     ]
-    DISALLOWED_STATUSES = list(set(CaseStatusEnum.all()) - set(ALLOWED_STATUSES))
+    # DISALLOWED_STATUSES is used to parameterize tests, make the order stable to enable pytest-xdist
+    DISALLOWED_STATUSES = sorted(set(CaseStatusEnum.all()) - set(ALLOWED_STATUSES))
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This keeps the order stable between runs - the changing order precluded the use of pytest-xdist.

### Aim

This pytest-xdist to run the tests, so tests can run in parallel.
$ pip install pytest

Add -n {number of processes} to the pytest command, e.g. `-n 3`

### Non Aims
Changes to enable or document pytest-xdist at this point (changes to makefile, changes to docs, changes to CI)

These changes may come after running this in dev for a while to characterise it.