### PR TITLE
LTD-4534: Update search signals to refresh Product document also

### DIFF
--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -325,6 +325,19 @@ class ProductSearchTests(DataTestClient):
         for key, value in expected_data.items():
             self.assertEqual(hits[0][key], value)
 
+    def test_application_reference_code_refresh(self):
+        application = self.create_standard_application_case(self.organisation)
+        good_on_application = application.goods.first()
+        response = self.client.get(
+            self.product_search_url, {"search": good_on_application.good.name}, **self.gov_headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = response.json()
+        hits = response["results"]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["application"]["reference_code"], application.reference_code)
+
 
 class ProductSearchSuggestionsTests(ProductSearchTests):
     product_suggest_url = reverse("product_suggest")

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -348,9 +348,9 @@ class ProductSearchSuggestionsTests(ProductSearchTests):
             (
                 {"q": "camera"},
                 [
+                    {"field": "name", "value": "Thermal camera", "index": "lite"},
                     {"field": "name", "value": "Instax HD camera", "index": "lite"},
                     {"field": "report_summary", "value": "components for imaging cameras", "index": "lite"},
-                    {"field": "name", "value": "Thermal camera", "index": "lite"},
                 ],
             ),
             (
@@ -398,8 +398,10 @@ class ProductSearchSuggestionsTests(ProductSearchTests):
     def test_product_search_suggestions(self, query, expected_suggestions):
         response = self.client.get(self.product_suggest_url, query, **self.gov_headers)
         self.assertEqual(response.status_code, 200)
+        actual = sorted(response.json(), key=lambda d: d["value"])
+        expected = sorted(expected_suggestions, key=lambda d: d["value"])
 
-        self.assertEqual(response.json(), expected_suggestions)
+        self.assertEqual(actual, expected)
 
 
 class MoreLikeThisViewTests(DataTestClient):

--- a/api/search/signals.py
+++ b/api/search/signals.py
@@ -4,12 +4,13 @@ from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from api.applications.models import BaseApplication
+from api.applications.models import BaseApplication, GoodOnApplication
+from api.goods.models import Good
 from api.search.tasks import update_search_index
 
 
 @receiver(post_save)
-def update_application_document(sender, **kwargs):
+def update_search_documents(sender, **kwargs):
     if not settings.LITE_API_ENABLE_ES or issubclass(sender, Task):
         return
 
@@ -17,32 +18,42 @@ def update_application_document(sender, **kwargs):
     model_name = sender._meta.model_name
     instance = kwargs["instance"]
 
+    application_document_model = "applications.BaseApplication"
+    product_document_model = "applications.GoodOnApplication"
+
     """
     To keep the index fresh we need to update them whenever the underlying data is updated.
     The immediate attributes of the index are handled by django_elasticsearch_dsl but
     additional changes are required to update the related models.
     The registry update code requires model corresponding to the index which is BaseApplication
-    in our case. We intercept the signals and update the index.
+    and GoodOnApplication in our case. We intercept the signals and update the index.
     """
     to_update = []
 
     if issubclass(sender, BaseApplication):
-        to_update.append(instance.baseapplication.pk)
+        to_update.append((application_document_model, instance.baseapplication.pk))
+
+    if issubclass(sender, GoodOnApplication):
+        to_update.append((product_document_model, instance.pk))
+
+    if issubclass(sender, Good):
+        for good_on_application in instance.goods_on_application.all():
+            to_update.append((product_document_model, good_on_application.pk))
 
     try:
         if app_label == "cases" and model_name == "caseassignment":
-            to_update.append(instance.case.baseapplication.pk)
+            to_update.append((application_document_model, instance.case.baseapplication.pk))
         elif app_label == "cases" and model_name == "case":
-            to_update.append(instance.baseapplication.pk)
+            to_update.append((application_document_model, instance.baseapplication.pk))
         elif app_label == "goods" and model_name == "good":
             for good in instance.goods_on_application.all():
-                to_update.append(good.application.pk)
+                to_update.append((application_document_model, good.application.pk))
         elif app_label == "parties" and model_name == "party":
             for party in instance.parties_on_application.all():
-                to_update.append(party.application.pk)
+                to_update.append((application_document_model, party.application.pk))
         elif app_label == "organisations" and model_name == "organisation":
             for case in instance.cases.all():
-                to_update.append(case.baseapplication.pk)
+                to_update.append((application_document_model, case.baseapplication.pk))
     except ObjectDoesNotExist:
         pass
 
@@ -52,4 +63,4 @@ def update_application_document(sender, **kwargs):
         if not settings.BACKGROUND_TASK_ENABLED:
             update_task = update_search_index.now
 
-        update_task("applications.BaseApplication", *map(str, to_update))
+        update_task(to_update)

--- a/api/search/tasks.py
+++ b/api/search/tasks.py
@@ -6,12 +6,12 @@ UPDATE_SEARCH_INDEX_QUEUE = "update_search_index_queue"
 
 
 @background(queue=UPDATE_SEARCH_INDEX_QUEUE, schedule=0)
-def update_search_index(model_name, *ids):
+def update_search_index(model_pk_pairs):
     """Update the search index with instances of a model as specified by
     the supplied model_name and ids.
     """
-    model = apps.get_model(model_name)
 
-    for id_ in ids:
-        instance = model.objects.get(pk=id_)
+    for model_name, pk in model_pk_pairs:
+        model = apps.get_model(model_name)
+        instance = model.objects.get(pk=str(pk))
         registry.update(instance)

--- a/api/search/tests/test_signals.py
+++ b/api/search/tests/test_signals.py
@@ -12,7 +12,7 @@ class UpdateApplicationDocumentTest(DataTestClient):
     def test_standard_application(self, mock_task):
         application = self.create_standard_application_case(self.organisation)
 
-        assert [call([("applications.BaseApplication", application.pk)])] in mock_task.call_args_list
+        mock_task.assert_any_call([("applications.BaseApplication", application.pk)])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -21,16 +21,14 @@ class UpdateApplicationDocumentTest(DataTestClient):
             self.queue, self.create_standard_application_case(self.organisation), self.gov_user
         )
 
-        assert [
-            call([("applications.BaseApplication", assignment.case.baseapplication.pk)])
-        ] in mock_task.call_args_list
+        mock_task.assert_any_call([("applications.BaseApplication", assignment.case.baseapplication.pk)])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
     def test_case(self, mock_task):
         case = self.create_standard_application_case(self.organisation).get_case()
 
-        assert [call([("applications.BaseApplication", case.baseapplication.pk)])] in mock_task.call_args_list
+        mock_task.assert_any_call([("applications.BaseApplication", case.baseapplication.pk)])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -41,7 +39,7 @@ class UpdateApplicationDocumentTest(DataTestClient):
         application.goods.add(good_on_app)
         application.save()
 
-        assert [call([("applications.BaseApplication", good_on_app.application.pk)])] in mock_task.call_args_list
+        mock_task.assert_any_call([("applications.BaseApplication", good_on_app.application.pk)])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -50,18 +48,18 @@ class UpdateApplicationDocumentTest(DataTestClient):
         party = self.create_party("test party", self.organisation, PartyType.END_USER, application=application)
         party.save()
 
-        assert [
-            call([("applications.BaseApplication", party.parties_on_application.all()[0].application.pk)])
-        ] in mock_task.call_args_list
+        mock_task.assert_any_call(
+            [("applications.BaseApplication", party.parties_on_application.all()[0].application.pk)]
+        )
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
     def test_organisation(self, mock_task):
         self.create_standard_application_case(self.organisation)
 
-        assert [
-            call([("applications.BaseApplication", self.organisation.cases.all()[0].baseapplication.pk)])
-        ] in mock_task.call_args_list
+        mock_task.assert_any_call(
+            [("applications.BaseApplication", self.organisation.cases.all()[0].baseapplication.pk)]
+        )
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -69,4 +67,4 @@ class UpdateApplicationDocumentTest(DataTestClient):
         application = self.create_standard_application_case(self.organisation)
 
         for good_on_application in application.goods.all():
-            assert [call([("applications.GoodOnApplication", good_on_application.pk)])] in mock_task.call_args_list
+            mock_task.assert_any_call([("applications.GoodOnApplication", good_on_application.pk)])

--- a/api/search/tests/test_tasks.py
+++ b/api/search/tests/test_tasks.py
@@ -10,6 +10,12 @@ class UpdateSearchIndexTests(DataTestClient):
         app1 = self.create_standard_application_case(self.organisation)
         app2 = self.create_standard_application_case(self.organisation)
 
-        update_search_index.now("applications.StandardApplication", str(app1.pk), str(app2.pk))
+        update_search_index.now(
+            [
+                ("applications.StandardApplication", app1.pk),
+                ("applications.StandardApplication", app2.pk),
+            ]
+        )
 
-        mock_registry.update.assert_has_calls([call(app1), call(app2)])
+        mock_registry.update.assert_any_call(app1)
+        mock_registry.update.assert_any_call(app2)


### PR DESCRIPTION
## Change description

Updates the various models are intercepted in save() signal to refresh the indexes however it is only updating Application document.

When an application is first submitted by Exporter we run flagging rules which result in saving of underlying 'Good' instances. At this point the ProductDocument is not refreshed so if we search for a product in this application we see the reference_code as None as if it is still in draft state. Updating product document here pulls inner document for the Application with the updated reference code.

Without this change also eventually the reference code gets refreshed as the application progresses through various teams which result in updating of product attributes but if it is in submitted state then it doesn't get updated.

[LTD-4534](https://uktrade.atlassian.net/browse/LTD-4534)


[LTD-4534]: https://uktrade.atlassian.net/browse/LTD-4534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ