### PR TITLE
Increase the number of product suggestions we obtain from opensearch

### DIFF
--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -196,7 +196,7 @@ class ProductSuggestDocumentView(RetrieveAPIView):
         query_str = self.request.GET.get("q", "")
 
         query = {
-            "size": 30,
+            "size": 150,
             "query": {
                 "multi_match": {
                     "query": query_str,


### PR DESCRIPTION
This is due to the fact that we collapse down the number of results to make them unique so given a lot of duplicates we might end up with far fewer results than we expect

From testing in some cases starting off with 30 only return 5 results after collapsing for uniqueness

To work around this we're just grabbing a larger number from opensearch to ensure we get a larger number of results after the unique filter

This could still potentially bring back fewer results than we want but this is a quick fix to solve the problem

