### PR TITLE
LTD-4434: Index only TAU rated control list entries

### DIFF
--- a/api/search/product/documents.py
+++ b/api/search/product/documents.py
@@ -133,8 +133,8 @@ class ProductDocumentType(Document):
         copy_to="wildcard",
         analyzer=descriptive_text_analyzer,
     )
-    control_list_entries = fields.NestedField(attr="good.control_list_entries", doc_class=Rating)
-    ratings = fields.TextField(attr="good.name", multi=True)  # is overwritten in prepare
+    control_list_entries = fields.NestedField(attr="control_list_entries", doc_class=Rating)
+    ratings = fields.TextField(attr="good.name", multi=True)
 
     queues = fields.NestedField(doc_class=Queue, attr="application.queues")
 
@@ -227,7 +227,7 @@ class ProductDocumentType(Document):
         return data
 
     def prepare_ratings(self, instance):
-        return [cle.rating for cle in instance.good.control_list_entries.all()]
+        return [cle.rating for cle in instance.control_list_entries.all()]
 
     def prepare_regimes(self, instance):
         regimes = []

--- a/api/search/product/documents.py
+++ b/api/search/product/documents.py
@@ -134,7 +134,7 @@ class ProductDocumentType(Document):
         analyzer=descriptive_text_analyzer,
     )
     control_list_entries = fields.NestedField(attr="control_list_entries", doc_class=Rating)
-    ratings = fields.TextField(attr="good.name", multi=True)
+    ratings = fields.TextField(multi=True)
 
     queues = fields.NestedField(doc_class=Queue, attr="application.queues")
 

--- a/api/search/product/tests/test_helpers.py
+++ b/api/search/product/tests/test_helpers.py
@@ -41,6 +41,7 @@ test_applications_data = [
                     "report_summary": "sniper rifles",
                     "assessment_date": parse("2021-06-08T15:51:28.529110+00:00"),
                     "comment": "no concerns",
+                    "control_list_entries": ["FR AI"],
                 },
             },
             {
@@ -48,13 +49,14 @@ test_applications_data = [
                     "name": "Thermal camera",
                     "part_number": "IMG-1300",
                     "is_good_controlled": True,
-                    "control_list_entries": ["6A003"],
+                    "control_list_entries": ["6A005"],
                 },
                 "good_on_application": {
                     "is_good_controlled": True,
                     "report_summary": "Imaging sensors",
                     "assessment_date": parse("2021-07-08T15:51:28.529110+00:00"),
                     "comment": "for industrial use only",
+                    "control_list_entries": ["6A003"],
                 },
             },
             {
@@ -69,6 +71,7 @@ test_applications_data = [
                     "report_summary": "Magnetic sensors",
                     "assessment_date": parse("2022-08-20T15:51:28.529110+00:00"),
                     "comment": "for industrial use only",
+                    "control_list_entries": ["6A006"],
                 },
             },
         ],
@@ -107,6 +110,7 @@ test_applications_data = [
                     "is_good_controlled": True,
                     "report_summary": "components for spectrometers",
                     "comment": "Research and development. Potentially under WVS regime",
+                    "control_list_entries": ["6A004"],
                 },
             },
             {
@@ -121,6 +125,7 @@ test_applications_data = [
                     "report_summary": "mechanical keyboards",
                     "assessment_date": parse("2022-10-08T15:51:28.529110+00:00"),
                     "comment": "dual use",
+                    "control_list_entries": ["PL9010"],
                 },
             },
             {
@@ -135,6 +140,7 @@ test_applications_data = [
                     "report_summary": "Chemicals",
                     "assessment_date": parse("2023-10-21T15:51:28.529110+00:00"),
                     "comment": "industrial use",
+                    "control_list_entries": ["1D003"],
                 },
             },
         ],
@@ -167,13 +173,14 @@ test_applications_data = [
                     "name": "M3 Pro Max",
                     "part_number": "867-5309",
                     "is_good_controlled": True,
-                    "control_list_entries": ["6A001a1d"],
+                    "control_list_entries": ["MEND2"],
                 },
                 "good_on_application": {
                     "is_good_controlled": True,
                     "report_summary": "marine position fixing equipment",
                     "regime_entries": ["Wassenaar Arrangement"],
                     "assessment_date": parse("2023-10-22T15:51:28.529110+00:00"),
+                    "control_list_entries": ["6A001a1d"],
                 },
             },
             {
@@ -188,6 +195,7 @@ test_applications_data = [
                     "report_summary": "components for imaging cameras",
                     "regime_entries": ["Wassenaar Arrangement Sensitive"],
                     "assessment_date": parse("2023-10-23T15:51:28.529110+00:00"),
+                    "control_list_entries": ["6A003b4a"],
                 },
             },
             {
@@ -202,6 +210,7 @@ test_applications_data = [
                     "report_summary": "chemicals used for general laboratory work/scientific research",
                     "regime_entries": ["CWC Schedule 3"],
                     "assessment_date": parse("2023-10-24T15:51:28.529110+00:00"),
+                    "control_list_entries": ["1C35016"],
                 },
             },
             {
@@ -215,6 +224,7 @@ test_applications_data = [
                     "is_good_controlled": False,
                     "report_summary": "technology for shotguns",
                     "assessment_date": parse("2023-08-24T15:51:28.529110+00:00"),
+                    "control_list_entries": ["ML22a"],
                 },
             },
         ],

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -121,19 +121,21 @@ class ProductSearchTests(DataTestClient):
     @pytest.mark.elasticsearch
     @parameterized.expand(
         [
-            ({"search": "PL9010"}, 1, "PL9010"),
-            ({"search": "6A003"}, 1, "6A003"),
-            ({"search": "6A006"}, 1, "6A006"),
+            ({"search": "PL9010"}, 1, ["PL9010"]),
+            ({"search": "6A003"}, 1, ["6A003"]),
+            ({"search": "6A006"}, 1, ["6A006"]),
+            ({"search": "6A005"}, 0, []),
+            ({"search": "MEND2"}, 0, []),
         ]
     )
-    def test_product_search_by_control_list_entries(self, query, expected_count, expected_cle):
+    def test_product_search_by_control_list_entries(self, query, expected_count, expected_cles):
         response = self.client.get(self.product_search_url, query, **self.gov_headers)
         self.assertEqual(response.status_code, 200)
 
         response = response.json()
         self.assertEqual(response["count"], expected_count)
-        self.assertIn(
-            expected_cle, [entry["rating"] for item in response["results"] for entry in item["control_list_entries"]]
+        self.assertEqual(
+            expected_cles, [entry["rating"] for item in response["results"] for entry in item["control_list_entries"]]
         )
 
     @pytest.mark.elasticsearch


### PR DESCRIPTION
## Change description

Index only the ratings provided by TAU.
Exporter suggested ratings need not be indexed.

[LTD-4434](https://uktrade.atlassian.net/browse/LTD-4434)


[LTD-4434]: https://uktrade.atlassian.net/browse/LTD-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ