### PR TITLE
Augment search results with model instances

### DIFF
--- a/api/search/product/serializers.py
+++ b/api/search/product/serializers.py
@@ -9,6 +9,7 @@ from api.search import models
 
 
 class ProductDocumentSerializer(DocumentSerializer):
+    name = serializers.SerializerMethodField()
     highlight = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
     index = serializers.SerializerMethodField()
@@ -19,7 +20,6 @@ class ProductDocumentSerializer(DocumentSerializer):
         document = documents.ProductDocumentType
         fields = (
             "id",
-            "name",
             "description",
             "control_list_entries",
             "ratings",
@@ -52,6 +52,9 @@ class ProductDocumentSerializer(DocumentSerializer):
         if field_name in self.Meta.extra_kwargs:
             kwargs.update(self.Meta.extra_kwargs[field_name])
         return kwargs
+
+    def get_name(self, obj):
+        return obj.instance.name
 
     def get_highlight(self, obj):
         if hasattr(obj.meta, "highlight"):

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -256,6 +256,7 @@ class ProductSearchTests(DataTestClient):
         view.request = request
         view.format_kwarg = None
         queryset = view.get_queryset()
+        view.augment_hits_with_instances(queryset)
         serializer = view.get_serializer(queryset, many=True)
         actual_fields = serializer.data[0].keys()
 

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -61,17 +61,21 @@ class ProductSearchTests(DataTestClient):
         ]
     )
     @patch("api.search.product.views.ProductDocumentView", spec=True)
-    def test_product_search_pagination(self, paginator, response_type, view):
+    def test_product_search_pagination(self, pagination, response_type, view):
         """
         We override `list()` method in the view to augment search hits with model instances.
         Depending on pagination is set or not the response varies. If there is pagination
         we get count, previous and next fields in the response otherwise it is just a list.
         To avoid conditions in the test we just test for the type of response.
         """
-        setattr(view.__class__, "pagination_class", paginator)
+        current_pagination = getattr(view.__class__, "pagination_class")
+        setattr(view.__class__, "pagination_class", pagination)
         response = self.client.get(self.product_search_url, {"search": "shifter"}, **self.gov_headers)
         self.assertEqual(response.status_code, 200)
         assert type(response.json()) == response_type
+
+        # revert as we are updating class attribute
+        setattr(view.__class__, "pagination_class", current_pagination)
 
     @pytest.mark.elasticsearch
     @parameterized.expand(

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -1,3 +1,4 @@
+from django_elasticsearch_dsl.search import Search
 from django_elasticsearch_dsl_drf import filter_backends
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from elasticsearch_dsl.query import Query
@@ -81,6 +82,11 @@ class ProductDocumentView(DocumentViewSet):
 
     highlight_fields = {"*": {"enabled": True, "options": {"pre_tags": ["<b>"], "post_tags": ["</b>"]}}}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.search = Search(using=self.client, index=self.index, doc_type=self.document._doc_type.name)
+
     def get_search_indexes(self):
         if self.request.GET.get("database") in settings.ELASTICSEARCH_PRODUCT_INDEXES:
             return settings.ELASTICSEARCH_PRODUCT_INDEXES[self.request.GET["database"]]
@@ -148,7 +154,8 @@ class ProductDocumentView(DocumentViewSet):
                 }
             }
         )
-        return super().get_queryset()
+        queryset = super().get_queryset()
+        return queryset
 
 
 class ProductSuggestDocumentView(APIView):

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -1,4 +1,3 @@
-from django_elasticsearch_dsl.search import Search
 from django_elasticsearch_dsl_drf import filter_backends
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from elasticsearch_dsl.query import Query


### PR DESCRIPTION
## Change description

We define an elastic search document type based on a model which allows to index the fields we are interested in.
These are later useful to perform searches based on those fields and results contain the fields specified in the document.
However we have requirement where we want to show additional details from the model which are not necessarily index and made available for search.
To achieve this we need to augment the search results (hits) with model instances so that at the time of generating the response we can include additional fields using the model instance.

In this case we override the `list()` method that the plugin uses and hydrate the results with additional fields.

[LTD-4429](https://uktrade.atlassian.net/browse/LTD-4429)


[LTD-4429]: https://uktrade.atlassian.net/browse/LTD-4429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ