### PR TITLE
LTD-4333-4335: Add option to search by applicant and assessment note

### DIFF
--- a/api/search/product/documents.py
+++ b/api/search/product/documents.py
@@ -147,7 +147,7 @@ class ProductDocumentType(Document):
 
     application = fields.NestedField(doc_class=ApplicationOnProduct)
 
-    rating_comment = fields.TextField(attr="comment", copy_to="wildcard", analyzer=descriptive_text_analyzer)
+    assessment_note = fields.TextField(attr="comment", copy_to="wildcard", analyzer=descriptive_text_analyzer)
 
     report_summary = fields.TextField(
         attr="report_summary",

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -199,6 +199,15 @@ class ProductSearchTests(DataTestClient):
         response = response.json()
         self.assertEqual(response["count"], expected_count)
 
+    @pytest.mark.elasticsearch
+    def test_product_search_by_applicant(self):
+        query_params = {"search": f"{self.organisation.name}"}
+        response = self.client.get(self.product_search_url, query_params, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = response.json()
+        self.assertEqual(response["count"], 6)
+
 
 class MoreLikeThisViewTests(DataTestClient):
     @pytest.mark.elasticsearch

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -41,6 +41,7 @@ class ProductSearchTests(DataTestClient):
             report_summary="sniper rifles",
             assessed_by=self.tau_user1,
             assessment_date=parse("2021-06-08T15:51:28.529110+00:00"),
+            comment="no concerns",
         )
 
         good = GoodFactory(
@@ -57,6 +58,7 @@ class ProductSearchTests(DataTestClient):
             report_summary="Imaging sensors",
             assessed_by=self.tau_user1,
             assessment_date=parse("2021-07-08T15:51:28.529110+00:00"),
+            comment="for industrial use only",
         )
 
         good = GoodFactory(
@@ -73,6 +75,7 @@ class ProductSearchTests(DataTestClient):
             report_summary="Magnetic sensors",
             assessed_by=self.tau_user1,
             assessment_date=parse("2022-08-20T15:51:28.529110+00:00"),
+            comment="for industrial use only",
         )
 
         good = GoodFactory(
@@ -89,6 +92,7 @@ class ProductSearchTests(DataTestClient):
             report_summary="mechanical keyboards",
             assessed_by=self.tau_user2,
             assessment_date=parse("2022-10-08T15:51:28.529110+00:00"),
+            comment="dual use",
         )
 
         good = GoodFactory(
@@ -105,6 +109,7 @@ class ProductSearchTests(DataTestClient):
             report_summary="Chemicals",
             assessed_by=self.tau_user2,
             assessment_date=parse("2023-10-21T15:51:28.529110+00:00"),
+            comment="industrial use",
         )
 
         call_command("search_index", models=["applications.GoodOnApplication"], action="rebuild", force=True)
@@ -207,6 +212,20 @@ class ProductSearchTests(DataTestClient):
 
         response = response.json()
         self.assertEqual(response["count"], 6)
+
+    @pytest.mark.elasticsearch
+    @parameterized.expand(
+        [
+            ({"search": "industrial"}, 3),
+            ({"search": "dual"}, 1),
+        ]
+    )
+    def test_product_search_by_assessment_note(self, query, expected_count):
+        response = self.client.get(self.product_search_url, query, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = response.json()
+        self.assertEqual(response["count"], expected_count)
 
 
 class MoreLikeThisViewTests(DataTestClient):

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -38,6 +38,7 @@ class ProductDocumentView(DocumentViewSet):
         "part_number",
         "control_list_entries",
         "report_summary",
+        "organisation",
     ]
 
     search_nested_fields = {

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -39,6 +39,7 @@ class ProductDocumentView(DocumentViewSet):
         "control_list_entries",
         "report_summary",
         "organisation",
+        "assessment_note",
     ]
 
     search_nested_fields = {
@@ -92,7 +93,7 @@ class ProductDocumentView(DocumentViewSet):
                         ],
                         "highlight": {
                             "fields": {
-                                "rating_comment": self.highlight_fields["*"]["options"],
+                                "assessment_note": self.highlight_fields["*"]["options"],
                             }
                         },
                     },


### PR DESCRIPTION
## Change description

Add Applicant (organisation) and assessment note to the list of fields to search.
Simple and related changes so combined into a single PR.

[LTD-4333](https://uktrade.atlassian.net/browse/LTD-4333)
[LTD-4335](https://uktrade.atlassian.net/browse/LTD-4335)


[LTD-4333]: https://uktrade.atlassian.net/browse/LTD-4333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LTD-4335]: https://uktrade.atlassian.net/browse/LTD-4335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ