### PR TITLE
Ltd 4439 uk sanctions name

### DIFF
--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -264,7 +264,7 @@ class Command(BaseCommand):
                     )
                     document.save()
                     successful += 1
-                except:  # pragma: no cover # noqa
+                except:  # noqa
                     failed += 1
                     logger.exception(
                         "Error loading uk sanction record -> %s",

--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -204,7 +204,7 @@ class Command(BaseCommand):
                 exc_info=True,
             )
 
-    def _get_primary_name(self, names):
+    def _get_primary_names_dict(self, names):
         backup_name = None
         for name in names:
             nametype = name.get("nametype")
@@ -239,7 +239,7 @@ class Command(BaseCommand):
                             item,
                         )
                         continue
-                    primary_name = self._get_primary_name(item["names"]["name"])
+                    primary_name = self._get_primary_names_dict(item["names"]["name"])
 
                     name = join_fields(primary_name, fields=["name1", "name2", "name3", "name4", "name5", "name6"])
                     address = ",".join(address_list)

--- a/api/external_data/management/commands/ingest_sanctions.py
+++ b/api/external_data/management/commands/ingest_sanctions.py
@@ -204,9 +204,9 @@ class Command(BaseCommand):
                 exc_info=True,
             )
 
-    def _get_primary_name(self, item):
+    def _get_primary_name(self, names):
         backup_name = None
-        for name in item["names"]["names"]:
+        for name in names:
             nametype = name.get("nametype")
             if not nametype:
                 continue
@@ -233,7 +233,13 @@ class Command(BaseCommand):
                     for address_item in item.get("addresses", {}).get("address", []):
                         address_list.append(" ".join(address_item.values()))
 
-                    primary_name = self._get_primary_name(item)
+                    if "names" not in item:
+                        logger.warning(
+                            "No name found for record %s",
+                            item,
+                        )
+                        continue
+                    primary_name = self._get_primary_name(item["names"]["name"])
 
                     name = join_fields(primary_name, fields=["name1", "name2", "name3", "name4", "name5", "name6"])
                     address = ",".join(address_list)
@@ -266,7 +272,9 @@ class Command(BaseCommand):
                         exc_info=True,
                     )
             logger.info(
-                f"uk sanctions (successful:{successful} failed:{failed})",
+                "uk sanctions (successful:%s failed:%s)",
+                successful,
+                failed,
             )
         except:  # pragma: no cover # noqa
             logger.exception(

--- a/api/external_data/management/commands/tests/test_ingest_sanctions.py
+++ b/api/external_data/management/commands/tests/test_ingest_sanctions.py
@@ -884,3 +884,84 @@ class PopulateSanctionsTests(DataTestClient):
 
         doc = documents.SanctionDocumentType.get("uk:5678")
         self.assertEqual(doc.name, "Primary name")
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_primary_name_no_names_record_ignored(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "5678",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name1": "Primary name",
+                            "nametype": "Primary Name",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [],
+            }
+        }
+
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [],
+                },
+                "entities": {
+                    "entity": [],
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        with self.assertRaises(NotFoundError):
+            documents.SanctionDocumentType.get("uk:1234")
+
+        doc = documents.SanctionDocumentType.get("uk:5678")
+        self.assertEqual(doc.name, "Primary name")

--- a/api/external_data/management/commands/tests/test_ingest_sanctions.py
+++ b/api/external_data/management/commands/tests/test_ingest_sanctions.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import Index, Search
 import requests_mock
 
@@ -600,3 +601,286 @@ class PopulateSanctionsTests(DataTestClient):
                 content=b"<designations><designation>Designation</designation></designations>",
             )
             ingest_sanctions.get_uk_sanctions_list()
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_primary_name_variation(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "Primary name variation test",
+                            "nametype": "Primary Name Variation",
+                        },
+                        {
+                            "name1": "Primary name variation test alias",
+                            "nametype": "alias",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [],
+            }
+        }
+
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [],
+                },
+                "entities": {
+                    "entity": [],
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        doc = documents.SanctionDocumentType.get("uk:1234")
+        self.assertEqual(doc.name, "Primary name variation test")
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_primary_name_takes_precedence_over_variation(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "Primary name variation test",
+                            "nametype": "Primary Name Variation",
+                        },
+                        {
+                            "name1": "Primary name",
+                            "nametype": "Primary Name",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [],
+            }
+        }
+
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [],
+                },
+                "entities": {
+                    "entity": [],
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        doc = documents.SanctionDocumentType.get("uk:1234")
+        self.assertEqual(doc.name, "Primary name")
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_primary_name_no_name_type_ignored(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "No name type",
+                        },
+                        {
+                            "name1": "Primary name",
+                            "nametype": "Primary Name",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [],
+            }
+        }
+
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [],
+                },
+                "entities": {
+                    "entity": [],
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        doc = documents.SanctionDocumentType.get("uk:1234")
+        self.assertEqual(doc.name, "Primary name")
+
+    @pytest.mark.elasticsearch
+    @mock.patch.object(ingest_sanctions, "get_un_sanctions")
+    @mock.patch.object(ingest_sanctions, "get_office_financial_sanctions_implementation")
+    @mock.patch.object(ingest_sanctions, "get_uk_sanctions_list")
+    def test_populate_sanctions_primary_name_no_name_record_ignored(
+        self, mock_get_uk_sanctions_list, mock_get_office_financial_sanctions_implementation, mock_get_un_sanctions
+    ):
+        mock_get_uk_sanctions_list.return_value = [
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "1234",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "No name type",
+                        },
+                        {
+                            "name1": "Primary name",
+                            "nametype": "No primary name type",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+            {
+                "lastupdated": "2020/12/31",
+                "datedesignated": "2020/12/10",
+                "uniqueid": "unique-id",
+                "ofsigroupid": "5678",
+                "unreferencenumber": None,
+                "names": {
+                    "name": [
+                        {
+                            "name6": "No name type",
+                        },
+                        {
+                            "name1": "Primary name",
+                            "nametype": "Primary Name",
+                        },
+                    ]
+                },
+                "addresses": {
+                    "address": [
+                        {
+                            "addressLine1": "address line 1",
+                            "addressLine2": "address line 2",
+                        },
+                        {
+                            "addressLine1": "another address line 1",
+                            "addressLine2": "another address line 2",
+                        },
+                    ]
+                },
+            },
+        ]
+
+        mock_get_office_financial_sanctions_implementation.return_value = {
+            "arrayoffinancialsanctionstarget": {
+                "financialsanctionstarget": [],
+            }
+        }
+
+        mock_get_un_sanctions.return_value = {
+            "consolidated_list": {
+                "individuals": {
+                    "individual": [],
+                },
+                "entities": {
+                    "entity": [],
+                },
+            },
+        }
+
+        call_command("ingest_sanctions", rebuild=True)
+
+        with self.assertRaises(NotFoundError):
+            documents.SanctionDocumentType.get("uk:1234")
+
+        doc = documents.SanctionDocumentType.get("uk:5678")
+        self.assertEqual(doc.name, "Primary name")


### PR DESCRIPTION
### Aim

Fix issues where data coming from the sanctions third party data is missing certain pieces of data.

In these cases we either fallback to another piece of data or just ignore that particular row.

[LTD-4439](https://uktrade.atlassian.net/browse/LTD-4439)


[LTD-4439]: https://uktrade.atlassian.net/browse/LTD-4439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ