### PR TITLE
Fix SSL connection issue with UN sanctions web server

### DIFF
--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -1,5 +1,7 @@
 import itertools
 import logging
+import ssl
+import urllib3
 
 from dateutil import parser
 
@@ -18,8 +20,30 @@ import hashlib
 logger = logging.getLogger(__name__)
 
 
+class CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    # "Transport adapter" that allows us to use custom ssl_context.
+
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, ssl_context=self.ssl_context
+        )
+
+
+def get_legacy_session():
+    # https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+    session = requests.session()
+    session.mount("https://", CustomHttpAdapter(ctx))
+    return session
+
+
 def get_un_sanctions():
-    response = requests.get(settings.SANCTION_LIST_SOURCES["un_sanctions_file"])
+    response = get_legacy_session().get(settings.SANCTION_LIST_SOURCES["un_sanctions_file"])
     response.raise_for_status()
     return xmltodict.parse(
         response.content,


### PR DESCRIPTION
### Aim

Fix SSL connection issue with UN sanctions web server

This appears to have happened due to us upgrading our cryptography library for a security patch

The fix for this comes from https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled

[LTD-4436](https://uktrade.atlassian.net/browse/LTD-4436)


[LTD-4436]: https://uktrade.atlassian.net/browse/LTD-4436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ