### PR TITLE
When unsetting a report summary subject, the legacy report_summary fi…

### DIFF
--- a/api/assessments/serializers.py
+++ b/api/assessments/serializers.py
@@ -70,15 +70,20 @@ class AssessmentSerializer(GoodControlReviewSerializer):
         list_serializer_class = AssessmentUpdateListSerializer
 
     def validate(self, data):
-        # If we have a report summary subject, overwrite whatever report_summary value
-        # we have with the string from the subject/prefix
-        if "report_summary_subject" in data:
+        if data.get("is_good_controlled") is False:
+            # Goods that are not controlled should have a blank report summary
+
+            data["report_summary"] = None
+            data["report_summary_prefix"] = None
+            data["report_summary_subject"] = None
+        elif "report_summary_subject" in data:
+            # If we have a report summary subject, overwrite whatever report_summary value
+            # we have with the string from the subject/prefix
             if data.get("report_summary_prefix") and data.get("report_summary_subject"):
                 data["report_summary"] = f"{data['report_summary_prefix'].name} {data['report_summary_subject'].name}"
             elif data.get("report_summary_subject"):
                 data["report_summary"] = data["report_summary_subject"].name
             else:
-                # Goods that are not controlled do not need a report summary
                 data["report_summary"] = None
         return data
 

--- a/api/assessments/serializers.py
+++ b/api/assessments/serializers.py
@@ -72,11 +72,14 @@ class AssessmentSerializer(GoodControlReviewSerializer):
     def validate(self, data):
         # If we have a report summary subject, overwrite whatever report_summary value
         # we have with the string from the subject/prefix
-        if data.get("report_summary_subject"):
-            if data.get("report_summary_prefix"):
+        if "report_summary_subject" in data:
+            if data.get("report_summary_prefix") and data.get("report_summary_subject"):
                 data["report_summary"] = f"{data['report_summary_prefix'].name} {data['report_summary_subject'].name}"
-            else:
+            elif data.get("report_summary_subject"):
                 data["report_summary"] = data["report_summary_subject"].name
+            else:
+                # Goods that are not controlled do not need a report summary
+                data["report_summary"] = None
         return data
 
     def update_good(self, instance, validated_data):

--- a/api/assessments/serializers.py
+++ b/api/assessments/serializers.py
@@ -77,9 +77,7 @@ class AssessmentSerializer(GoodControlReviewSerializer):
             data["report_summary_subject"] = None
         elif "report_summary_subject" in data:
             if data["report_summary_subject"] is None:
-                raise serializers.ValidationError(
-                    {"report_summary_subject": strings.Assessment.REQUIRE_REPORT_SUMMARY_SUBJECT_ON_CONTROLLED_GOODS}
-                )
+                raise serializers.ValidationError({"report_summary_subject": strings.Picklists.REQUIRED_REPORT_SUMMARY})
 
             # If we have a report summary subject, overwrite whatever report_summary value
             # we have with the string from the subject/prefix

--- a/api/assessments/serializers.py
+++ b/api/assessments/serializers.py
@@ -72,19 +72,22 @@ class AssessmentSerializer(GoodControlReviewSerializer):
     def validate(self, data):
         if data.get("is_good_controlled") is False:
             # Goods that are not controlled should have a blank report summary
-
             data["report_summary"] = None
             data["report_summary_prefix"] = None
             data["report_summary_subject"] = None
         elif "report_summary_subject" in data:
+            if data["report_summary_subject"] is None:
+                raise serializers.ValidationError(
+                    {"report_summary_subject": strings.Assessment.REQUIRE_REPORT_SUMMARY_SUBJECT_ON_CONTROLLED_GOODS}
+                )
+
             # If we have a report summary subject, overwrite whatever report_summary value
             # we have with the string from the subject/prefix
             if data.get("report_summary_prefix") and data.get("report_summary_subject"):
                 data["report_summary"] = f"{data['report_summary_prefix'].name} {data['report_summary_subject'].name}"
-            elif data.get("report_summary_subject"):
-                data["report_summary"] = data["report_summary_subject"].name
             else:
-                data["report_summary"] = None
+                data["report_summary"] = data["report_summary_subject"].name
+
         return data
 
     def update_good(self, instance, validated_data):

--- a/api/assessments/tests/test_views.py
+++ b/api/assessments/tests/test_views.py
@@ -61,11 +61,7 @@ class MakeAssessmentsViewTests(DataTestClient):
             }
         ]
         response = self.client.put(self.assessment_url, data, **self.gov_headers)
-        expected_response_data = {
-            "errors": [
-                {"report_summary_subject": [strings.Assessment.REQUIRE_REPORT_SUMMARY_SUBJECT_ON_CONTROLLED_GOODS]}
-            ]
-        }
+        expected_response_data = {"errors": [{"report_summary_subject": [strings.Picklists.REQUIRED_REPORT_SUMMARY]}]}
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertDictEqual(response.json(), expected_response_data)

--- a/api/assessments/tests/test_views.py
+++ b/api/assessments/tests/test_views.py
@@ -213,11 +213,11 @@ class MakeAssessmentsViewTests(DataTestClient):
         all_cles = [cle.rating for cle in good_on_application_3.control_list_entries.all()]
         assert all_cles == []
         assert good_on_application_3.report_summary_prefix_id == None
-        assert good_on_application_3.report_summary_subject_id == report_summary_subject.id
+        assert good_on_application_3.report_summary_subject_id == None
         assert good_on_application_3.is_good_controlled == False
         assert good_on_application_3.comment == "some comment"
         assert good_on_application_3.is_ncsc_military_information_security == True
-        assert good_on_application_3.report_summary == report_summary_subject.name
+        assert good_on_application_3.report_summary == None
         assert good_on_application_3.assessed_by == self.gov_user
         assert good_on_application_3.assessment_date.isoformat() == "2023-11-03T12:00:00+00:00"
 


### PR DESCRIPTION
When unsetting a report summary subject, the legacy report_summary field was not being set.

On the frontend in TAU (and probably elsewhere) this manifests as the user seeing stale data, as the legacy field was used as fallback.
