### PR TITLE
Add option to search by regime

### DIFF
--- a/api/search/product/documents.py
+++ b/api/search/product/documents.py
@@ -56,6 +56,22 @@ email_analyzer = analysis.analyzer(
 )
 
 
+class Regime(InnerDoc):
+    # e.g. "W"
+    shortened_name = fields.KeywordField(
+        fields={
+            "raw": fields.KeywordField(normalizer=lowercase_normalizer),
+            "suggest": fields.CompletionField(),
+        },
+        copy_to="wildcard",
+    )
+    # e.g. "Wassenaar Arrangement"
+    name = fields.TextField(
+        copy_to="wildcard",
+        analyzer=descriptive_text_analyzer,
+    )
+
+
 class Rating(InnerDoc):
     rating = fields.KeywordField(
         fields={
@@ -169,7 +185,8 @@ class ProductDocumentType(Document):
         copy_to="wildcard",
     )
 
-    regime = fields.Keyword()
+    regime_entries = fields.NestedField(attr="regime_entries", doc_class=Regime)
+
     assessed_by = fields.NestedField(doc_class=GovUser, attr="assessed_by")
     assessment_date = fields.DateField(
         attr="assessment_date",

--- a/api/search/product/serializers.py
+++ b/api/search/product/serializers.py
@@ -32,7 +32,7 @@ class ProductDocumentSerializer(DocumentSerializer):
             "rating_comment",
             "report_summary",
             "part_number",
-            "regime",
+            "regime_entries",
             "queues",
             "assessed_by",
             "assessment_date",
@@ -41,7 +41,7 @@ class ProductDocumentSerializer(DocumentSerializer):
             "name": {"required": False, "allow_null": True},
             "canonical_name": {"required": False},
             "id": {"required": False},
-            "regime": {"required": False},
+            "regime_entries": {"required": False},
             "queues": {"required": False},
         }
 

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -25,6 +25,9 @@ class ProductSearchTests(DataTestClient):
         self.tau_user2 = GovUserFactory(
             baseuser_ptr=BaseUserFactory(first_name="TAU", last_name="Advisor2"), team=self.team
         )
+        self.tau_user3 = GovUserFactory(
+            baseuser_ptr=BaseUserFactory(first_name="TAU", last_name="Advisor3"), team=self.team
+        )
 
         # Create few products and add them to an application
         good = GoodFactory(
@@ -125,7 +128,7 @@ class ProductSearchTests(DataTestClient):
             is_good_controlled=True,
             report_summary="marine position fixing equipment",
             regime_entries=["Wassenaar Arrangement"],
-            assessed_by=self.tau_user2,
+            assessed_by=self.tau_user3,
             assessment_date=parse("2023-10-22T15:51:28.529110+00:00"),
         )
 
@@ -142,7 +145,7 @@ class ProductSearchTests(DataTestClient):
             is_good_controlled=True,
             report_summary="imaging cameras",
             regime_entries=["Wassenaar Arrangement Sensitive"],
-            assessed_by=self.tau_user2,
+            assessed_by=self.tau_user3,
             assessment_date=parse("2023-10-23T15:51:28.529110+00:00"),
         )
 
@@ -159,7 +162,7 @@ class ProductSearchTests(DataTestClient):
             is_good_controlled=True,
             report_summary="chemicals used for general laboratory work/scientific research",
             regime_entries=["CWC Schedule 3"],
-            assessed_by=self.tau_user2,
+            assessed_by=self.tau_user3,
             assessment_date=parse("2023-10-24T15:51:28.529110+00:00"),
         )
 
@@ -270,7 +273,7 @@ class ProductSearchTests(DataTestClient):
     @parameterized.expand(
         [
             ({"search": "Advisor1"}, 3),
-            ({"search": "Advisor2"}, 5),
+            ({"search": "Advisor2"}, 2),
         ]
     )
     def test_product_search_by_assessing_officer(self, query, expected_count):

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -147,7 +147,7 @@ class ProductSearchTests(DataTestClient):
         )
 
         good = GoodFactory(
-            name="mom's homemade lemonade",
+            name="controlled chemical substance",
             part_number="xyz123",
             organisation=self.organisation,
             is_good_controlled=True,
@@ -287,7 +287,7 @@ class ProductSearchTests(DataTestClient):
         self.assertEqual(response.status_code, 200)
 
         response = response.json()
-        self.assertEqual(response["count"], 6)
+        self.assertEqual(response["count"], 9)
 
     @pytest.mark.elasticsearch
     @parameterized.expand(

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -112,6 +112,57 @@ class ProductSearchTests(DataTestClient):
             comment="industrial use",
         )
 
+        good = GoodFactory(
+            name="M2 Pro Max",
+            part_number="867-5309",
+            organisation=self.organisation,
+            is_good_controlled=True,
+            control_list_entries=["6A001a1d"],
+        )
+        GoodOnApplicationFactory(
+            application=self.case,
+            good=good,
+            is_good_controlled=True,
+            report_summary="marine position fixing equipment",
+            regime_entries=["Wassenaar Arrangement"],
+            assessed_by=self.tau_user2,
+            assessment_date=parse("2023-10-22T15:51:28.529110+00:00"),
+        )
+
+        good = GoodFactory(
+            name="Instax HD camera",
+            part_number="abc123xyz",
+            organisation=self.organisation,
+            is_good_controlled=True,
+            control_list_entries=["6A003b4a"],
+        )
+        GoodOnApplicationFactory(
+            application=self.case,
+            good=good,
+            is_good_controlled=True,
+            report_summary="imaging cameras",
+            regime_entries=["Wassenaar Arrangement Sensitive"],
+            assessed_by=self.tau_user2,
+            assessment_date=parse("2023-10-23T15:51:28.529110+00:00"),
+        )
+
+        good = GoodFactory(
+            name="mom's homemade lemonade",
+            part_number="xyz123",
+            organisation=self.organisation,
+            is_good_controlled=True,
+            control_list_entries=["1C35016"],
+        )
+        GoodOnApplicationFactory(
+            application=self.case,
+            good=good,
+            is_good_controlled=True,
+            report_summary="chemicals used for general laboratory work/scientific research",
+            regime_entries=["CWC Schedule 3"],
+            assessed_by=self.tau_user2,
+            assessment_date=parse("2023-10-24T15:51:28.529110+00:00"),
+        )
+
         call_command("search_index", models=["applications.GoodOnApplication"], action="rebuild", force=True)
 
     @pytest.mark.elasticsearch
@@ -177,9 +228,34 @@ class ProductSearchTests(DataTestClient):
     @pytest.mark.elasticsearch
     @parameterized.expand(
         [
+            ({"search": "Wassenaar Arrangement"}, 2, "W", "Wassenaar Arrangement"),
+            ({"search": "WS"}, 1, "WS", "Wassenaar Arrangement Sensitive"),
+            ({"search": "CWC 3"}, 1, "CWC 3", "CWC Schedule 3"),
+        ]
+    )
+    def test_product_search_by_regime(
+        self, query, expected_count, expected_regime_shortened_name, expected_regime_name
+    ):
+        response = self.client.get(self.product_search_url, query, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = response.json()
+        self.assertEqual(response["count"], expected_count)
+        self.assertIn(
+            expected_regime_shortened_name,
+            [entry["shortened_name"] for item in response["results"] for entry in item["regime_entries"]],
+        )
+        self.assertIn(
+            expected_regime_name,
+            [entry["name"] for item in response["results"] for entry in item["regime_entries"]],
+        )
+
+    @pytest.mark.elasticsearch
+    @parameterized.expand(
+        [
             ({"search": "sensor"}, 2, "Magnetic sensors"),
             ({"search": "sensor"}, 2, "Imaging sensors"),
-            ({"search": "chemicals"}, 1, "Chemicals"),
+            ({"search": "chemicals"}, 2, "Chemicals"),
         ]
     )
     def test_product_search_by_report_summary(self, query, expected_count, expected_report_summary):
@@ -194,7 +270,7 @@ class ProductSearchTests(DataTestClient):
     @parameterized.expand(
         [
             ({"search": "Advisor1"}, 3),
-            ({"search": "Advisor2"}, 2),
+            ({"search": "Advisor2"}, 5),
         ]
     )
     def test_product_search_by_assessing_officer(self, query, expected_count):

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -33,19 +33,13 @@ class ProductDocumentView(DocumentViewSet):
         filter_backends.HighlightBackend,
     ]
 
-    search_fields = [
-        "name",
-        "part_number",
-        "control_list_entries",
-        "report_summary",
-        "organisation",
-        "assessment_note",
-    ]
+    search_fields = ["name", "part_number", "control_list_entries", "report_summary", "regime_entries"]
 
     search_nested_fields = {
         # explicitly defined to make highlighting work
         "clc": {"path": "control_list_entries", "fields": ["rating", "text", "parent"]},
         "assessed_by": {"path": "assessed_by", "fields": ["first_name", "last_name", "email"]},
+        "regime_entries": {"path": "regime_entries", "fields": ["shortened_name", "name"]},
     }
 
     filter_fields = {

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -33,7 +33,14 @@ class ProductDocumentView(DocumentViewSet):
         filter_backends.HighlightBackend,
     ]
 
-    search_fields = ["name", "part_number", "control_list_entries", "report_summary", "regime_entries"]
+    search_fields = [
+        "name",
+        "part_number",
+        "control_list_entries",
+        "report_summary",
+        "organisation",
+        "assessment_note",
+    ]
 
     search_nested_fields = {
         # explicitly defined to make highlighting work


### PR DESCRIPTION
### Aim

Update the product search API to support searching by regime. Both the regime `name` and `shortened_name` can be searched on.

[LTD-4330](https://uktrade.atlassian.net/browse/LTD-4330)


[LTD-4330]: https://uktrade.atlassian.net/browse/LTD-4330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ