### PR TITLE
LTD-4142-update-test-to-confirm-finalisation-no-inform

### DIFF
--- a/api/cases/tests/test_refuse_licence.py
+++ b/api/cases/tests/test_refuse_licence.py
@@ -41,7 +41,9 @@ class RefuseCaseTests(DataTestClient):
             self.assertTrue(document.visible_to_exporter)
 
         # Confirm finalisation can succeed with only a refuse doc
-        self.assertEqual(GeneratedCaseDocument.objects.filter(case=self.application.id)[0].advice_type, "refuse")
+        case_documents_query = GeneratedCaseDocument.objects.filter(case=self.application.id)
+        self.assertEqual(case_documents_query.count(), 1)
+        self.assertEqual(case_documents_query[0].advice_type, "refuse")
         self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify.assert_called_with(case)
@@ -64,7 +66,9 @@ class RefuseCaseTests(DataTestClient):
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
         # Confirm finalisation can succeed with only a refuse doc
-        self.assertEqual(GeneratedCaseDocument.objects.filter(case=self.application.id)[0].advice_type, "refuse")
+        case_documents_query = GeneratedCaseDocument.objects.filter(case=self.application.id)
+        self.assertEqual(case_documents_query.count(), 1)
+        self.assertEqual(case_documents_query[0].advice_type, "refuse")
         self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify.assert_called_with(case)

--- a/api/cases/tests/test_refuse_licence.py
+++ b/api/cases/tests/test_refuse_licence.py
@@ -61,7 +61,8 @@ class RefuseCaseTests(DataTestClient):
         self.assertEqual(self.application.status, CaseStatus.objects.get(status=CaseStatusEnum.FINALISED))
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
-
+        # Confirm finalisation can succeed with only a refuse doc
+        self.assertEqual(GeneratedCaseDocument.objects.filter(case=self.application.id)[0].advice_type, "refuse")
         self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify.assert_called_with(case)

--- a/api/cases/tests/test_refuse_licence.py
+++ b/api/cases/tests/test_refuse_licence.py
@@ -40,6 +40,8 @@ class RefuseCaseTests(DataTestClient):
         for document in GeneratedCaseDocument.objects.filter(advice_type__isnull=False):
             self.assertTrue(document.visible_to_exporter)
 
+        # Confirm finalisation can succeed with only a refuse doc
+        self.assertEqual(GeneratedCaseDocument.objects.filter(case=self.application.id)[0].advice_type, "refuse")
         self.assertEqual(Audit.objects.count(), 3)
         case = get_case(self.application.id)
         mock_notify.assert_called_with(case)


### PR DESCRIPTION
This Updates the tests during refusal finalisation to ensure we can proceed with just a refusal letter

https://uktrade.atlassian.net/browse/LTD-4142
