### PR TITLE
Remove sending back the exception data in the validation error

### DIFF
--- a/api/documents/celery_tasks.py
+++ b/api/documents/celery_tasks.py
@@ -32,7 +32,7 @@ def scan_document_for_viruses(self, document_id):
 
         try:
             document.scan_for_viruses()
-        except Exception as exc:  # noqa
+        except Exception:
             logger.exception("Document virus scan failed")
             raise
 

--- a/api/documents/libraries/process_document.py
+++ b/api/documents/libraries/process_document.py
@@ -4,11 +4,13 @@ from rest_framework import serializers
 
 from api.documents.celery_tasks import scan_document_for_viruses, delete_document_from_s3
 
+logger = logging.getLogger(__name__)
+
 
 def process_document(document):
     try:
         document_id = str(document.id)
         scan_document_for_viruses.apply_async(args=(document_id,), link_error=delete_document_from_s3.si(document_id))
-    except Exception as e:
-        logging.error(e)
-        raise serializers.ValidationError({"document": e})
+    except Exception:
+        logger.exception("Error scanning document with id %s for viruses", document_id)
+        raise serializers.ValidationError({"document": "Error scanning document for viruses"})


### PR DESCRIPTION
### Aim

This removes exception information from being sent back in a validation error.
