### PR TITLE
[LTD-4576] Fix clear assessments endpoint

### DIFF
--- a/api/assessments/serializers.py
+++ b/api/assessments/serializers.py
@@ -70,7 +70,7 @@ class AssessmentSerializer(GoodControlReviewSerializer):
         list_serializer_class = AssessmentUpdateListSerializer
 
     def validate(self, data):
-        if data.get("is_good_controlled") is False:
+        if "is_good_controlled" in data and data["is_good_controlled"] in (False, None):
             # Goods that are not controlled should have a blank report summary
             data["report_summary"] = None
             data["report_summary_prefix"] = None

--- a/api/cases/generated_documents/tests/test_generate_document.py
+++ b/api/cases/generated_documents/tests/test_generate_document.py
@@ -1,5 +1,6 @@
 import os, io
 
+from datetime import datetime
 from unittest import mock
 from api.audit_trail.enums import AuditType
 from parameterized import parameterized
@@ -75,9 +76,10 @@ class GenerateDocumentTests(DataTestClient):
 
         audit = Audit.objects.all().first()
         self.assertEqual(AuditType(audit.verb), AuditType.GENERATE_DECISION_LETTER)
+        year_now = datetime.now().year
         self.assertEqual(
             audit.payload,
-            {"decision": advicetype, "case_reference": "GBSIEL/2023/0000001/P"},
+            {"decision": advicetype, "case_reference": f"GBSIEL/{year_now}/0000001/P"},
         )
 
         audit_text = AuditSerializer(audit).data["text"]


### PR DESCRIPTION
### Aim

TAU users are currently unable to clear assessments following the most recent changes to the assessment endpoint.  This change ensures that clear assessments works as intended.


[LTD-4576](https://uktrade.atlassian.net/browse/LTD-4576)


[LTD-4576]: https://uktrade.atlassian.net/browse/LTD-4576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ