### PR TITLE
LTD-4395 - Ensure previous assessment table only shows assessments from cases that went past TAU

### DIFF
--- a/api/cases/tests/test_good_precedents_view.py
+++ b/api/cases/tests/test_good_precedents_view.py
@@ -68,7 +68,23 @@ class GoodPrecedentsListViewTests(DataTestClient):
             comment="Classic product",
         )
 
-        # TODO: Add applications with statuses that should not be returned -
+        unwanted_draft_application = self.create_draft_standard_application(self.organisation)
+        goa = GoodOnApplicationFactory(
+            good=self.good,
+            application=unwanted_draft_application,
+            quantity=10,
+            report_summary="test2",
+            is_good_controlled=True,
+            is_ncsc_military_information_security=False,
+            comment="Classic product",
+        )
+        goa.control_list_entries.add(ControlListEntry.objects.get(rating="ML1a"))
+        goa.regime_entries.add(RegimeEntry.objects.get(name="Wassenaar Arrangement"))
+        goa.report_summary_prefix = ReportSummaryPrefix.objects.get(name="components for")
+        goa.report_summary_subject = ReportSummarySubject.objects.get(name="neural computers")
+        goa.save()
+
+        self.submit_application(unwanted_draft_application)
 
         self.url = reverse("cases:good_precedents", kwargs={"pk": self.case.id})
 

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1179,10 +1179,19 @@ class GoodOnPrecedentList(ListAPIView):
 
     def get_queryset(self):
         case = get_case(self.kwargs["pk"])
-        gonas = GoodOnApplication.objects.filter(application=case).all()
-        goods = {gona.good_id for gona in gonas}
+        goods = (
+            GoodOnApplication.objects.filter(application=case)
+            .order_by("good_id")
+            .distinct("good_id")
+            .values_list("good_id", flat=True)
+        )
+
         return (
-            GoodOnApplication.objects.filter(good__in=goods, good__status=GoodStatus.VERIFIED)
+            GoodOnApplication.objects.filter(
+                application__status__status__in=CaseStatusEnum.post_tau_statuses,
+                good__in=goods,
+                good__status=GoodStatus.VERIFIED,
+            )
             .exclude(application=case)
             # Ensure any precedents we return have a non-None value for is_good_controlled.
             # GoodOnApplication records with is_good_controlled=None are either not yet assessed

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1188,7 +1188,7 @@ class GoodOnPrecedentList(ListAPIView):
 
         return (
             GoodOnApplication.objects.filter(
-                application__status__status__in=CaseStatusEnum.post_tau_statuses,
+                application__status__status__in=CaseStatusEnum.precedent_statuses,
                 good__in=goods,
                 good__status=GoodStatus.VERIFIED,
             )

--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -71,7 +71,7 @@ class CaseStatusEnum:
 
     compliance_visit_statuses = [OPEN, UNDER_INTERNAL_REVIEW, RETURN_TO_INSPECTOR, AWAITING_EXPORTER_RESPONSE, CLOSED]
 
-    post_tau_statuses = [
+    precedent_statuses = [
         UNDER_REVIEW,
         OGD_ADVICE,
         OGD_CONSOLIDATION,

--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -71,6 +71,16 @@ class CaseStatusEnum:
 
     compliance_visit_statuses = [OPEN, UNDER_INTERNAL_REVIEW, RETURN_TO_INSPECTOR, AWAITING_EXPORTER_RESPONSE, CLOSED]
 
+    post_tau_statuses = [
+        UNDER_REVIEW,
+        OGD_ADVICE,
+        OGD_CONSOLIDATION,
+        UNDER_FINAL_REVIEW,
+        FINAL_REVIEW_COUNTERSIGN,
+        FINAL_REVIEW_SECOND_COUNTERSIGN,
+        FINALISED,
+    ]
+
     choices = [
         (APPEAL_FINAL_REVIEW, "Appeal final review"),
         (APPEAL_REVIEW, "Appeal review"),


### PR DESCRIPTION
Ensure previous assessment table only shows assessments from cases that went past TAU

This adds filtering by status, so any statuses after TAU should be filtered out - it's acknowledged in the original ticket that to not be perfect - status may not be the only thing that decides this - but in practice, for the assessments here this gets us most of the way there.