### PR TITLE
 LTD-4282-report-sla-numbers

### DIFF
--- a/api/cases/management/commands/sla_processing_time_report.py
+++ b/api/cases/management/commands/sla_processing_time_report.py
@@ -1,0 +1,111 @@
+from datetime import datetime, time, timedelta
+from django.db.models import Q
+from django.conf import settings
+from django.utils import timezone
+from pytz import timezone as tz
+
+from api.cases.models import EcjuQuery
+from api.common.dates import is_weekend, is_bank_holiday
+from api.audit_trail.models import Audit, AuditType
+from api.cases.models import Case
+
+SLA_CUTOFF_START_TIME = time(9, 0, 0)
+SLA_CUTOFF_END_TIME = time(17, 0, 0)
+
+
+def get_all_case_sla():
+    case_sla_records = []
+    for case in Case.objects.all():
+        case_sla_records.append(get_case_sla(case))
+    return case_sla_records
+
+
+def today(time=None):
+    """
+    returns today's date with the provided time
+    """
+    if not time:
+        time = timezone.localtime().time()
+    return datetime.combine(timezone.localtime(), time, tzinfo=tz(settings.TIME_ZONE))
+
+
+def get_case_sla(case):
+
+    elapsed_days = 0
+    working_days = 0
+    sla_days = 0
+    rfi_working_days = 0
+    rfi_non_working_days = 0
+
+    start_date = get_start_date(case)
+    end_date = get_end_date(case)
+
+    if start_date:
+        for date in daterange(start_date, end_date):
+            elapsed_days += 1
+            if not is_bank_holiday(date, call_api=True) and not is_weekend(date):
+                # `Check cut off time for on `start_date
+                working_days += 1
+                if not is_active_ecju_queries(date, case.id):
+                    rfi_working_days += 1
+            elif is_active_ecju_queries(date, case.id):
+                rfi_non_working_days += 1
+
+    return {
+        "id": case.id,
+        "reference_code": case.reference_code,
+        "elapsed_days": elapsed_days,
+        "working_days": working_days,
+        "rfi_queries": EcjuQuery.objects.filter(case_id=case.id).count(),
+        "elapsed__rfi_days": rfi_working_days + rfi_non_working_days,
+        "rfi_working_days": rfi_working_days,
+        "sla_days": sla_days,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+
+def get_start_date(case):
+    update_audit_logs = Audit.objects.filter(target_object_id=case.id, verb=AuditType.UPDATED_STATUS).order_by(
+        "created_at"
+    )
+
+    for update_audit_log in update_audit_logs:
+        if update_audit_log.payload.get("status", {}).get("new", "").lower() == "submitted":
+            return update_audit_log.created_at
+
+
+def get_end_date(case):
+    update_audit_logs = Audit.objects.filter(target_object_id=case.id, verb=AuditType.UPDATED_STATUS).order_by(
+        "-created_at"
+    )
+    for update_audit_log in update_audit_logs:
+        if update_audit_log.payload.get("status", {}).get("new", "").lower() in ("finalised", "withdrawn"):
+            return update_audit_log.created_at
+    return today(time=SLA_CUTOFF_END_TIME)
+
+
+def daterange(start_date, end_date):
+    days_dif = int((datetime.combine(end_date, time.max) - datetime.combine(start_date, time.max)).days) + 1
+    for n in range(days_dif):
+        days_dif -= 1
+        if days_dif == 0:
+            yield end_date
+        else:
+            yield start_date + timedelta(n)
+
+
+def is_active_ecju_queries(date, case_id):
+    date_start_time = datetime.combine(date, time.min)
+    date_end_time = datetime.combine(date, time.max)
+    return EcjuQuery.objects.filter(
+        # Queries we haven't responded to
+        Q(responded_at__isnull=True) & Q(created_at__lte=date_end_time)
+        # Queries in this timeframe
+        | (Q(created_at__lte=date_end_time) & Q(responded_at__gte=date_end_time))
+        # Queries created today
+        | Q(created_at__range=(date_start_time, date_end_time))
+        # Queries responded today
+        | Q(responded_at__range=(date_start_time, date_end_time)),
+        Q(case_id=case_id),
+    ).exists()

--- a/api/cases/management/commands/tests/test_sla_processing_time_report.py
+++ b/api/cases/management/commands/tests/test_sla_processing_time_report.py
@@ -1,0 +1,213 @@
+from unittest import mock
+
+from datetime import time, datetime
+from api.audit_trail.models import Audit
+
+from parameterized import parameterized
+from freezegun import freeze_time
+from django.test import TestCase
+from django.utils import timezone
+
+from api.audit_trail.enums import AuditType
+from test_helpers.clients import DataTestClient
+
+from api.cases.management.commands.sla_processing_time_report import (
+    today,
+    get_end_date,
+    get_start_date,
+    daterange,
+    is_active_ecju_queries,
+    get_all_case_sla,
+)
+
+
+@freeze_time("2020-01-01 12:00:01")
+class TodayTestCase(TestCase):
+    def test_today_without_time(self):
+        output = today()
+        self.assertEqual(
+            output,
+            datetime(2020, 1, 1, 12, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+    def test_today_with_time(self):
+        output = today(time=time(1, 0, 1))
+        self.assertEqual(
+            output,
+            datetime(2020, 1, 1, 1, 0, 1, tzinfo=timezone.get_current_timezone()),
+        )
+
+
+class SlaProcessingTimeReport(DataTestClient):
+    TODAY = datetime(2020, 2, 12)
+    TZINFO = timezone.get_current_timezone()
+
+    def setUp(self):
+        super().setUp()
+        self.standard_application = self.create_draft_standard_application(self.organisation)
+        self.case = self.submit_application(self.standard_application)
+
+    def create_case_submitted_audit_event(self, case):
+        return self.create_audit(
+            verb=AuditType.UPDATED_STATUS,
+            target=case,
+            payload={"status": {"new": "submitted"}},
+            actor=self.gov_user,
+        )
+
+    def create_case_finalised_audit_event(self, case):
+        return self.create_audit(
+            verb=AuditType.UPDATED_STATUS,
+            target=case,
+            payload={"status": {"new": "finalised"}},
+            actor=self.gov_user,
+        )
+
+    @freeze_time("2020-01-01 12:00:01")
+    def test_get_end_date_no_audit(self):
+        self.assertEqual(
+            get_end_date(self.case), datetime.combine(timezone.localtime(), time(17, 0, 0), tzinfo=self.TZINFO)
+        )
+
+    @freeze_time("2020-01-05 12:15:01")
+    def test_get_end_date_with_audit(self):
+
+        audit = self.create_case_finalised_audit_event(self.case)
+        self.assertEqual(get_end_date(self.case), audit.created_at)
+
+    def test_get_end_date(self):
+        Audit.objects.filter()
+        audit = self.create_case_finalised_audit_event(self.case)
+        self.assertEqual(get_end_date(self.case), audit.created_at)
+
+    def test_get_start_date_audit_test(self):
+
+        Audit.objects.filter(target_object_id=self.case.id).delete()
+        self.create_audit(
+            verb=AuditType.UPDATED_STATUS,
+            target=self.case,
+            payload={"status": {"new": "unknown"}},
+            actor=self.gov_user,
+        )
+
+        self.assertEqual(get_start_date(self.case), None)
+
+    def test_date_range(self):
+        date_start = datetime(2020, 1, 1, 12, 0, 1, tzinfo=self.TZINFO)
+        date_end = datetime(2020, 3, 2, 17, 0, 5, tzinfo=self.TZINFO)
+        date_list = list(daterange(date_start, date_end))
+        self.assertEqual(len(date_list), 62)
+        self.assertEqual(date_list[0], date_start)
+        self.assertEqual(date_list[-1], date_end)
+
+    @parameterized.expand(
+        [
+            (datetime(2020, 1, 1, 12, 0, 1), None, True),
+            (datetime(2020, 3, 17, 12, 0, 1), None, True),
+            (datetime(2020, 3, 17, 9, 0, 1), datetime(2020, 3, 17, 9, 0, 15), True),
+            (datetime(2020, 3, 1, 9, 0, 1), datetime(2020, 3, 19, 9, 0, 15), True),
+            (datetime(2020, 1, 1, 12, 0, 1), datetime(2020, 3, 1, 12, 0, 1), False),
+            (datetime(2020, 4, 1, 17, 0, 1), datetime(2020, 5, 17, 12, 0, 1), False),
+            (datetime(2020, 5, 1, 12, 0, 1), None, False),
+        ]
+    )
+    def test_is_active_ecju_queries(self, query_created_at, query_responded_at, expected):
+        query_date = datetime(2020, 3, 17, 12, 0, 1, tzinfo=self.TZINFO)
+        self.create_ecju_query(case=self.case, created_at=query_created_at, responded_at=query_responded_at)
+        has_queries = is_active_ecju_queries(query_date, self.case.id)
+        self.assertEqual(has_queries, expected)
+
+    @freeze_time("2022-01-05 12:25:01")
+    @mock.patch("api.cases.management.commands.sla_processing_time_report.is_bank_holiday")
+    @mock.patch("api.cases.management.commands.sla_processing_time_report.is_weekend")
+    def test_get_case_sla_records(self, mock_is_bank_holiday, mock_is_weekend):
+        mock_is_bank_holiday.return_value = False
+        mock_is_weekend.return_value = False
+
+        audit_submitted = self.create_case_submitted_audit_event(self.case)
+        audit_submitted.created_at = datetime(2022, 1, 1, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_submitted.save()
+        audit_finalised = self.create_case_finalised_audit_event(self.case)
+        audit_finalised.created_at = datetime(2022, 2, 2, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_finalised.save()
+
+        self.case_1 = self.submit_application(self.create_draft_standard_application(self.organisation))
+
+        audit_submitted_1 = self.create_case_submitted_audit_event(self.case_1)
+        audit_submitted_1.created_at = datetime(2019, 4, 1, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_submitted_1.save()
+        audit_finalised_2 = self.create_case_finalised_audit_event(self.case_1)
+        audit_finalised_2.created_at = datetime(2019, 4, 18, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_finalised_2.save()
+
+        self.create_ecju_query(
+            case=self.case_1, created_at=datetime(2019, 4, 10, 9, 0, 1), responded_at=datetime(2019, 4, 14, 9, 0, 1)
+        )
+
+        sla_report = get_all_case_sla()
+        case_1 = sla_report[0]
+        case_2 = sla_report[1]
+
+        self.assertEqual(case_1["elapsed_days"], 33)
+        self.assertEqual(case_1["working_days"], 33)
+        self.assertEqual(case_1["sla_days"], 0)
+        self.assertEqual(case_1["rfi_queries"], 0)
+        self.assertEqual(case_1["start_date"], audit_submitted.created_at)
+        self.assertEqual(case_1["end_date"], audit_finalised.created_at)
+
+        self.assertEqual(case_2["elapsed_days"], 18)
+        self.assertEqual(case_2["working_days"], 18)
+        self.assertEqual(case_2["sla_days"], 0)
+        self.assertEqual(case_2["rfi_queries"], 1)
+        self.assertEqual(case_2["elapsed__rfi_days"], 13)
+        self.assertEqual(case_2["rfi_working_days"], 13)
+
+    @freeze_time("2022-01-05 12:25:01")
+    @mock.patch("api.cases.management.commands.sla_processing_time_report.is_bank_holiday")
+    @mock.patch("api.cases.management.commands.sla_processing_time_report.is_weekend")
+    def test_get_case_sla_records_bank_holiday_weekend(self, mock_is_bank_holiday, mock_is_weekend):
+        mock_is_bank_holiday.return_value = True
+        mock_is_weekend.return_value = True
+
+        audit_submitted = self.create_case_submitted_audit_event(self.case)
+        audit_submitted.created_at = datetime(2022, 1, 1, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_submitted.save()
+        audit_finalised = self.create_case_finalised_audit_event(self.case)
+        audit_finalised.created_at = datetime(2022, 2, 2, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_finalised.save()
+
+        self.case_1 = self.submit_application(self.create_draft_standard_application(self.organisation))
+
+        audit_submitted_1 = self.create_case_submitted_audit_event(self.case_1)
+        audit_submitted_1.created_at = datetime(2019, 4, 1, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_submitted_1.save()
+        audit_finalised_2 = self.create_case_finalised_audit_event(self.case_1)
+        audit_finalised_2.created_at = datetime(2019, 4, 18, 12, 0, 1, tzinfo=self.TZINFO)
+        audit_finalised_2.save()
+
+        self.create_ecju_query(
+            case=self.case_1, created_at=datetime(2019, 4, 10, 9, 0, 1), responded_at=datetime(2019, 4, 14, 9, 0, 1)
+        )
+
+        sla_report = get_all_case_sla()
+        case_1 = sla_report[0]
+        case_2 = sla_report[1]
+
+        self.assertEqual(case_1["elapsed_days"], 33)
+        self.assertEqual(case_1["working_days"], 0)
+        self.assertEqual(case_1["sla_days"], 0)
+        self.assertEqual(case_1["rfi_queries"], 0)
+
+        self.assertEqual(case_2["elapsed_days"], 18)
+        self.assertEqual(case_2["working_days"], 0)
+        self.assertEqual(case_2["sla_days"], 0)
+        self.assertEqual(case_2["rfi_queries"], 1)
+        self.assertEqual(case_2["elapsed__rfi_days"], 5)
+        self.assertEqual(case_2["rfi_working_days"], 0)
+
+    def test_get_case_sla_no_start_date(self):
+        self.case_1 = self.submit_application(self.create_draft_standard_application(self.organisation))
+        Audit.objects.filter(target_object_id=self.case_1.id).delete()
+
+        case_2 = get_all_case_sla()[1]
+        self.assertEqual(case_2["start_date"], None)

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -1092,8 +1092,12 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
 
         return letter_template
 
-    def create_ecju_query(self, case, question="ECJU question", gov_user=None):
+    def create_ecju_query(self, case, question="ECJU question", gov_user=None, created_at=None, responded_at=None):
         ecju_query = EcjuQuery(case=case, question=question, raised_by_user=gov_user if gov_user else self.gov_user)
+        if created_at:
+            ecju_query.created_at = created_at
+        if responded_at:
+            ecju_query.responded_at = responded_at
         ecju_query.save()
         return ecju_query
 


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4289

This is a WIP 

Currently this is a skeleton report which can be used to  :

- Update SLA, alter or create orginal_submission_date numbers historically 
- Create a report for all deals with SLA days to compare against submission of SLA's published historically. This will be required for business sign-off

Above will be done via management commands and migrations

improvements to follow:

- Check if a case is within SLA time parameters before adding days
- Check if a ECJU is within SLA time parameters before subtracting days
