### PR TITLE
Fix invalid query 400 response

### DIFF
--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -256,7 +256,7 @@ class ProductSearchTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response = response.json()
-        self.assertEqual(response["errors"]["error"], "Invalid search string")
+        self.assertEqual(response["errors"]["search"], "Invalid search string")
 
     @pytest.mark.elasticsearch
     @parameterized.expand(

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -245,19 +245,18 @@ class ProductSearchTests(DataTestClient):
     @pytest.mark.elasticsearch
     @parameterized.expand(
         [
-            ({"search": "sensor AND"}, 0),
-            ({"search": "sensor OR"}, 0),
-            ({"search": "sensor AND (image NOT)"}, 0),
-            ({"search": "AND sensor"}, 0),
+            ({"search": "sensor AND"},),
+            ({"search": "sensor OR"},),
+            ({"search": "sensor AND (image NOT)"},),
+            ({"search": "AND sensor"},),
         ]
     )
-    def test_product_search_syntax_error(self, query, expected_count):
+    def test_product_search_syntax_error(self, query):
         response = self.client.get(self.product_search_url, query, **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         response = response.json()
-        self.assertEqual(response["error"], "Invalid search string")
-        self.assertEqual(response["count"], expected_count)
+        self.assertEqual(response["errors"]["error"], "Invalid search string")
 
     @pytest.mark.elasticsearch
     @parameterized.expand(

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
+from rest_framework.exceptions import ValidationError
 
 from django.conf import settings
 from django.db.models import Case, When
@@ -116,19 +117,10 @@ class ProductDocumentView(DocumentViewSet):
         response = self.document._index.validate_query(body=query)
         return response["valid"]
 
-    def dispatch(self, request, *args, **kwargs):
-        self.search._index = self.get_search_indexes()
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
         if not self.validate_search_terms():
-            return JsonResponse(
-                data={
-                    "error": "Invalid search string",
-                    "results": [],
-                    "count": 0,
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        return super().dispatch(request, *args, **kwargs)
+            raise ValidationError({"error": "Invalid search string"})
 
     def get_queryset(self):
         self.search._index = self.get_search_indexes()

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -118,7 +118,7 @@ class ProductDocumentView(DocumentViewSet):
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)
         if not self.validate_search_terms():
-            raise ValidationError({"error": "Invalid search string"})
+            raise ValidationError({"search": "Invalid search string"})
 
     def get_queryset(self):
         self.search._index = self.get_search_indexes()

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -2,7 +2,6 @@ from django_elasticsearch_dsl_drf import filter_backends
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from elasticsearch_dsl.query import Query
 
-from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
@@ -11,7 +10,6 @@ from rest_framework.exceptions import ValidationError
 from django.conf import settings
 from django.db.models import Case, When
 from django.db.models.fields import IntegerField
-from django.http import JsonResponse
 
 from api.core.authentication import GovAuthentication
 from api.search import models


### PR DESCRIPTION
### Aim

This is a small API change to the product search invalid query 400 response that enables a fix to the error content in the frontend.

[LTD-4537](https://uktrade.atlassian.net/browse/LTD-4537)


[LTD-4537]: https://uktrade.atlassian.net/browse/LTD-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ