### PR TITLE
Match the docker linux version that's on cloudfoundry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM python:3.8.18-slim
+FROM ubuntu:22.04
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 RUN apt-get update --fix-missing
-RUN apt-get install -y libpq-dev gcc \
+RUN apt-get install -y libpq-dev gcc curl \
   build-essential python3-dev python3-pip python3-setuptools python3-wheel \
   python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 \
-  libffi-dev shared-mime-info swig git imagemagick poppler-utils
+  libffi-dev shared-mime-info swig git imagemagick poppler-utils openssl
+RUN curl https://pyenv.run | bash
+ENV HOME /root
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/bin:$PATH
+RUN pyenv install -v 3.8.18
+RUN pyenv global 3.8.18
 RUN pip3 install pipenv
 ADD Pipfile* /app/
-RUN pipenv install --dev --system --deploy
-RUN pip3 install endesive==1.5.9
+RUN pipenv install --dev --deploy
+RUN pipenv install endesive==1.5.9
 ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - db
     expose:
       - 8100
-    command: python manage.py runserver 0.0.0.0:${PORT:-8100}
+    command: pipenv run python manage.py runserver 0.0.0.0:${PORT:-8100}
     networks:
       - lite
     stdin_open: true
@@ -43,7 +43,7 @@ services:
       - redis
     depends_on:
       - api
-    command: watchmedo auto-restart -d . -R -p '*.py' -- celery -A api.conf worker -l info
+    command: pipenv run watchmedo auto-restart -d . -R -p '*.py' -- celery -A api.conf worker -l info
     networks:
       - lite
 


### PR DESCRIPTION
This is so that we can have a development environment that is more consistent with our production environments

### Aim

Match linux versions to what's on cloudfoundry
