### PR TITLE
[LTD-4189] Ensure case sub-status is reset on status change

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -128,7 +128,21 @@ class Case(TimestampableModel):
         if not self.reference_code and self.status != get_case_status_by_status(CaseStatusEnum.DRAFT):
             self.reference_code = generate_reference_code(self)
 
+        self._reset_sub_status_on_status_change()
+
         super(Case, self).save(*args, **kwargs)
+
+    def _reset_sub_status_on_status_change(self):
+        status_changed = False
+        try:
+            case = Case.objects.get(id=self.pk)
+        except Case.DoesNotExist:
+            return  # If our case record does not yet exist in the DB, return early
+        old_status = case.status
+        status_changed = old_status != self.status
+
+        if status_changed:
+            self.sub_status = None  # Reset sub-status on any status change
 
     def get_case(self):
         """

--- a/api/cases/tests/test_models.py
+++ b/api/cases/tests/test_models.py
@@ -1,8 +1,10 @@
+from uuid import UUID
 from parameterized import parameterized
 
 from api.cases.models import Case, BadSubStatus
+from api.cases.tests.factories import CaseFactory
 from api.staticdata.statuses.enums import CaseSubStatusIdEnum
-from api.staticdata.statuses.models import CaseStatus
+from api.staticdata.statuses.models import CaseStatus, CaseSubStatus
 from test_helpers.clients import DataTestClient
 
 
@@ -29,3 +31,27 @@ class CaseTests(DataTestClient):
 
         self.case.refresh_from_db()
         assert str(self.case.sub_status.id) == sub_status
+
+    @parameterized.expand(
+        [
+            (
+                "under_final_review",
+                "under_final_review",
+                UUID(CaseSubStatusIdEnum.UNDER_FINAL_REVIEW__INFORM_LETTER_SENT),
+                UUID(CaseSubStatusIdEnum.UNDER_FINAL_REVIEW__INFORM_LETTER_SENT),
+            ),
+            ("under_final_review", "finalised", UUID(CaseSubStatusIdEnum.UNDER_FINAL_REVIEW__INFORM_LETTER_SENT), None),
+        ]
+    )
+    def test_case_save_reset_sub_status(self, previous_status, new_status, previous_sub_status, expected_sub_status):
+        sub_status = CaseSubStatus.objects.get(id=previous_sub_status)
+        case = CaseFactory(
+            status=CaseStatus.objects.get(status=previous_status),
+            sub_status=sub_status,
+        )
+        case.refresh_from_db()
+        assert case.sub_status == sub_status
+        case.status = CaseStatus.objects.get(status=new_status)
+        case.save()
+        case.refresh_from_db()
+        self.assertEqual(case.sub_status_id, expected_sub_status)


### PR DESCRIPTION
### Aim

Ensure case sub-status is reset when case status is changed.  This adds to our existing post save case signal.

[LTD-4189](https://uktrade.atlassian.net/browse/LTD-4189)


[LTD-4189]: https://uktrade.atlassian.net/browse/LTD-4189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ