### PR TITLE
Add is_query_closed property

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -612,6 +612,10 @@ class EcjuQuery(TimestampableModel):
         choices=ECJUQueryType.choices, max_length=50, default=ECJUQueryType.ECJU, null=False, blank=False
     )
 
+    @property
+    def is_query_closed(self):
+        return self.responded_at is not None
+
     notifications = GenericRelation(ExporterNotification, related_query_name="ecju_query")
 
     def save(self, *args, **kwargs):

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -617,7 +617,7 @@ class EcjuQueryDetail(APIView):
         If validate only, this will return if the data is acceptable or not.
         """
         ecju_query = get_ecju_query(ecju_pk)
-        if ecju_query.response:
+        if ecju_query.is_query_closed:
             return JsonResponse(
                 data={"errors": f"Responding to closed {ecju_query.get_query_type_display()} is not allowed"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -664,7 +664,7 @@ class EcjuQueryAddDocument(APIView):
         Adds a document to the specified good
         """
         ecju_query = get_ecju_query(kwargs["query_pk"])
-        if ecju_query.response:
+        if ecju_query.is_query_closed:
             return JsonResponse(
                 {"errors": "Adding document for a closed query is not allowed"}, status=status.HTTP_400_BAD_REQUEST
             )


### PR DESCRIPTION
### Aim

This is to decouple the response text from the "closed" status of a query, to enable closing a query without response text. There are no new tests needed as there is test coverage already in this file `api/cases/tests/test_case_ecju_queries.py`

[LTD-4614](https://uktrade.atlassian.net/browse/LTD-4614)


[LTD-4614]: https://uktrade.atlassian.net/browse/LTD-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ