### PR TITLE
LTD-4613-add-is-ecju-query-manually-closed 

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -622,7 +622,13 @@ class EcjuQuery(TimestampableModel):
 
     @queryable_property
     def is_query_closed(self):
-        return self.responded_at is not None
+        return self.responded_by_user is not None
+
+    @queryable_property
+    def is_manually_closed(self):
+        if self.responded_by_user:
+            return GovUser.objects.filter(pk=self.responded_by_user.id).exists()
+        return False
 
     # This method allows the above propery to be used in filtering objects. Similar to db fields.
     @is_query_closed.filter(lookups=("exact",))

--- a/api/cases/serializers.py
+++ b/api/cases/serializers.py
@@ -575,6 +575,7 @@ class EcjuQueryGovSerializer(serializers.ModelSerializer):
             "query_type",
             "documents",
             "is_query_closed",
+            "is_manually_closed",
         )
 
     def get_raised_by_user_name(self, instance):
@@ -613,6 +614,7 @@ class EcjuQueryExporterViewSerializer(serializers.ModelSerializer):
             "responded_at",
             "documents",
             "is_query_closed",
+            "is_manually_closed",
         )
 
     def get_responded_by_user(self, instance):

--- a/api/cases/tests/test_case_ecju_queries.py
+++ b/api/cases/tests/test_case_ecju_queries.py
@@ -169,6 +169,7 @@ class ECJUQueriesViewTests(DataTestClient):
         self.assertEqual(ecju_query.response, None)
         self.assertEqual(str(ecju_query.case.id), response_data["ecju_query"]["case"])
         self.assertEqual(ecju_query.is_query_closed, response_data["ecju_query"]["is_query_closed"])
+        self.assertEqual(ecju_query.is_manually_closed, response_data["ecju_query"]["is_manually_closed"])
 
     def test_ecju_query_open_query_count(self):
         """
@@ -245,6 +246,7 @@ class ECJUQueriesCreateTest(DataTestClient):
         self.assertEqual(response_data["ecju_query_id"], str(ecju_query.id))
         self.assertEqual("Test ECJU Query question?", ecju_query.question)
         self.assertEqual(False, ecju_query.is_query_closed)
+        self.assertEqual(False, ecju_query.is_manually_closed)
 
         mock_notify.assert_called_with(case.id)
 
@@ -343,6 +345,9 @@ class ECJUQueriesResponseTests(DataTestClient):
         response = response.json()["ecju_query"]
         self.assertEqual(response["response"], data["response"])
 
+        response_get = self.client.get(query_response_url, data, **self.gov_headers)
+        self.assertEqual(False, response_get.json()["ecju_query"]["is_manually_closed"])
+
         query_response_audit = Audit.objects.filter(verb=AuditType.ECJU_QUERY_RESPONSE)
         self.assertTrue(query_response_audit.exists())
         audit_obj = query_response_audit.first()
@@ -377,6 +382,9 @@ class ECJUQueriesResponseTests(DataTestClient):
         audit_text = AuditSerializer(audit_obj).data["text"]
         self.assertEqual(audit_text, " manually closed a query: exporter provided details.")
         self.assertEqual(audit_obj.target.id, case.id)
+
+        response_get = self.client.get(query_response_url, data, **self.gov_headers)
+        self.assertEqual(True, response_get.json()["ecju_query"]["is_manually_closed"])
 
     def test_caseworker_manually_closes_query_exporter_responds_raises_error(self):
         case = self.create_standard_application_case(self.organisation)


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4613

As part of this change we need to know if the user who responded to a query is a GOV user 