### PR TITLE
 fix-GeneratedDocumentSendTests 

### DIFF
--- a/api/cases/generated_documents/tests/test_views.py
+++ b/api/cases/generated_documents/tests/test_views.py
@@ -60,11 +60,10 @@ class GeneratedDocumentSendTests(DataTestClient):
         # Check add audit
         self.assertEqual(Audit.objects.all().count(), 2)
 
-        audit = Audit.objects.all().first()
-        self.assertEqual(AuditType(audit.verb), AuditType.DECISION_LETTER_SENT)
+        audit = Audit.objects.get(verb=AuditType.DECISION_LETTER_SENT)
         self.assertEqual(
             audit.payload,
-            {"decision": "inform", "case_reference": "GBSIEL/2023/0000001/P"},
+            {"decision": "inform", "case_reference": self.case.reference_code},
         )
         audit_text = AuditSerializer(audit).data["text"]
         self.assertEqual(audit_text, "sent an inform letter.")
@@ -111,10 +110,11 @@ class GeneratedDocumentSendTests(DataTestClient):
         mocked_notify_function.assert_called_with(self.case.get_case())
 
         # Check add audit
+
         audit = Audit.objects.get(verb=AuditType.DECISION_LETTER_SENT)
         self.assertEqual(
             audit.payload,
-            {"decision": "inform", "case_reference": "GBSIEL/2023/0000001/P"},
+            {"decision": "inform", "case_reference": self.case.reference_code},
         )
 
         audit_text = AuditSerializer(audit).data["text"]

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -234,6 +234,9 @@ class ProductSearchTests(DataTestClient):
 
     @classmethod
     def tearDownClass(cls):
+        # Clean up all the objects created for these tests
+        # Some other tests expecting certain reference codes and count of goods
+        # so they will fail if these are not cleanedup properly.
         Good.objects.filter(organisation=cls.organisation).delete()
         GovUser.objects.filter(team=cls.team).delete()
         cls.application.delete()

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -213,30 +213,24 @@ def get_products_data(organisation, application, gov_users):
 class ProductSearchTests(DataTestClient):
     product_search_url = reverse("product_search-list")
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.organisation = OrganisationFactory(name="Product search")
-        cls.application = StandardApplicationFactory()
+    def setUp(self):
+        super().setUp()
+        self.organisation = OrganisationFactory(name="Product search")
+        self.application = StandardApplicationFactory()
 
-        cls.team = TeamFactory()
-        cls.tau_users = [
-            GovUserFactory(baseuser_ptr=BaseUserFactory(**user), team=cls.team) for user in get_users_data()
+        self.team = TeamFactory()
+        self.tau_users = [
+            GovUserFactory(baseuser_ptr=BaseUserFactory(**user), team=self.team) for user in get_users_data()
         ]
 
         # Create few products and add them to an application
-        for product in get_products_data(cls.organisation, cls.application, cls.tau_users):
+        for product in get_products_data(self.organisation, self.application, self.tau_users):
             GoodOnApplicationFactory(good=GoodFactory(**product["good"]), **product["good_on_application"])
 
         # Rebuild indexes with the products created
         call_command("search_index", models=["applications.GoodOnApplication"], action="rebuild", force=True)
 
-    @classmethod
-    def tearDownClass(cls):
-        Good.objects.filter(organisation=cls.organisation).delete()
-        GovUser.objects.filter(team=cls.team).delete()
-        cls.application.delete()
-        cls.team.delete()
+        
 
     def test_search_results_serializer(self):
         document = ProductDocumentType()

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -230,8 +230,6 @@ class ProductSearchTests(DataTestClient):
         # Rebuild indexes with the products created
         call_command("search_index", models=["applications.GoodOnApplication"], action="rebuild", force=True)
 
-        
-
     def test_search_results_serializer(self):
         document = ProductDocumentType()
         expected_fields = list(document._fields.keys())


### PR DESCRIPTION
Fixing tests where reference numbers don't match 
this could possibly be due to uncleaned up data 

