### PR TITLE
LTD-4525: Don't show suggestions for assessment_note

### DIFF
--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -212,7 +212,6 @@ class ProductSuggestDocumentView(RetrieveAPIView):
                         "consignee_country",
                         "end_user_country",
                         "ultimate_end_user_country",
-                        "assessment_note",
                     ],
                 }
             },


### PR DESCRIPTION
## Change description

Assessment note can be very long; searching and looking for suggestions in this doesn't provide much value. It is also difficult to edit query string if a suggestion related to assessment_note is selected.

[LTD-4525](https://uktrade.atlassian.net/browse/LTD-4525)


[LTD-4525]: https://uktrade.atlassian.net/browse/LTD-4525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ