### PR TITLE
Add detail endpoint for application appeal

### DIFF
--- a/api/appeals/tests/factories.py
+++ b/api/appeals/tests/factories.py
@@ -10,6 +10,8 @@ class AppealFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Appeal
 
+    grounds_for_appeal = factory.Faker("text")
+
 
 class AppealDocumentFactory(factory.django.DjangoModelFactory):
     class Meta:

--- a/api/applications/urls.py
+++ b/api/applications/urls.py
@@ -138,7 +138,12 @@ urlpatterns = [
         name="application_denial_matches",
     ),
     path(
-        "<uuid:pk>/appeal/",
+        "<uuid:pk>/appeals/",
+        applications.ApplicationAppeals.as_view(),
+        name="appeals",
+    ),
+    path(
+        "<uuid:pk>/appeals/<uuid:appeal_pk>/",
         applications.ApplicationAppeal.as_view(),
         name="appeal",
     ),

--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -12,11 +12,13 @@ from rest_framework.generics import (
     CreateAPIView,
     ListAPIView,
     ListCreateAPIView,
+    RetrieveAPIView,
     RetrieveUpdateDestroyAPIView,
     UpdateAPIView,
 )
 from rest_framework.views import APIView
 
+from api.appeals.models import Appeal
 from api.appeals.serializers import AppealSerializer
 from api.applications import constants
 from api.applications.creators import validate_application_ready_for_submission, _validate_agree_to_declaration
@@ -1042,7 +1044,7 @@ class ApplicationRouteOfGoods(UpdateAPIView):
         )
 
 
-class ApplicationAppeal(CreateAPIView):
+class ApplicationAppeals(CreateAPIView):
     authentication_classes = (ExporterAuthentication,)
     serializer_class = AppealSerializer
 
@@ -1058,3 +1060,18 @@ class ApplicationAppeal(CreateAPIView):
         super().perform_create(serializer)
         self.application.appeal = serializer.instance
         self.application.save()
+
+
+class ApplicationAppeal(RetrieveAPIView):
+    authentication_classes = (ExporterAuthentication,)
+    lookup_url_kwarg = "appeal_pk"
+    queryset = Appeal.objects.all()
+    serializer_class = AppealSerializer
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
+        try:
+            self.application = BaseApplication.objects.get(pk=self.kwargs["pk"])
+        except BaseApplication.DoesNotExist:
+            raise Http404()


### PR DESCRIPTION
### Aim

Add detail endpoint to get information about an appeal.

This also renames the create endpoint to situate it under a "list" endpoint.

[LTD-4125](https://uktrade.atlassian.net/browse/LTD-4125)


[LTD-4125]: https://uktrade.atlassian.net/browse/LTD-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ