### PR TITLE
Set sub-status when case has been appealed

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -48,7 +48,10 @@ from api.staticdata.denial_reasons.models import DenialReason
 from api.staticdata.f680_clearance_types.models import F680ClearanceType
 from api.staticdata.regimes.models import RegimeEntry
 from api.staticdata.report_summaries.models import ReportSummaryPrefix, ReportSummarySubject
-from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.enums import (
+    CaseStatusEnum,
+    CaseSubStatusIdEnum,
+)
 from api.staticdata.statuses.libraries.case_status_validate import is_case_status_draft
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from api.staticdata.trade_control.enums import TradeControlProductCategory, TradeControlActivity
@@ -260,6 +263,7 @@ class BaseApplication(ApplicationPartyMixin, Case):
         )
 
         self.update_status(CaseStatusEnum.UNDER_APPEAL)
+        self.set_sub_status(CaseSubStatusIdEnum.UNDER_APPEAL__REQUEST_RECEIVED)
         self.add_to_queue(Queue.objects.get(id=QueuesEnum.LU_APPEALS))
 
 

--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -232,7 +232,7 @@ class BaseApplication(ApplicationPartyMixin, Case):
             },
         )
 
-    def update_status(self, status):
+    def set_status(self, status):
         case = self.get_case()
 
         old_status = self.status
@@ -262,7 +262,7 @@ class BaseApplication(ApplicationPartyMixin, Case):
             payload={},
         )
 
-        self.update_status(CaseStatusEnum.UNDER_APPEAL)
+        self.set_status(CaseStatusEnum.UNDER_APPEAL)
         self.set_sub_status(CaseSubStatusIdEnum.UNDER_APPEAL__REQUEST_RECEIVED)
         self.add_to_queue(Queue.objects.get(id=QueuesEnum.LU_APPEALS))
 

--- a/api/applications/tests/test_appeal.py
+++ b/api/applications/tests/test_appeal.py
@@ -11,7 +11,10 @@ from api.audit_trail.models import (
 from api.appeals.models import AppealDocument
 from api.appeals.tests.factories import AppealFactory
 from api.queues.models import Queue
-from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.enums import (
+    CaseStatusEnum,
+    CaseSubStatusIdEnum,
+)
 
 from lite_routing.routing_rules_internal.enums import QueuesEnum
 
@@ -55,12 +58,14 @@ class AppealApplicationTests(DataTestClient):
             appeal.documents.all(),
             AppealDocument.objects.none(),
         )
-
         self.assertEqual(
             self.application.status.status,
             CaseStatusEnum.UNDER_APPEAL,
         )
-
+        self.assertEqual(
+            str(self.application.sub_status.pk),
+            CaseSubStatusIdEnum.UNDER_APPEAL__REQUEST_RECEIVED,
+        )
         self.assertIn(
             Queue.objects.get(id=QueuesEnum.LU_APPEALS),
             self.application.queues.all(),


### PR DESCRIPTION
### Aim

Set sub-status when a case has been appealed. 

[LTD-4233](https://uktrade.atlassian.net/browse/LTD-4233)


[LTD-4233]: https://uktrade.atlassian.net/browse/LTD-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ