### PR TITLE
LTD-4475: Add assessing officer details from model instance

### DIFF
--- a/api/search/product/serializers.py
+++ b/api/search/product/serializers.py
@@ -13,6 +13,7 @@ class ProductDocumentSerializer(DocumentSerializer):
     name = serializers.SerializerMethodField()
     quantity = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
+    assessed_by_full_name = serializers.SerializerMethodField()
     highlight = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
     index = serializers.SerializerMethodField()
@@ -66,7 +67,10 @@ class ProductDocumentSerializer(DocumentSerializer):
         return obj.instance.quantity
 
     def get_value(self, obj):
-        return obj.instance.value.to_eng_string()
+        return obj.instance.value
+
+    def get_assessed_by_full_name(self, obj):
+        return obj.instance.assessed_by.full_name if obj.instance.assessed_by else ""
 
     def get_highlight(self, obj):
         if hasattr(obj.meta, "highlight"):
@@ -91,7 +95,8 @@ class ProductDocumentSerializer(DocumentSerializer):
             key = str(instance.id)
             additional_fields_data[key] = {
                 "quantity": instance.quantity,
-                "value": instance.value.to_eng_string(),
+                "value": instance.value,
+                "assessed_by_full_name": instance.assessed_by.full_name if instance.assessed_by else "",
             }
 
         return additional_fields_data

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -301,6 +301,31 @@ class ProductSearchTests(DataTestClient):
         response = response.json()
         self.assertEqual(response["count"], expected_count)
 
+    @pytest.mark.elasticsearch
+    @parameterized.expand(
+        [
+            (
+                {"search": "ABC-123"},
+                1,
+                {
+                    "quantity": 5,
+                    "value": 1200.00,
+                    "assessed_by_full_name": "TAU Advisor1",
+                },
+            ),
+        ]
+    )
+    def test_product_search_additional_fields(self, query, expected_count, expected_data):
+        response = self.client.get(self.product_search_url, query, **self.gov_headers)
+        self.assertEqual(response.status_code, 200)
+
+        response = response.json()
+        hits = response["results"]
+        self.assertEqual(len(hits), expected_count)
+
+        for key, value in expected_data.items():
+            self.assertEqual(hits[0][key], value)
+
 
 class MoreLikeThisViewTests(DataTestClient):
     @pytest.mark.elasticsearch

--- a/api/users/models.py
+++ b/api/users/models.py
@@ -120,7 +120,6 @@ class GovNotification(BaseNotification):
 
 
 class BaseUserCompatMixin:
-
     baseuser_ptr: BaseUser
 
     @property
@@ -134,6 +133,10 @@ class BaseUserCompatMixin:
     @property
     def last_name(self):
         return self.baseuser_ptr.last_name
+
+    @property
+    def full_name(self):
+        return f"{self.baseuser_ptr.first_name} {self.baseuser_ptr.last_name}"
 
     @property
     def email(self):
@@ -159,7 +162,6 @@ class BaseUserCompatMixin:
 
 
 class ExporterUser(models.Model, BaseUserCompatMixin):
-
     baseuser_ptr = models.OneToOneField(
         BaseUser,
         on_delete=models.CASCADE,
@@ -190,7 +192,6 @@ class ExporterUser(models.Model, BaseUserCompatMixin):
 
 
 class GovUser(models.Model, BaseUserCompatMixin):
-
     baseuser_ptr = models.OneToOneField(
         BaseUser,
         on_delete=models.CASCADE,


### PR DESCRIPTION
## Change description

We index `assessed_by` but it is better if we expose this from model instance as this field can be `None` and we can perform all the checks in the serializer and return a value to just display in the template.

[LTD-4475](https://uktrade.atlassian.net/browse/LTD-4475)


[LTD-4475]: https://uktrade.atlassian.net/browse/LTD-4475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ