### PR TITLE
Stabilise to configuration for cflinuxfs3 and swig

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: CFLAGS=-I/home/vcap/deps/1/python/include/python3.8.18m pip3 install endesive==1.5.9 && python manage.py migrate && gunicorn --worker-class gevent -c api/conf/gconfig.py -b 0.0.0.0:$PORT api.conf.wsgi
+web: SWIG_LIB=/home/vcap/deps/0/apt/usr/share/swig3.0 CFLAGS=-I/home/vcap/deps/1/python/include/python3.8.18m pip3 install endesive==1.5.9 && python manage.py migrate && gunicorn --worker-class gevent -c api/conf/gconfig.py -b 0.0.0.0:$PORT api.conf.wsgi
 worker: python manage.py process_tasks
 celeryworker: celery -A api.conf worker -l info

--- a/apt.yml
+++ b/apt.yml
@@ -1,2 +1,3 @@
 packages:
 - swig
+- swig3.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ applications:
     memory: 1G
     health-check-type: http
     health-check-http-endpoint: /healthcheck/
+    stack: cflinuxfs3


### PR DESCRIPTION
This explicitly sets versions for the cf stack and swig in preparation for the cflinuxfs4 upgrade

These are currently the implicit versions but it's once we upgrade the stack and swig version these changes become "sticky" and mean that even if we try to rollback we can still be stuck with these versions, if these are set explicitly then if we need to rollback it will rollback to these specific versions
