### PR TITLE
[LTD-4359] Ensure precedents API excludes products with is_good_controlled=None

### DIFF
--- a/api/cases/tests/test_good_precedents_view.py
+++ b/api/cases/tests/test_good_precedents_view.py
@@ -42,6 +42,17 @@ class GoodPrecedentsListViewTests(DataTestClient):
         self.gona_2.report_summary_prefix = ReportSummaryPrefix.objects.get(name="components for")
         self.gona_2.report_summary_subject = ReportSummarySubject.objects.get(name="neural computers")
         self.gona_2.save()
+
+        # Expect this to be missing from API responses as is_good_controlled=None
+        self.gona_3 = GoodOnApplicationFactory(
+            good=self.good,
+            application=self.draft_2,
+            quantity=10,
+            report_summary="test2",
+            is_good_controlled=None,
+            is_ncsc_military_information_security=False,
+            comment="Classic product",
+        )
         self.submit_application(self.draft_2)
         self.url = reverse("cases:good_precedents", kwargs={"pk": self.case.id})
 

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1184,6 +1184,10 @@ class GoodOnPrecedentList(ListAPIView):
         return (
             GoodOnApplication.objects.filter(good__in=goods, good__status=GoodStatus.VERIFIED)
             .exclude(application=case)
+            # Ensure any precedents we return have a non-None value for is_good_controlled.
+            # GoodOnApplication records with is_good_controlled=None are either not yet assessed
+            # or are legacy records
+            .exclude(is_good_controlled=None)
             .select_related(
                 "report_summary_prefix",
                 "report_summary_subject",


### PR DESCRIPTION
### Aim

Ensure the precedents API excludes GoodOnApplication entries with `is_good_controlled=None` from results.  These are either unassessed GoodOnApplication records or pre-date `is_good_controlled` being set on assessment, so it is best to exclude them from precedents.

[LTD-4359](https://uktrade.atlassian.net/browse/LTD-4359)


[LTD-4359]: https://uktrade.atlassian.net/browse/LTD-4359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ