### PR TITLE
Allow cases queues to be set by both gov and exporter users

### DIFF
--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -160,7 +160,7 @@ class CaseDetailBasic(RetrieveAPIView):
 
 
 class SetQueues(APIView):
-    authentication_classes = (GovAuthentication,)
+    authentication_classes = (SharedAuthentication,)
 
     @transaction.atomic
     def put(self, request, pk):


### PR DESCRIPTION
### Aim

Allow cases queues to be set by both gov and exporter users. **Note** this doesn't mean that an exporter can change this value themselves just that we allow calls on behalf of the exporter to make this change.

[LTD-4120](https://uktrade.atlassian.net/browse/LTD-4120)


[LTD-4120]: https://uktrade.atlassian.net/browse/LTD-4120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ