### PR TITLE
Use custom serializer for countersign user

### DIFF
--- a/api/applications/serializers/advice.py
+++ b/api/applications/serializers/advice.py
@@ -16,7 +16,6 @@ from api.goodstype.models import GoodsType
 from api.gov_users.serializers import (
     GovUserListSerializer,
     GovUserSimpleSerializer,
-    GovUserViewSerializer,
 )
 from lite_content.lite_api import strings
 from api.parties.enums import PartyType
@@ -24,7 +23,7 @@ from api.parties.models import Party
 from api.staticdata.countries.models import Country
 from api.staticdata.denial_reasons.models import DenialReason
 from api.teams.models import Team
-from api.teams.serializers import TeamReadOnlySerializer
+from api.teams.serializers import TeamSerializer, TeamReadOnlySerializer
 from api.users.models import GovUser
 from api.users.enums import UserStatuses
 
@@ -270,13 +269,29 @@ class CountersignDecisionAdviceSerializer(serializers.ModelSerializer):
         list_serializer_class = CountersignAdviceWithDecisionListSerializer
 
 
+class CountersignedUserSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField(source="baseuser_ptr_id")
+    team = TeamSerializer()
+
+    class Meta:
+        model = GovUser
+        fields = (
+            "id",
+            "first_name",
+            "last_name",
+            "email",
+            "team",
+        )
+        read_only_fields = fields
+
+
 class CountersignDecisionAdviceViewSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     valid = serializers.BooleanField()
     order = serializers.IntegerField()
     outcome_accepted = serializers.BooleanField()
     reasons = serializers.CharField()
-    countersigned_user = GovUserViewSerializer()
+    countersigned_user = CountersignedUserSerializer()
     advice = AdviceViewSerializer()
 
 


### PR DESCRIPTION
### Aim

Add a custom user serializer that doesn't have the role nested serializer for countersign advice.

This is due to the fact that this ends up being a deeply nested serializer that ends up creating a significant number of unused objects (~20,000). Removing this causes a significant speed improvement.

[LTD-4530](https://uktrade.atlassian.net/browse/LTD-4530)


[LTD-4530]: https://uktrade.atlassian.net/browse/LTD-4530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ