### PR TITLE
LTD-4511: Increase the maximum number of suggestions retrieved from the query

### DIFF
--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -196,7 +196,7 @@ class ProductSuggestDocumentView(RetrieveAPIView):
         query_str = self.request.GET.get("q", "")
 
         query = {
-            "size": 15,
+            "size": 30,
             "query": {
                 "multi_match": {
                     "query": query_str,


### PR DESCRIPTION
## Change description

We run a query to retrieve suggestions for the given search string and specify the number of maximum results which is 15 at the moment.

In some cases eg for destinations we could get many hits. In case of consignee, end-user and ultimate end-users if the destination is same for all these parties, depending on the total number of applications for these destinations total count may well exceed 15 and we may not include certain party types hence we miss showing either one or more of these party types in some cases.

Increase the count to 30 to make sure all categories are included in suggestions.

It is to be noted that this is the maximum number of hits so we may not always get this number of hits. Also we limit the number of suggestions to show in frontend which is 10.

[LTD-4511](https://uktrade.atlassian.net/browse/LTD-4511)


[LTD-4511]: https://uktrade.atlassian.net/browse/LTD-4511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ