### PR TITLE
 LTD-4305-remove-none-sub-status-audit-log 

### DIFF
--- a/api/applications/tests/test_application_sub_status.py
+++ b/api/applications/tests/test_application_sub_status.py
@@ -62,10 +62,10 @@ class ApplicationManageStatusTests(DataTestClient):
         audit = Audit.objects.filter(verb=AuditType.UPDATED_SUB_STATUS).order_by("-created_at")[0]
         self.assertEqual(
             audit.payload,
-            {"status": "Under final review", "sub_status": "none"},
+            {"status": "Under final review", "sub_status": None},
         )
         audit_text = AuditSerializer(audit).data["text"]
-        self.assertEqual(audit_text, "updated the status to Under final review - none")
+        self.assertEqual(audit_text, "updated the status to Under final review")
 
     def test_exporter_set_application_sub_status(self):
         self.assertIsNone(self.standard_application.sub_status)

--- a/api/applications/views/applications.py
+++ b/api/applications/views/applications.py
@@ -549,7 +549,7 @@ class ApplicationManageSubStatus(UpdateAPIView):
         response_data = super().put(request, pk)
 
         if not sub_status:
-            sub_status = "none"
+            sub_status = None
         else:
             sub_status = CaseSubStatus.objects.get(id=sub_status).name
         # Update the model


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4305

remove 'none' in audit log working when reseting sub status 