### PR TITLE
Fix licence document quantity value not showing

### DIFF
--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -1048,7 +1048,7 @@ def _get_goods_context(application, final_advice, licence=None):
     # we need to make sure only to keep approved goods that are not in proviso goods
     # otherwise goods are duplicated in the licence document. Also we need to copy quantity
     # and value data from the approve good object to the proviso good object.
-    if AdviceType.PROVISO in goods_context:
+    if goods_context[AdviceType.PROVISO] is not []:
         approve_goods = goods_context[AdviceType.APPROVE]
         proviso_goods = goods_context[AdviceType.PROVISO]
         # Copy quantity and value data from approve good to proviso good

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -1048,7 +1048,7 @@ def _get_goods_context(application, final_advice, licence=None):
     # we need to make sure only to keep approved goods that are not in proviso goods
     # otherwise goods are duplicated in the licence document. Also we need to copy quantity
     # and value data from the approve good object to the proviso good object.
-    if goods_context[AdviceType.PROVISO] is not []:
+    if goods_context[AdviceType.PROVISO] != []:
         approve_goods = goods_context[AdviceType.APPROVE]
         proviso_goods = goods_context[AdviceType.PROVISO]
         # Copy quantity and value data from approve good to proviso good

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -1044,14 +1044,16 @@ def _get_goods_context(application, final_advice, licence=None):
             good_on_application = goods_on_application_dict[advice.good_id]
             goods_context[advice.type].append(_get_good_on_application_context_with_advice(good_on_application, advice))
 
-    # Because we append goods that are approved with proviso to the approved goods below
-    # we need to remove them from the approved goods list otherwise they are duplicated
-    # in the licence document.
-    proviso_good_ids = [item["id"] for item in goods_context[AdviceType.PROVISO]]
-    if proviso_good_ids:
-        current_approved_goods = goods_context.pop(AdviceType.APPROVE)
-        goods_context[AdviceType.APPROVE] = [
-            item for item in current_approved_goods if item["id"] not in proviso_good_ids
+    # Because we append goods that are approved with proviso to the approved goods below,
+    # only add proviso goods if they are not already in approved goods. If the lists are
+    # equal then keep the data in approved goods as this has gone through the
+    # `_get_good_on_licence_context()` function above which adds quantity and value data
+    # from the good_on_licence and formats it to show in the generated document.
+    if AdviceType.PROVISO in goods_context:
+        proviso_goods = goods_context[AdviceType.PROVISO]
+        current_approved_goods = goods_context[AdviceType.APPROVE]
+        goods_context[AdviceType.PROVISO] = [
+            item for item in proviso_goods if item["id"] not in [item["id"] for item in current_approved_goods]
         ]
 
     # Move proviso elements into approved because they are treated the same

--- a/api/letter_templates/tests/test_context_generation.py
+++ b/api/letter_templates/tests/test_context_generation.py
@@ -593,8 +593,8 @@ class DocumentContextGenerationTests(DataTestClient):
         good_on_licence = GoodOnLicenceFactory(good=good_on_application, quantity=3, value=420, licence=licence)
 
         context = get_document_context(case)
-        render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
+        self.assertNotIn(AdviceType.PROVISO, context["goods"])
         self.assertEqual(context["goods"][AdviceType.APPROVE][0]["quantity"], "3.0 Items")
         self.assertEqual(context["goods"][AdviceType.APPROVE][0]["value"], "£420.00")
 
@@ -625,7 +625,6 @@ class DocumentContextGenerationTests(DataTestClient):
         good_on_licence = GoodOnLicenceFactory(good=good_on_application, quantity=3, value=420, licence=licence)
 
         context = get_document_context(case)
-        render_to_string(template_name="letter_templates/case_context_test.html", context=context)
 
         self.assertEqual(context["goods"][AdviceType.APPROVE][0]["quantity"], "3.0 Items")
         self.assertEqual(context["goods"][AdviceType.APPROVE][0]["value"], "£420.00")


### PR DESCRIPTION
### Aim

This is a fix for the production issue where licence quantities and values were not showing on the generated licence document. This affected multiple exporters who raised the issue to lite support.

After initial investigation it looked as if the issue was appearing only for PROVISO licences. Due to an earlier change which fixed the variable output in the generated document from `applied_for_quantity`  and `applied_for_value` to `quantity` and `value` taken from the good on licence, the quantity and value was not showing on the generated licence document.

The problem is in the way PROVISO good data are combined with APPROVE good data in the context generator.

This PR fixes the issue in a way that makes sure we are still using the correct data taken from the good on licence, but combines the APPROVE and PROVISO data in a way that the quantity and value fields are copied from the APPROVE data to the PROVISO data and this then gets put back into APPROVE later in the context function (the other parts of the function could use simplifying, but is out of scope for the time being...) so that, finally, all fields show on the generated licence document as expected.

[LTD-4240](https://uktrade.atlassian.net/browse/LTD-4240)


[LTD-4240]: https://uktrade.atlassian.net/browse/LTD-4240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ