### PR TITLE
LTD-4561: Wait till the lock is available before updating Licence table

### DIFF
--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http.response import JsonResponse, HttpResponse
@@ -954,6 +956,8 @@ class FinaliseView(UpdateAPIView):
                 )
 
             licence.decisions.set([Decision.objects.get(name=decision) for decision in required_decisions])
+
+            logging.info("Initiate issue of licence %s (status: %s)", licence.reference_code, licence.status)
             licence.issue()
 
             return_payload["licence"] = licence.id
@@ -976,6 +980,7 @@ class FinaliseView(UpdateAPIView):
         old_status = case.status.status
         case.status = get_case_status_by_status(CaseStatusEnum.FINALISED)
         case.save()
+        logging.info("Case status is now finalised")
 
         decisions = required_decisions.copy()
 
@@ -1016,6 +1021,8 @@ class FinaliseView(UpdateAPIView):
         documents.update(visible_to_exporter=True)
         for document in documents:
             document.send_exporter_notifications()
+
+        logging.info("Licence documents visible to exporter, notification sent")
 
         return JsonResponse(return_payload, status=status.HTTP_201_CREATED)
 

--- a/api/licences/celery_tasks.py
+++ b/api/licences/celery_tasks.py
@@ -29,6 +29,7 @@ def send_licence_details_to_lite_hmrc(licence_id, action):
     try:
         with transaction.atomic():
             # transaction.atomic + select_for_update + nowait=True will throw an error if row has already been locked
+            logger.info("Attempt to acquire lock (non-blocking) before updating licence %s", str(licence_id))
             licence = Licence.objects.select_for_update(nowait=True).get(id=licence_id)
             send_licence(licence, action)
     except HMRCIntegrationException as e:

--- a/api/licences/celery_tasks.py
+++ b/api/licences/celery_tasks.py
@@ -9,7 +9,6 @@ from api.licences.models import Licence
 
 MAX_ATTEMPTS = 5
 RETRY_BACKOFF = 1200
-DEFER_EXECUTION_DELAY = 10  # secs
 
 logger = get_task_logger(__name__)
 
@@ -28,10 +27,15 @@ def send_licence_details_to_lite_hmrc(licence_id, action):
     """
     try:
         with transaction.atomic():
-            # transaction.atomic + select_for_update + nowait=True will throw an error if row has already been locked
-            # nowait=True makes it non-blocking
-            logger.info("Attempt to acquire lock (non-blocking) before updating licence %s", str(licence_id))
-            licence = Licence.objects.select_for_update(nowait=True).get(id=licence_id)
+            # It is essential to use select_for_update() without nowait=True because
+            # if lock is not available then we need to wait here till it is available.
+            #
+            # This task is scheduled when licence is issued which is already part of a transaction.
+            # Licence row would've already been locked during that transaction so if continue
+            # without waiting it will result in OperationalError.
+            # Wait here till it is released at which point this continues execution.
+            logger.info("Attempt to acquire lock (blocking) before updating licence %s", str(licence_id))
+            licence = Licence.objects.select_for_update().get(id=licence_id)
 
             send_licence(licence, action)
     except HMRCIntegrationException as e:
@@ -54,6 +58,4 @@ def schedule_licence_details_to_lite_hmrc(licence_id, action):
 
     logger.info("Scheduling task to %s licence %s details in lite-hmrc", action, licence.reference_code)
 
-    # Defer task execution to allow for all Licence updates to complete
-    # so that the task be able to acquire lock when it executes
-    send_licence_details_to_lite_hmrc.apply_async(args=(licence_id, action), countdown=DEFER_EXECUTION_DELAY)
+    send_licence_details_to_lite_hmrc.delay(licence_id, action)

--- a/api/licences/libraries/hmrc_integration_operations.py
+++ b/api/licences/libraries/hmrc_integration_operations.py
@@ -35,7 +35,7 @@ class HMRCIntegrationException(APIException):
 def send_licence(licence: Licence, action: str):
     """Sends licence information to lite-hmrc"""
 
-    logging.info(f"Sending licence '{licence.reference_code}' with action '{action}' to lite-hmrc")
+    logging.info("Sending licence %s with action %s to lite-hmrc", licence.reference_code, action)
 
     url = f"{settings.LITE_HMRC_INTEGRATION_URL}{SEND_LICENCE_ENDPOINT}"
     data = {"licence": HMRCIntegrationLicenceSerializer(licence).data}
@@ -51,10 +51,11 @@ def send_licence(licence: Licence, action: str):
         )
 
     if response.status_code == status.HTTP_201_CREATED:
+        logging.info("Record that new licence %s with action %s is sent to lite-hmrc", licence.reference_code, action)
         licence.hmrc_integration_sent_at = timezone.now()
         licence.save()
 
-    logging.info(f"Successfully sent licence '{licence.reference_code}' with action '{action}' to lite-hmrc")
+    logging.info("Successfully sent licence %s with action %s to lite-hmrc", licence.reference_code, action)
 
 
 def get_mail_status(licence: Licence):

--- a/api/licences/libraries/hmrc_integration_operations.py
+++ b/api/licences/libraries/hmrc_integration_operations.py
@@ -33,9 +33,9 @@ class HMRCIntegrationException(APIException):
 
 
 def send_licence(licence: Licence, action: str):
-    """Sends licence information to HMRC Integration"""
+    """Sends licence information to lite-hmrc"""
 
-    logging.info(f"Sending licence '{licence.id}', action '{action}' to HMRC Integration")
+    logging.info(f"Sending licence '{licence.reference_code}' with action '{action}' to lite-hmrc")
 
     url = f"{settings.LITE_HMRC_INTEGRATION_URL}{SEND_LICENCE_ENDPOINT}"
     data = {"licence": HMRCIntegrationLicenceSerializer(licence).data}
@@ -46,15 +46,15 @@ def send_licence(licence: Licence, action: str):
 
     if response.status_code not in [status.HTTP_200_OK, status.HTTP_201_CREATED]:
         raise HMRCIntegrationException(
-            f"An unexpected response was received when sending licence '{licence.id}', action '{action}' to HMRC "
-            f"Integration -> status={response.status_code}, message={response.text}"
+            f"An unexpected response was received when sending licence '{licence.reference_code}', action '{action}' to lite-hmrc "
+            f"-> status={response.status_code}, message={response.text}"
         )
 
     if response.status_code == status.HTTP_201_CREATED:
         licence.hmrc_integration_sent_at = timezone.now()
         licence.save()
 
-    logging.info(f"Successfully sent licence '{licence.id}', action '{action}' to HMRC Integration")
+    logging.info(f"Successfully sent licence '{licence.reference_code}' with action '{action}' to lite-hmrc")
 
 
 def get_mail_status(licence: Licence):

--- a/api/licences/tests/test_api_to_hmrc_integration.py
+++ b/api/licences/tests/test_api_to_hmrc_integration.py
@@ -477,14 +477,14 @@ class HMRCIntegrationTasksTests(DataTestClient):
                 value=product.value,
             )
 
-    @mock.patch("api.licences.celery_tasks.send_licence_details_to_lite_hmrc.apply_async")
+    @mock.patch("api.licences.celery_tasks.send_licence_details_to_lite_hmrc.delay")
     def test_schedule_licence_details_to_lite_hmrc(self, send_licence_details_to_lite_hmrc_task):
         send_licence_details_to_lite_hmrc_task.return_value = None
 
         schedule_licence_details_to_lite_hmrc(str(self.standard_licence.id), self.hmrc_integration_status)
 
         send_licence_details_to_lite_hmrc_task.assert_called_with(
-            args=(str(self.standard_licence.id), self.hmrc_integration_status), countdown=10
+            str(self.standard_licence.id), self.hmrc_integration_status
         )
 
     @mock.patch("api.licences.celery_tasks.send_licence")
@@ -507,9 +507,7 @@ class HMRCIntegrationTasksTests(DataTestClient):
     def test_send_licence_to_hmrc_integration_with_background_task_success(self, send_licence):
         send_licence.return_value = None
 
-        send_licence_details_to_lite_hmrc.apply_async(
-            args=(str(self.standard_licence.id), self.hmrc_integration_status)
-        )
+        send_licence_details_to_lite_hmrc.delay(str(self.standard_licence.id), self.hmrc_integration_status)
 
         send_licence.assert_called_once()
 


### PR DESCRIPTION
# Change description

The task that sends licence details to lite-hmrc is scheduled when licence is issued which is already part of a transaction.
Licence row would've already been locked during that transaction so if continue without waiting it will result in `OperationalError`.

[LTD-4561](https://uktrade.atlassian.net/browse/LTD-4561)


[LTD-4561]: https://uktrade.atlassian.net/browse/LTD-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ