### PR TITLE
[LTD-4277] Add various fields to precedent API response

### DIFF
--- a/api/cases/tests/test_good_precedents_view.py
+++ b/api/cases/tests/test_good_precedents_view.py
@@ -1,6 +1,11 @@
+from pytz import timezone
+
 from api.flags.enums import SystemFlags
 from parameterized import parameterized
 from api.goods.enums import GoodStatus
+from api.staticdata.control_list_entries.models import ControlListEntry
+from api.staticdata.regimes.models import RegimeEntry
+from api.staticdata.report_summaries.models import ReportSummarySubject, ReportSummaryPrefix
 from test_helpers.clients import DataTestClient
 from api.applications.tests.factories import GoodOnApplicationFactory
 from django.urls import reverse
@@ -24,29 +29,82 @@ class GoodPrecedentsListViewTests(DataTestClient):
         # Create another application
         self.draft_2 = self.create_draft_standard_application(self.organisation)
         self.gona_2 = GoodOnApplicationFactory(
-            good=self.good, application=self.draft_2, quantity=10, report_summary="test2"
+            good=self.good,
+            application=self.draft_2,
+            quantity=10,
+            report_summary="test2",
+            is_good_controlled=True,
+            is_ncsc_military_information_security=False,
+            comment="Classic product",
         )
+        self.gona_2.control_list_entries.add(ControlListEntry.objects.get(rating="ML1a"))
+        self.gona_2.regime_entries.add(RegimeEntry.objects.get(name="Wassenaar Arrangement"))
+        self.gona_2.report_summary_prefix = ReportSummaryPrefix.objects.get(name="components for")
+        self.gona_2.report_summary_subject = ReportSummarySubject.objects.get(name="neural computers")
+        self.gona_2.save()
         self.submit_application(self.draft_2)
         self.url = reverse("cases:good_precedents", kwargs={"pk": self.case.id})
 
-    @parameterized.expand(
-        [(GoodStatus.DRAFT, 0), (GoodStatus.SUBMITTED, 0), (GoodStatus.QUERY, 0), (GoodStatus.VERIFIED, 1)]
-    )
-    def test_get(self, status, count):
+    @parameterized.expand([GoodStatus.DRAFT, GoodStatus.SUBMITTED, GoodStatus.QUERY])
+    def test_get_no_matching_precedents(self, status):
         self.good.status = status
         self.good.save()
         response = self.client.get(self.url, **self.gov_headers)
         assert response.status_code == 200
         json = response.json()
-        assert json["count"] == count
-        if count > 0:
-            # Check the first gona b/c it is more interesting
-            gona = json["results"][0]
-            assert gona["id"] == str(self.gona_2.id)
-            assert gona["good"] == str(self.good.id)
-            assert gona["application"] == str(self.draft_2.id)
-            assert gona["reference"] == self.draft_2.reference_code
-            assert gona["destinations"] == ["Great Britain"]
-            assert gona["wassenaar"]
-            assert gona["quantity"] == 10.0
-            assert gona["report_summary"] == "test2"
+        assert json["count"] == 0
+
+    def test_get_with_matching_precedents(self):
+        self.good.status = GoodStatus.VERIFIED
+        self.good.save()
+        response = self.client.get(self.url, **self.gov_headers)
+        assert response.status_code == 200
+        json = response.json()
+        wassenaar_regime = RegimeEntry.objects.get(name="Wassenaar Arrangement")
+        assert json == {
+            "count": 1,
+            "total_pages": 1,
+            "results": [
+                {
+                    "id": str(self.gona_2.id),
+                    "queue": None,
+                    "application": str(self.draft_2.id),
+                    "reference": self.draft_2.reference_code,
+                    "good": str(self.good.id),
+                    "report_summary": "test2",
+                    "quantity": 10.0,
+                    "unit": None,
+                    "value": None,
+                    "control_list_entries": ["ML1a"],
+                    "destinations": ["Great Britain"],
+                    "wassenaar": True,
+                    "submitted_at": self.draft_2.submitted_at.astimezone(timezone("UTC")).strftime(
+                        "%Y-%m-%dT%H:%M:%S.%fZ"
+                    ),
+                    "goods_starting_point": "",
+                    "regime_entries": [
+                        {
+                            "name": "Wassenaar Arrangement",
+                            "pk": str(wassenaar_regime.id),
+                            "shortened_name": "W",
+                            "subsection": {
+                                "name": "Wassenaar Arrangement",
+                                "pk": str(wassenaar_regime.subsection.id),
+                                "regime": {"name": "WASSENAAR", "pk": str(wassenaar_regime.subsection.regime.id)},
+                            },
+                        }
+                    ],
+                    "is_good_controlled": True,
+                    "is_ncsc_military_information_security": False,
+                    "comment": "Classic product",
+                    "report_summary_prefix": {
+                        "id": "42e813cb-a75c-4f60-a121-dbe949222dd8",  # /PS-IGNORE
+                        "name": "components for",
+                    },
+                    "report_summary_subject": {
+                        "id": "266cb5b0-85ad-49fb-8d8e-a742af9ebb4b",  # /PS-IGNORE
+                        "name": "neural computers",
+                    },
+                }
+            ],
+        }

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1184,6 +1184,10 @@ class GoodOnPrecedentList(ListAPIView):
         return (
             GoodOnApplication.objects.filter(good__in=goods, good__status=GoodStatus.VERIFIED)
             .exclude(application=case)
+            .select_related(
+                "report_summary_prefix",
+                "report_summary_subject",
+            )
             .prefetch_related(
                 "good",
                 "good__flags",

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -84,7 +84,7 @@ from api.documents.libraries.delete_documents_on_bad_request import delete_docum
 from api.documents.libraries.s3_operations import document_download_stream
 from api.documents.models import Document
 from api.goods.enums import GoodStatus
-from api.goods.serializers import GoodOnApplicationSerializer
+from api.goods.serializers import GoodOnApplicationPrecedentSerializer
 from api.licences.models import Licence
 from api.licences.service import get_case_licences
 from api.organisations.libraries.get_organisation import get_request_user_organisation_id
@@ -1175,7 +1175,7 @@ class CountersignDecisionAdvice(APIView):
 
 class GoodOnPrecedentList(ListAPIView):
     authentication_classes = (GovAuthentication,)
-    serializer_class = GoodOnApplicationSerializer
+    serializer_class = GoodOnApplicationPrecedentSerializer
 
     def get_queryset(self):
         case = get_case(self.kwargs["pk"])

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -767,6 +767,22 @@ class GoodOnApplicationSerializer(serializers.ModelSerializer):
         return [dest["party__country__name"] for dest in destinations]
 
 
+class GoodOnApplicationPrecedentSerializer(GoodOnApplicationSerializer):
+
+    report_summary_prefix = ReportSummaryPrefixSerializer()
+    report_summary_subject = ReportSummarySubjectSerializer()
+
+    class Meta:
+        model = GoodOnApplication
+        fields = list(GoodOnApplicationSerializer.Meta.fields) + [
+            "is_good_controlled",
+            "is_ncsc_military_information_security",
+            "comment",
+            "report_summary_prefix",
+            "report_summary_subject",
+        ]
+
+
 class GoodSerializerInternal(serializers.Serializer):
     id = serializers.UUIDField()
     name = serializers.CharField()


### PR DESCRIPTION
### Aim

This PR ensures that the following fields are present on the precedent API endpoint response;
- `is_good_controlled`
- `is_ncsc_military_information_security`
- `report_summary_prefix`
- `report_summary_subject`
- `comment`

This will enable the "previous assessments" page to show previous assessments in full and enable us to submit a previous assessment as the new assessment for a product on an application.

[LTD-4277](https://uktrade.atlassian.net/browse/LTD-4277)


[LTD-4277]: https://uktrade.atlassian.net/browse/LTD-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ