### PR TITLE
LTD-4468: Add endpoint to provide suggestions for the search terms

### DIFF
--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -302,6 +302,56 @@ class ProductSearchTests(DataTestClient):
         self.assertEqual(response["count"], expected_count)
 
 
+class ProductSearchSuggestionsTests(ProductSearchTests):
+    product_suggest_url = reverse("product_suggest")
+
+    @pytest.mark.elasticsearch
+    @parameterized.expand(
+        [
+            (
+                {"q": "camera"},
+                [
+                    {"field": "name", "value": "Instax HD camera", "index": "lite"},
+                    {"field": "report_summary", "value": "components for imaging cameras", "index": "lite"},
+                    {"field": "name", "value": "Thermal camera", "index": "lite"},
+                ],
+            ),
+            (
+                {"q": "te"},
+                [
+                    {"field": "report_summary", "value": "technology for shotguns", "index": "lite"},
+                ],
+            ),
+            (
+                {"q": "1"},
+                [
+                    {"field": "ratings", "value": "1D003", "index": "lite"},
+                    {"field": "ratings", "value": "1C35016", "index": "lite"},
+                    {"field": "part_number", "value": "15606", "index": "lite"},
+                ],
+            ),
+            (
+                {"q": "ai"},
+                [
+                    {"field": "ratings", "value": "FR AI", "index": "lite"},
+                ],
+            ),
+            (
+                {"q": "sh"},
+                [
+                    {"field": "name", "value": "Frequency shifter", "index": "lite"},
+                    {"field": "report_summary", "value": "technology for shotguns", "index": "lite"},
+                ],
+            ),
+        ]
+    )
+    def test_product_search_suggestions(self, query, expected_suggestions):
+        response = self.client.get(self.product_suggest_url, query, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json(), expected_suggestions)
+
+
 class MoreLikeThisViewTests(DataTestClient):
     @pytest.mark.elasticsearch
     def test_more_like_this_404(self):

--- a/api/search/product/urls.py
+++ b/api/search/product/urls.py
@@ -12,7 +12,7 @@ router.register(r"search", views.ProductDocumentView, basename="product_search")
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("suggest/", views.ProductSuggestDocumentView.as_view(), name="product_suggest"),
+    path("suggest-poc/", views.ProductSuggestPoCDocumentView.as_view(), name="product_suggest_poc"),
     path("spire/<str:pk>/comment/", views.CommentView.as_view(), name="retrieve_spire_product_comment"),
     path("lite/<uuid:pk>/comment/", views.CommentView.as_view(), name="retrieve_lite_product_comment"),
     path("lite/<uuid:pk>/", views.RetrieveLiteProductView.as_view(), name="retrieve_lite_product"),

--- a/api/search/product/urls.py
+++ b/api/search/product/urls.py
@@ -12,6 +12,7 @@ router.register(r"search", views.ProductDocumentView, basename="product_search")
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("suggest/", views.ProductSuggestDocumentView.as_view(), name="product_suggest"),
     path("suggest-poc/", views.ProductSuggestPoCDocumentView.as_view(), name="product_suggest_poc"),
     path("spire/<str:pk>/comment/", views.CommentView.as_view(), name="retrieve_spire_product_comment"),
     path("lite/<uuid:pk>/comment/", views.CommentView.as_view(), name="retrieve_lite_product_comment"),

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -187,7 +187,7 @@ class ProductDocumentView(DocumentViewSet):
         return Response(serializer.data)
 
 
-class ProductSuggestDocumentView(APIView):
+class ProductSuggestPoCDocumentView(APIView):
     allowed_http_methods = ["get"]
     authentication_classes = (GovAuthentication,)
 

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -193,6 +193,9 @@ class ProductSuggestDocumentView(RetrieveAPIView):
     def get(self, request):
         query_str = self.request.GET.get("q", "")
 
+        # Use only most recent word to look for suggestions
+        query_str = query_str.split()[-1]
+
         query = {
             "size": 5,
             "query": {

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -193,16 +193,6 @@ class ProductSuggestDocumentView(RetrieveAPIView):
     def get(self, request):
         query_str = self.request.GET.get("q", "")
 
-        # Use only most recent word to look for suggestions
-        #
-        # Suggestions are shown to the user as they start typing search terms
-        # however they can choose to ignore and enter their own query.
-        # In such cases when they start typing second word then we are expected to show
-        # suggestions for this word rather than the whole phrase.
-        # Considering whole phrase won't help as they are unlikely to be any suggestions.
-        # eg if they enter "ML1a AND ri", then we show suggestions for 'ri'
-        query_str = query_str.split()[-1]
-
         query = {
             "size": 15,
             "query": {

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -197,7 +197,7 @@ class ProductSuggestDocumentView(RetrieveAPIView):
         query_str = query_str.split()[-1]
 
         query = {
-            "size": 5,
+            "size": 15,
             "query": {
                 "multi_match": {
                     "query": query_str,


### PR DESCRIPTION
## Change description

To help users specify a data category when performing a search we are providing suggestions by checking which fields given search term matches with. This is done using multi match prefix query where prefix match is performed on each word. Highlight indicates where given search term is matched and these fields are returned as suggestions.

[LTD-4468](https://uktrade.atlassian.net/browse/LTD-4468)

[LTD-4468]: https://uktrade.atlassian.net/browse/LTD-4468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ