### PR TITLE
LTD-4213: Allow LU users to set finalised status

### DIFF
--- a/api/applications/libraries/application_helpers.py
+++ b/api/applications/libraries/application_helpers.py
@@ -1,11 +1,20 @@
+from django.http import JsonResponse
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.exceptions import PermissionDenied
+
 from api.audit_trail import service as audit_trail_service
 from api.audit_trail.enums import AuditType
+from api.cases.enums import CaseTypeSubTypeEnum
 from api.core.constants import GovPermissions
 from api.core.permissions import assert_user_has_permission
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.applications.models import HmrcQuery
+from api.organisations.libraries.get_organisation import get_request_user_organisation_id
 from api.users.models import GovUser
-from rest_framework.request import Request
+from lite_content.lite_api import strings
+from lite_routing.routing_rules_internal.enums import TeamIdEnum
 
 
 def optional_str_to_bool(optional_string: str):
@@ -74,3 +83,51 @@ def create_submitted_audit(request: Request, application: HmrcQuery, old_status:
         ignore_case_status=True,
         send_notification=False,
     )
+
+
+def check_user_can_set_status(request, application, data):
+    """
+    Checks whether an user (internal/exporter) can set the requested status
+    Returns error response if user cannot set the status, None otherwise
+    """
+
+    if hasattr(request.user, "exporteruser"):
+        if get_request_user_organisation_id(request) != application.organisation.id:
+            raise PermissionDenied()
+
+        if data["status"] == CaseStatusEnum.FINALISED:
+            return JsonResponse(
+                data={"errors": [strings.Applications.Generic.Finalise.Error.SET_FINALISED]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not can_status_be_set_by_exporter_user(application.status.status, data["status"]):
+            return JsonResponse(
+                data={"errors": [strings.Applications.Generic.Finalise.Error.EXPORTER_SET_STATUS]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+    elif hasattr(request.user, "govuser"):
+        gov_user = request.user.govuser
+
+        if data["status"] == CaseStatusEnum.FINALISED:
+            lu_user = str(gov_user.team.id) == TeamIdEnum.LICENSING_UNIT
+            if lu_user and assert_user_has_permission(gov_user, GovPermissions.MANAGE_LICENCE_FINAL_ADVICE):
+                return None
+
+            return JsonResponse(
+                data={"errors": [strings.Applications.Generic.Finalise.Error.SET_FINALISED]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        is_licence_application = application.case_type.sub_type != CaseTypeSubTypeEnum.EXHIBITION
+        if not can_status_be_set_by_gov_user(
+            gov_user, application.status.status, data["status"], is_licence_application
+        ):
+            return JsonResponse(
+                data={"errors": [strings.Applications.Generic.Finalise.Error.GOV_SET_STATUS]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+    else:
+        return JsonResponse(data={"errors": ["Invalid user type"]}, status=status.HTTP_401_UNAUTHORIZED)
+
+    return None

--- a/api/applications/tests/test_application_status.py
+++ b/api/applications/tests/test_application_status.py
@@ -360,21 +360,3 @@ class ApplicationManageStatusTests(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.hmrc_query.status, get_case_status_by_status(CaseStatusEnum.CLOSED))
-
-    def test_gov_user_set_hmrc_invalid_status_failure(self):
-        self.hmrc_query = self.create_hmrc_query(self.organisation)
-        self.submit_application(self.hmrc_query)
-
-        # HMRC case status can only be CLOSED, SUBMITTED or RESUBMITTED
-        data = {"status": CaseStatusEnum.WITHDRAWN}
-        url = reverse("applications:manage_status", kwargs={"pk": self.hmrc_query.id})
-        response = self.client.put(url, data=data, **self.gov_headers)
-
-        self.hmrc_query.refresh_from_db()
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.json().get("errors")["status"][0], strings.Statuses.BAD_STATUS)
-        self.assertEqual(
-            self.standard_application.status,
-            get_case_status_by_status(CaseStatusEnum.SUBMITTED),
-        )

--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -493,9 +493,6 @@ class ApplicationManageStatus(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if not can_set_status(application, data["status"]):
-            raise ValidationError({"status": [strings.Statuses.BAD_STATUS]})
-
         if hasattr(request.user, "exporteruser"):
             if get_request_user_organisation_id(request) != application.organisation.id:
                 raise PermissionDenied()

--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -33,9 +33,9 @@ from api.applications.helpers import (
 )
 from api.applications.libraries.application_helpers import (
     optional_str_to_bool,
-    can_status_be_set_by_exporter_user,
     can_status_be_set_by_gov_user,
     create_submitted_audit,
+    check_user_can_set_status,
 )
 from api.applications.libraries.case_status_helpers import submit_application
 from api.applications.libraries.edit_applications import (
@@ -68,7 +68,6 @@ from api.audit_trail.enums import AuditType
 from api.cases.enums import AdviceLevel, AdviceType, CaseTypeSubTypeEnum, CaseTypeEnum
 from api.cases.generated_documents.models import GeneratedCaseDocument
 from api.cases.generated_documents.helpers import auto_generate_case_document
-from api.cases.helpers import can_set_status
 from api.cases.libraries.get_flags import get_flags
 from api.cases.service import get_destinations
 from api.cases.serializers import ApplicationManageSubStatusSerializer
@@ -483,33 +482,11 @@ class ApplicationManageStatus(APIView):
     @transaction.atomic
     def put(self, request, pk):
         application = get_application(pk)
-        is_licence_application = application.case_type.sub_type != CaseTypeSubTypeEnum.EXHIBITION
-
         data = deepcopy(request.data)
 
-        if data["status"] == CaseStatusEnum.FINALISED:
-            return JsonResponse(
-                data={"errors": [strings.Applications.Generic.Finalise.Error.SET_FINALISED]},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        if hasattr(request.user, "exporteruser"):
-            if get_request_user_organisation_id(request) != application.organisation.id:
-                raise PermissionDenied()
-
-            if not can_status_be_set_by_exporter_user(application.status.status, data["status"]):
-                return JsonResponse(
-                    data={"errors": [strings.Applications.Generic.Finalise.Error.EXPORTER_SET_STATUS]},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        else:
-            if not can_status_be_set_by_gov_user(
-                request.user.govuser, application.status.status, data["status"], is_licence_application
-            ):
-                return JsonResponse(
-                    data={"errors": [strings.Applications.Generic.Finalise.Error.GOV_SET_STATUS]},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+        error_response = check_user_can_set_status(request, application, data)
+        if error_response:
+            return error_response
 
         update_licence_status(application, data["status"])
 


### PR DESCRIPTION
### Change description

To support Appeals process we need LU users to be able to set the status to 'Finalised' at the end of an appeal. Currently this cannot be done so update endpoint to allow only LU users with necessary permissions can change status to 'Finalised'

Using this opportunity to refactor some of the checks into a helper function.

Add test that checks only LU can set status to finalised and fails for other internal users.

[LTD-4213](https://uktrade.atlassian.net/browse/LTD-4213)
