### PR TITLE
Fix calling update search index task

### DIFF
--- a/api/search/signals.py
+++ b/api/search/signals.py
@@ -63,4 +63,6 @@ def update_search_documents(sender, **kwargs):
         if not settings.BACKGROUND_TASK_ENABLED:
             update_task = update_search_index.now
 
+        to_update = [(model_name, str(pk)) for model_name, pk in to_update]
+
         update_task(to_update)

--- a/api/search/tasks.py
+++ b/api/search/tasks.py
@@ -13,5 +13,5 @@ def update_search_index(model_pk_pairs):
 
     for model_name, pk in model_pk_pairs:
         model = apps.get_model(model_name)
-        instance = model.objects.get(pk=str(pk))
+        instance = model.objects.get(pk=pk)
         registry.update(instance)

--- a/api/search/tests/test_signals.py
+++ b/api/search/tests/test_signals.py
@@ -1,4 +1,6 @@
-from unittest.mock import call, patch
+import json
+
+from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -7,12 +9,32 @@ from test_helpers.clients import DataTestClient
 
 
 class UpdateApplicationDocumentTest(DataTestClient):
+    def assertCallsAreJSONEncodable(self, mock_func):
+        """Check that the args and kwargs for a mock function are all JSON
+        encodable.
+
+        This is useful to check when we know a function is used as a background
+        task and we want to ensure all of the arguments its called with are
+        JSON encodable as this is what the background task library will be doing
+        """
+        for mock_call in mock_func.mock_calls:
+            try:
+                json.dumps(mock_call.args)
+            except TypeError:
+                self.fail("Call args are not JSON encodable")
+
+            try:
+                json.dumps(mock_call.kwargs)
+            except TypeError:
+                self.fail("Call kwargs are not JSON encodable")
+
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
     def test_standard_application(self, mock_task):
         application = self.create_standard_application_case(self.organisation)
 
-        mock_task.assert_any_call([("applications.BaseApplication", application.pk)])
+        self.assertCallsAreJSONEncodable(mock_task)
+        mock_task.assert_any_call([("applications.BaseApplication", str(application.pk))])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -21,14 +43,16 @@ class UpdateApplicationDocumentTest(DataTestClient):
             self.queue, self.create_standard_application_case(self.organisation), self.gov_user
         )
 
-        mock_task.assert_any_call([("applications.BaseApplication", assignment.case.baseapplication.pk)])
+        self.assertCallsAreJSONEncodable(mock_task)
+        mock_task.assert_any_call([("applications.BaseApplication", str(assignment.case.baseapplication.pk))])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
     def test_case(self, mock_task):
         case = self.create_standard_application_case(self.organisation).get_case()
 
-        mock_task.assert_any_call([("applications.BaseApplication", case.baseapplication.pk)])
+        self.assertCallsAreJSONEncodable(mock_task)
+        mock_task.assert_any_call([("applications.BaseApplication", str(case.baseapplication.pk))])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -39,7 +63,8 @@ class UpdateApplicationDocumentTest(DataTestClient):
         application.goods.add(good_on_app)
         application.save()
 
-        mock_task.assert_any_call([("applications.BaseApplication", good_on_app.application.pk)])
+        self.assertCallsAreJSONEncodable(mock_task)
+        mock_task.assert_any_call([("applications.BaseApplication", str(good_on_app.application.pk))])
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
     @patch("api.search.signals.update_search_index")
@@ -48,8 +73,9 @@ class UpdateApplicationDocumentTest(DataTestClient):
         party = self.create_party("test party", self.organisation, PartyType.END_USER, application=application)
         party.save()
 
+        self.assertCallsAreJSONEncodable(mock_task)
         mock_task.assert_any_call(
-            [("applications.BaseApplication", party.parties_on_application.all()[0].application.pk)]
+            [("applications.BaseApplication", str(party.parties_on_application.all()[0].application.pk))]
         )
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
@@ -57,8 +83,9 @@ class UpdateApplicationDocumentTest(DataTestClient):
     def test_organisation(self, mock_task):
         self.create_standard_application_case(self.organisation)
 
+        self.assertCallsAreJSONEncodable(mock_task)
         mock_task.assert_any_call(
-            [("applications.BaseApplication", self.organisation.cases.all()[0].baseapplication.pk)]
+            [("applications.BaseApplication", str(self.organisation.cases.all()[0].baseapplication.pk))]
         )
 
     @override_settings(BACKGROUND_TASK_ENABLED=True, LITE_API_ENABLE_ES=True)
@@ -67,4 +94,5 @@ class UpdateApplicationDocumentTest(DataTestClient):
         application = self.create_standard_application_case(self.organisation)
 
         for good_on_application in application.goods.all():
-            mock_task.assert_any_call([("applications.GoodOnApplication", good_on_application.pk)])
+            self.assertCallsAreJSONEncodable(mock_task)
+            mock_task.assert_any_call([("applications.GoodOnApplication", str(good_on_application.pk))])


### PR DESCRIPTION
The task needs to be called with args that are JSON encodable as this is how background_task will save the args to run the task later
