### PR TITLE
[LTD-4160] Add document to generated document send endpoint response

### DIFF
--- a/api/cases/generated_documents/serializers.py
+++ b/api/cases/generated_documents/serializers.py
@@ -21,6 +21,7 @@ class GeneratedCaseDocumentGovSerializer(serializers.ModelSerializer):
         model = GeneratedCaseDocument
         fields = (
             "template",
+            "advice_type",
             "text",
         )
 

--- a/api/cases/generated_documents/tests/test_views.py
+++ b/api/cases/generated_documents/tests/test_views.py
@@ -43,7 +43,14 @@ class GeneratedDocumentSendTests(DataTestClient):
         )
         response = self.client.post(url, **self.gov_headers)
         assert response.status_code == 200
-        assert response.json() == {"notification_sent": False}
+        assert response.json() == {
+            "notification_sent": False,
+            "document": {
+                "advice_type": generated_document.advice_type,
+                "template": str(generated_document.template.id),
+                "text": generated_document.text,
+            },
+        }
         generated_document.refresh_from_db()
         assert generated_document.visible_to_exporter == True
         # Check add audit
@@ -77,7 +84,14 @@ class GeneratedDocumentSendTests(DataTestClient):
         )
         response = self.client.post(url, **self.gov_headers)
         assert response.status_code == 200
-        assert response.json() == {"notification_sent": True}
+        assert response.json() == {
+            "notification_sent": True,
+            "document": {
+                "advice_type": generated_document.advice_type,
+                "template": str(generated_document.template.id),
+                "text": generated_document.text,
+            },
+        }
         generated_document.refresh_from_db()
         assert generated_document.visible_to_exporter == True
         mocked_notify_function.assert_called_with(self.case.get_case())

--- a/api/cases/generated_documents/views.py
+++ b/api/cases/generated_documents/views.py
@@ -175,11 +175,12 @@ class GeneratedDocumentSend(APIView):
             target=document.case,
             payload={"case_reference": document.case.reference_code, "decision": document.advice_type},
         )
+        serialized_document = GeneratedCaseDocumentGovSerializer(document).data
 
         layout_name = document.template.layout.filename
 
         if NOTIFICATION_FUNCTIONS.get(layout_name):
             NOTIFICATION_FUNCTIONS[layout_name](document.case)
-            return Response(data={"notification_sent": True})
+            return Response(data={"notification_sent": True, "document": serialized_document})
 
-        return Response(data={"notification_sent": False})
+        return Response(data={"notification_sent": False, "document": serialized_document})


### PR DESCRIPTION
### Aim

Add a serialized document to the "send generated document" endpoint response.

[LTD-4160](https://uktrade.atlassian.net/browse/LTD-4160)


[LTD-4160]: https://uktrade.atlassian.net/browse/LTD-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ