### PR TITLE
Update stack to cflinuxfs4

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: SWIG_LIB=/home/vcap/deps/0/apt/usr/share/swig3.0 CFLAGS=-I/home/vcap/deps/1/python/include/python3.8.18m pip3 install endesive==1.5.9 && python manage.py migrate && gunicorn --worker-class gevent -c api/conf/gconfig.py -b 0.0.0.0:$PORT api.conf.wsgi
+web: SWIG_LIB=/home/vcap/deps/0/apt/usr/share/swig4.0 CFLAGS=-I/home/vcap/deps/1/python/include/python3.8.18m pip3 install endesive==1.5.9 && python manage.py migrate && gunicorn --worker-class gevent -c api/conf/gconfig.py -b 0.0.0.0:$PORT api.conf.wsgi
 worker: python manage.py process_tasks
 celeryworker: celery -A api.conf worker -l info

--- a/apt.yml
+++ b/apt.yml
@@ -1,3 +1,3 @@
 packages:
 - swig
-- swig3.0
+- swig4.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,4 @@ applications:
     memory: 1G
     health-check-type: http
     health-check-http-endpoint: /healthcheck/
-    stack: cflinuxfs3
+    stack: cflinuxfs4


### PR DESCRIPTION
This is to upgrade to this particular stack before gov paas forcibly upgrades for us in November

This makes the following changes to ensure the new stack works:

  - Adds an explicit version of swig - When the new stack is set this automatically starts using swig4.0 instead of swig3.0, to ensure consistency with future rollouts I have pinned the version here
  - Adds the the SWIG_LIB env to the Procfile
    - This was originally set in vault and was pointing to the swig3.0 directory, to make sure this is more obvious I have added this explicitly to the Procfile
    - swig is required to install pykcs which is a sub-dependency of endesive
