### PR TITLE
[LTD-4710] Improve lite-api anonymisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ jobs:
       - <<: *image_python
       - <<: *image_postgres
       - <<: *image_elasticsearch
+      - <<: *image_redis
     working_directory: ~/lite-api
     environment:
       <<: *common_env_vars

--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ moto = {extras = ["s3"], version = "*"}
 [packages]
 factory-boy = "~=2.12.0"
 unittest-xml-reporting = "~=2.5.2"
-faker = "~=4.18.0"
+faker = "~=23.2.1"
 boto3 = "~=1.26.17"
 django-activity-stream = "~=0.10.0"
 django-allow-cidr = "~=0.5.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3c66c92729feb5352fb58a417bd4a4ddec7e29bb4041674f64d0cde084e825c5"
+            "sha256": "83bdf6fff2c27251a3340e2de8a845490d96c887f81874eb4b13683bebb2adc2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -326,42 +326,42 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:01911714117642a3f1792c7f376db572aadadbafcd8d75bb527166009c9f1d1b",
-                "sha256:0e89f7b84f421c56e7ff69f11c441ebda73b8a8e6488d322ef71746224c20fce",
-                "sha256:12d341bd42cdb7d4937b0cabbdf2a94f949413ac4504904d0cdbdce4a22cbf88",
-                "sha256:15a1fb843c48b4a604663fa30af60818cd28f895572386e5f9b8a665874c26e7",
-                "sha256:1cdcdbd117681c88d717437ada72bdd5be9de117f96e3f4d50dab3f59fd9ab20",
-                "sha256:1df6fcbf60560d2113b5ed90f072dc0b108d64750d4cbd46a21ec882c7aefce9",
-                "sha256:3c6048f217533d89f2f8f4f0fe3044bf0b2090453b7b73d0b77db47b80af8dff",
-                "sha256:3e970a2119507d0b104f0a8e281521ad28fc26f2820687b3436b8c9a5fcf20d1",
-                "sha256:44a64043f743485925d3bcac548d05df0f9bb445c5fcca6681889c7c3ab12764",
-                "sha256:4e36685cb634af55e0677d435d425043967ac2f3790ec652b2b88ad03b85c27b",
-                "sha256:5f8907fcf57392cd917892ae83708761c6ff3c37a8e835d7246ff0ad251d9298",
-                "sha256:69b22ab6506a3fe483d67d1ed878e1602bdd5912a134e6202c1ec672233241c1",
-                "sha256:6bfadd884e7280df24d26f2186e4e07556a05d37393b0f220a840b083dc6a824",
-                "sha256:6d0fbe73728c44ca3a241eff9aefe6496ab2656d6e7a4ea2459865f2e8613257",
-                "sha256:6ffb03d419edcab93b4b19c22ee80c007fb2d708429cecebf1dd3258956a563a",
-                "sha256:810bcf151caefc03e51a3d61e53335cd5c7316c0a105cc695f0959f2c638b129",
-                "sha256:831a4b37accef30cccd34fcb916a5d7b5be3cbbe27268a02832c3e450aea39cb",
-                "sha256:887623fe0d70f48ab3f5e4dbf234986b1329a64c066d719432d0698522749929",
-                "sha256:a0298bdc6e98ca21382afe914c642620370ce0470a01e1bef6dd9b5354c36854",
-                "sha256:a1327f280c824ff7885bdeef8578f74690e9079267c1c8bd7dc5cc5aa065ae52",
-                "sha256:c1f25b252d2c87088abc8bbc4f1ecbf7c919e05508a7e8628e6875c40bc70923",
-                "sha256:c3a5cbc620e1e17009f30dd34cb0d85c987afd21c41a74352d1719be33380885",
-                "sha256:ce8613beaffc7c14f091497346ef117c1798c202b01153a8cc7b8e2ebaaf41c0",
-                "sha256:d2a27aca5597c8a71abbe10209184e1a8e91c1fd470b5070a2ea60cafec35bcd",
-                "sha256:dad9c385ba8ee025bb0d856714f71d7840020fe176ae0229de618f14dae7a6e2",
-                "sha256:db4b65b02f59035037fde0998974d84244a64c3265bdef32a827ab9b63d61b18",
-                "sha256:e09469a2cec88fb7b078e16d4adec594414397e8879a4341c6ace96013463d5b",
-                "sha256:e53dc41cda40b248ebc40b83b31516487f7db95ab8ceac1f042626bc43a2f992",
-                "sha256:f1e85a178384bf19e36779d91ff35c7617c885da487d689b05c1366f9933ad74",
-                "sha256:f47be41843200f7faec0683ad751e5ef11b9a56a220d57f300376cd8aba81660",
-                "sha256:fb0cef872d8193e487fc6bdb08559c3aa41b659a7d9be48b2e10747f47863925",
-                "sha256:ffc73996c4fca3d2b6c1c8c12bfd3ad00def8621da24f547626bf06441400449"
+                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
+                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
+                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
+                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
+                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
+                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
+                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
+                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
+                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
+                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
+                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
+                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
+                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
+                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
+                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
+                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
+                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
+                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
+                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
+                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
+                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
+                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
+                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
+                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
+                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
+                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
+                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
+                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
+                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
+                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
+                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
+                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.4"
+            "version": "==42.0.5"
         },
         "cssselect2": {
             "hashes": [
@@ -406,12 +406,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:a2d4c4d4ea0b6f0895acde632071aff6400bfc331228fc978b05452a0ff3e9f1",
-                "sha256:b1260ed381b10a11753c73444408e19869f3241fc45c985cd55a30177c789d13"
+                "sha256:6e6ff3db2d8dd0c986b4eec8554c8e4f919b5c1ff62a5b4390c17aff2ed6e5c4",
+                "sha256:ddc24a0a8280a0430baa37aff11f28574720af05888c62b7cfe71d219f4599d3"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.10"
+            "version": "==4.2.11"
         },
         "django-activity-stream": {
             "hashes": [
@@ -652,12 +652,12 @@
         },
         "faker": {
             "hashes": [
-                "sha256:2ba20a4438429cb08d729175d7bb0435ef3c2c4cedc7b1ceb703ee6da8dad906",
-                "sha256:6279746aed175a693108238e6d1ab8d7e26d0ec7ff8474f61025b9fdaae15d65"
+                "sha256:0520a6b97e07c658b2798d7140971c1d5bc4bcd5013e7937fe075fd054aa320c",
+                "sha256:f07b64d27f67b62c7f0536a72f47813015b3b51cd4664918454011094321e464"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
-            "version": "==4.18.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==23.2.1"
         },
         "future": {
             "hashes": [
@@ -958,11 +958,11 @@
         },
         "phonenumbers": {
             "hashes": [
-                "sha256:175fcaa89780c9cb6e089fe61de960396c9fc0c01845aea26400975fb10a8ea8",
-                "sha256:273a969a863e9e38d4944b26fc277f408dc9aa84faa04996266efa4021adea00"
+                "sha256:2742071c9d0af09274c8a5b2a26d9a36acbf2ea5cb62943cc2ceadb5c0c87641",
+                "sha256:e45d0bc852516a3a6594bcec0ae47b825421a8adcfcf5f114ad148f1523d8646"
             ],
             "index": "pypi",
-            "version": "==8.13.30"
+            "version": "==8.13.31"
         },
         "pickleshare": {
             "hashes": [
@@ -1198,11 +1198,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pytz": {
             "hashes": [
@@ -1351,13 +1351,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.7.0"
         },
-        "text-unidecode": {
-            "hashes": [
-                "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
-                "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
-            ],
-            "version": "==1.3"
-        },
         "tinycss2": {
             "hashes": [
                 "sha256:2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847",
@@ -1384,11 +1377,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "markers": "python_version < '3.9'",
+            "version": "==4.10.0"
         },
         "tzdata": {
             "hashes": [
@@ -1411,7 +1404,7 @@
                 "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
                 "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.18"
         },
         "vine": {
@@ -1832,42 +1825,42 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:01911714117642a3f1792c7f376db572aadadbafcd8d75bb527166009c9f1d1b",
-                "sha256:0e89f7b84f421c56e7ff69f11c441ebda73b8a8e6488d322ef71746224c20fce",
-                "sha256:12d341bd42cdb7d4937b0cabbdf2a94f949413ac4504904d0cdbdce4a22cbf88",
-                "sha256:15a1fb843c48b4a604663fa30af60818cd28f895572386e5f9b8a665874c26e7",
-                "sha256:1cdcdbd117681c88d717437ada72bdd5be9de117f96e3f4d50dab3f59fd9ab20",
-                "sha256:1df6fcbf60560d2113b5ed90f072dc0b108d64750d4cbd46a21ec882c7aefce9",
-                "sha256:3c6048f217533d89f2f8f4f0fe3044bf0b2090453b7b73d0b77db47b80af8dff",
-                "sha256:3e970a2119507d0b104f0a8e281521ad28fc26f2820687b3436b8c9a5fcf20d1",
-                "sha256:44a64043f743485925d3bcac548d05df0f9bb445c5fcca6681889c7c3ab12764",
-                "sha256:4e36685cb634af55e0677d435d425043967ac2f3790ec652b2b88ad03b85c27b",
-                "sha256:5f8907fcf57392cd917892ae83708761c6ff3c37a8e835d7246ff0ad251d9298",
-                "sha256:69b22ab6506a3fe483d67d1ed878e1602bdd5912a134e6202c1ec672233241c1",
-                "sha256:6bfadd884e7280df24d26f2186e4e07556a05d37393b0f220a840b083dc6a824",
-                "sha256:6d0fbe73728c44ca3a241eff9aefe6496ab2656d6e7a4ea2459865f2e8613257",
-                "sha256:6ffb03d419edcab93b4b19c22ee80c007fb2d708429cecebf1dd3258956a563a",
-                "sha256:810bcf151caefc03e51a3d61e53335cd5c7316c0a105cc695f0959f2c638b129",
-                "sha256:831a4b37accef30cccd34fcb916a5d7b5be3cbbe27268a02832c3e450aea39cb",
-                "sha256:887623fe0d70f48ab3f5e4dbf234986b1329a64c066d719432d0698522749929",
-                "sha256:a0298bdc6e98ca21382afe914c642620370ce0470a01e1bef6dd9b5354c36854",
-                "sha256:a1327f280c824ff7885bdeef8578f74690e9079267c1c8bd7dc5cc5aa065ae52",
-                "sha256:c1f25b252d2c87088abc8bbc4f1ecbf7c919e05508a7e8628e6875c40bc70923",
-                "sha256:c3a5cbc620e1e17009f30dd34cb0d85c987afd21c41a74352d1719be33380885",
-                "sha256:ce8613beaffc7c14f091497346ef117c1798c202b01153a8cc7b8e2ebaaf41c0",
-                "sha256:d2a27aca5597c8a71abbe10209184e1a8e91c1fd470b5070a2ea60cafec35bcd",
-                "sha256:dad9c385ba8ee025bb0d856714f71d7840020fe176ae0229de618f14dae7a6e2",
-                "sha256:db4b65b02f59035037fde0998974d84244a64c3265bdef32a827ab9b63d61b18",
-                "sha256:e09469a2cec88fb7b078e16d4adec594414397e8879a4341c6ace96013463d5b",
-                "sha256:e53dc41cda40b248ebc40b83b31516487f7db95ab8ceac1f042626bc43a2f992",
-                "sha256:f1e85a178384bf19e36779d91ff35c7617c885da487d689b05c1366f9933ad74",
-                "sha256:f47be41843200f7faec0683ad751e5ef11b9a56a220d57f300376cd8aba81660",
-                "sha256:fb0cef872d8193e487fc6bdb08559c3aa41b659a7d9be48b2e10747f47863925",
-                "sha256:ffc73996c4fca3d2b6c1c8c12bfd3ad00def8621da24f547626bf06441400449"
+                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
+                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
+                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
+                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
+                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
+                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
+                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
+                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
+                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
+                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
+                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
+                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
+                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
+                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
+                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
+                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
+                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
+                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
+                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
+                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
+                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
+                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
+                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
+                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
+                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
+                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
+                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
+                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
+                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
+                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
+                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
+                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.4"
+            "version": "==42.0.5"
         },
         "decorator": {
             "hashes": [
@@ -2342,21 +2335,21 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae",
-                "sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca"
+                "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd",
+                "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.0.1"
+            "version": "==8.0.2"
         },
         "pytest-bdd": {
             "hashes": [
-                "sha256:652d9c5324076ed9348f1c69b6512c00c581708ff17f063771ea703b62d3b956",
-                "sha256:faf115b9de793dc2341e898347f936c3766179a54a018c132796302b120918e5"
+                "sha256:1b41a10a8391f1849f0a1524d77b2991d0d8042d2253ace9b616b89b4a9b97a7",
+                "sha256:331621122a46f9881110ae0dd43fedb29e96e8202de29256be3d76c53b57c1d2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==7.0.1"
+            "version": "==7.1.1"
         },
         "pytest-circleci-parallelized": {
             "hashes": [
@@ -2386,11 +2379,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.8.2"
+            "version": "==2.9.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -2552,18 +2545,18 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "markers": "python_version < '3.9'",
+            "version": "==4.10.0"
         },
         "urllib3": {
             "hashes": [
                 "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
                 "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.18"
         },
         "watchdog": {

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -9,7 +9,7 @@ from api.appeals.tests.factories import AppealFactory
 from api.cases.tests.factories import CaseNoteFactory, EcjuQueryFactory, FinalAdviceFactory
 from api.documents.tests.factories import DocumentFactory
 from api.document_data.models import DocumentData
-from api.goods.tests.factories import FirearmFactory
+from api.goods.tests.factories import FirearmFactory, GoodFactory
 from api.organisations.tests.factories import SiteFactory, OrganisationFactory
 from api.addresses.tests.factories import AddressFactory
 from api.staticdata.countries.models import Country
@@ -99,7 +99,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.firearm_good_details = FirearmFactory(
             serial_numbers=["serial number 1", "serial number 2"], serial_number="serial number"
         )
-        cls.firearm_good_details_2 = FirearmFactory(serial_numbers=[], serial_number="serial number")
+        cls.good = GoodFactory(description="some good description", organisation=OrganisationFactory())
 
     @classmethod
     def delete_test_data(cls):
@@ -219,3 +219,8 @@ class TestAnonymiseDumps(TransactionTestCase):
         assert str(self.firearm_good_details.id) in self.anonymised_sql
 
         assert self.firearm_good_details.serial_number not in self.anonymised_sql
+
+    def test_good_description_anonymised(self):
+        assert str(self.good.id) in self.anonymised_sql
+
+        assert self.good.description not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 
 from api.appeals.tests.factories import AppealFactory
+from api.cases.tests.factories import CaseNoteFactory
 from api.document_data.models import DocumentData
 from api.organisations.tests.factories import SiteFactory, OrganisationFactory
 from api.addresses.tests.factories import AddressFactory
@@ -16,6 +17,9 @@ from api.parties.tests.factories import PartyFactory
 from api.users.tests.factories import BaseUserFactory
 
 
+# Note: This must inherit from TransactionTestCase - if we use DataTestClient
+# instead, the DB state changes will occur in transactions that are not
+# visible to the pg_dump command called by db_anonymiser
 class TestAnonymiseDumps(TransactionTestCase):
     @classmethod
     def setUpClass(cls):
@@ -82,6 +86,7 @@ class TestAnonymiseDumps(TransactionTestCase):
             phone_number="+44baseuser",
         )
         cls.appeal = AppealFactory(grounds_for_appeal="appeal grounds")
+        cls.case_note = CaseNoteFactory(text="case note text")
 
     @classmethod
     def delete_test_data(cls):
@@ -94,6 +99,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.party.delete()
         cls.base_user.delete()
         cls.appeal.delete()
+        cls.case_note.delete()
 
     def test_users_baseuser_anonymised(self):
         assert str(self.base_user.id) in self.anonymised_sql
@@ -153,3 +159,7 @@ class TestAnonymiseDumps(TransactionTestCase):
     def test_appeal_anonymised(self):
         assert str(self.appeal.id) in self.anonymised_sql
         assert self.appeal.grounds_for_appeal not in self.anonymised_sql
+
+    def test_case_note_anonymised(self):
+        assert str(self.case_note.id) in self.anonymised_sql
+        assert self.case_note.text not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase
 
+from api.appeals.tests.factories import AppealFactory
 from api.document_data.models import DocumentData
 from api.organisations.tests.factories import SiteFactory, OrganisationFactory
 from api.addresses.tests.factories import AddressFactory
@@ -80,6 +81,7 @@ class TestAnonymiseDumps(TransactionTestCase):
             email="base@user.email",
             phone_number="+44baseuser",
         )
+        cls.appeal = AppealFactory(grounds_for_appeal="appeal grounds")
 
     @classmethod
     def delete_test_data(cls):
@@ -91,6 +93,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.denial.delete()
         cls.party.delete()
         cls.base_user.delete()
+        cls.appeal.delete()
 
     def test_users_baseuser_anonymised(self):
         assert str(self.base_user.id) in self.anonymised_sql
@@ -146,3 +149,7 @@ class TestAnonymiseDumps(TransactionTestCase):
     def test_document_data_excluded(self):
         assert self.document_data.s3_key not in self.anonymised_sql
         assert str(self.document_data.id) not in self.anonymised_sql
+
+    def test_appeal_anonymised(self):
+        assert str(self.appeal.id) in self.anonymised_sql
+        assert self.appeal.grounds_for_appeal not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 
 from api.appeals.tests.factories import AppealFactory
+from api.applications.tests.factories import GoodOnApplicationFactory, StandardApplicationFactory
 from api.cases.tests.factories import CaseNoteFactory, EcjuQueryFactory, FinalAdviceFactory
 from api.documents.tests.factories import DocumentFactory
 from api.document_data.models import DocumentData
@@ -100,6 +101,7 @@ class TestAnonymiseDumps(TransactionTestCase):
             serial_numbers=["serial number 1", "serial number 2"], serial_number="serial number"
         )
         cls.good = GoodFactory(description="some good description", organisation=OrganisationFactory())
+        cls.good_on_application = GoodOnApplicationFactory(comment="some goa comment", application=StandardApplicationFactory(), good=cls.good)
 
     @classmethod
     def delete_test_data(cls):
@@ -117,6 +119,8 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.ecju_query.delete()
         cls.document.delete()
         cls.firearm_good_details.delete()
+        cls.good.delete()
+        cls.good_on_application.delete()
 
     def test_users_baseuser_anonymised(self):
         assert str(self.base_user.id) in self.anonymised_sql
@@ -224,3 +228,8 @@ class TestAnonymiseDumps(TransactionTestCase):
         assert str(self.good.id) in self.anonymised_sql
 
         assert self.good.description not in self.anonymised_sql
+
+    def test_good_on_application_comment_anonymised(self):
+        assert str(self.good_on_application.id) in self.anonymised_sql
+
+        assert self.good_on_application.comment not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -12,6 +12,9 @@ from api.appeals.tests.factories import AppealFactory
 from api.appeals.models import Appeal
 from api.applications.tests.factories import GoodOnApplicationFactory, StandardApplicationFactory
 from api.applications.models import GoodOnApplication, StandardApplication
+from api.audit_trail.tests.factories import AuditFactory
+from api.audit_trail.models import Audit
+from api.audit_trail.enums import AuditType
 from api.cases.tests.factories import CaseNoteFactory, EcjuQueryFactory, FinalAdviceFactory
 from api.cases.models import CaseNote, EcjuQuery, Advice
 from api.documents.tests.factories import DocumentFactory
@@ -158,6 +161,244 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.good_on_application = GoodOnApplicationFactory(
             comment="some goa comment", application=StandardApplicationFactory(), good=cls.good
         )
+        cls.create_audit_trail_data()
+
+    @classmethod
+    def create_audit_trail_data(cls):
+        cls.audit_entries = {
+            AuditType.ADD_CASE_OFFICER_TO_CASE: AuditFactory(
+                verb=AuditType.ADD_CASE_OFFICER_TO_CASE, payload={"case_officer": "some officer"}
+            ),
+            AuditType.ADD_PARTY: AuditFactory(
+                verb=AuditType.ADD_PARTY, payload={"party_name": "some party", "party_type": "ultimate_end_user"}
+            ),
+            AuditType.APPROVED_ORGANISATION: AuditFactory(
+                verb=AuditType.APPROVED_ORGANISATION, payload={"organisation_name": "some organisation"}
+            ),
+            AuditType.ASSIGN_USER_TO_CASE: AuditFactory(
+                verb=AuditType.ASSIGN_USER_TO_CASE,
+                payload={"additional_text": "allocated self to the case", "queue": "some queue", "user": "some user"},
+            ),
+            AuditType.CREATE_REFUSAL_CRITERIA: AuditFactory(
+                verb=AuditType.CREATE_REFUSAL_CRITERIA,
+                payload={
+                    "additional_text": "some text",
+                    "advice_type": "refuse",
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                },
+            ),
+            AuditType.CREATED_CASE_NOTE: AuditFactory(
+                verb=AuditType.CREATED_CASE_NOTE,
+                payload={
+                    "additional_text": "some text",
+                },
+            ),
+            AuditType.CREATED_CASE_NOTE_WITH_MENTIONS: AuditFactory(
+                verb=AuditType.CREATED_CASE_NOTE_WITH_MENTIONS,
+                payload={
+                    "additional_text": "some text",
+                    "mention_users": ["user one", "user two"],
+                },
+            ),
+            AuditType.CREATED_ORGANISATION: AuditFactory(
+                verb=AuditType.CREATED_ORGANISATION,
+                payload={
+                    "organisation_name": "some organisation",
+                },
+            ),
+            AuditType.CREATED_SITE: AuditFactory(
+                verb=AuditType.CREATED_SITE,
+                payload={
+                    "site_name": "some site",
+                },
+            ),
+            AuditType.DELETE_APPLICATION_DOCUMENT: AuditFactory(
+                verb=AuditType.DELETE_APPLICATION_DOCUMENT,
+                payload={
+                    "file_name": "somefile.txt",
+                },
+            ),
+            AuditType.DELETE_PARTY_DOCUMENT: AuditFactory(
+                verb=AuditType.DELETE_PARTY_DOCUMENT,
+                payload={
+                    "file_name": "somefile.txt",
+                    "party_name": "some party",
+                    "party_type": "end_user",
+                },
+            ),
+            AuditType.DESTINATION_ADD_FLAGS: AuditFactory(
+                verb=AuditType.DESTINATION_ADD_FLAGS,
+                payload={
+                    "added_flags": ["flag1", "flag2"],
+                    "destination_name": "some destination",
+                },
+            ),
+            AuditType.DOCUMENT_ON_ORGANISATION_CREATE: AuditFactory(
+                verb=AuditType.DOCUMENT_ON_ORGANISATION_CREATE,
+                payload={
+                    "file_name": "somefile.txt",
+                    "document_type": "some doc type",
+                },
+            ),
+            AuditType.DOCUMENT_ON_ORGANISATION_DELETE: AuditFactory(
+                verb=AuditType.DOCUMENT_ON_ORGANISATION_DELETE,
+                payload={
+                    "file_name": "somefile.txt",
+                    "document_type": "some doc type",
+                },
+            ),
+            AuditType.ECJU_QUERY: AuditFactory(
+                verb=AuditType.ECJU_QUERY,
+                payload={
+                    "ecju_query": "some query",
+                },
+            ),
+            AuditType.ECJU_QUERY_MANUALLY_CLOSED: AuditFactory(
+                verb=AuditType.ECJU_QUERY_MANUALLY_CLOSED,
+                payload={
+                    "ecju_response": "some response",
+                },
+            ),
+            AuditType.ECJU_QUERY_RESPONSE: AuditFactory(
+                verb=AuditType.ECJU_QUERY_RESPONSE,
+                payload={
+                    "ecju_response": "some response",
+                },
+            ),
+            AuditType.LU_ADVICE: AuditFactory(
+                verb=AuditType.LU_ADVICE,
+                payload={
+                    "advice_type": "proviso",
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                },
+            ),
+            AuditType.LU_COUNTERSIGN: AuditFactory(
+                verb=AuditType.LU_COUNTERSIGN,
+                payload={
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                    "department": "somedept",
+                    "countersign_accepted": True,
+                    "order": 1,
+                },
+            ),
+            AuditType.LU_CREATE_MEETING_NOTE: AuditFactory(
+                verb=AuditType.LU_CREATE_MEETING_NOTE,
+                payload={
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                    "advice_type": "proviso",
+                    "additional_text": "some text",
+                },
+            ),
+            AuditType.LU_EDIT_ADVICE: AuditFactory(
+                verb=AuditType.LU_EDIT_ADVICE,
+                payload={
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                    "advice_type": "proviso",
+                    "additional_text": "some text",
+                },
+            ),
+            AuditType.LU_EDIT_MEETING_NOTE: AuditFactory(
+                verb=AuditType.LU_EDIT_MEETING_NOTE,
+                payload={
+                    "firstname": "somefirst",
+                    "lastname": "somelast",
+                    "advice_type": "proviso",
+                    "additional_text": "some text",
+                },
+            ),
+            AuditType.REGISTER_ORGANISATION: AuditFactory(
+                verb=AuditType.REGISTER_ORGANISATION,
+                payload={
+                    "organisation_name": "some organisation",
+                    "email": "email@example.net",
+                },
+            ),
+            AuditType.REJECTED_ORGANISATION: AuditFactory(
+                verb=AuditType.REJECTED_ORGANISATION,
+                payload={
+                    "organisation_name": "some organisation",
+                },
+            ),
+            AuditType.REMOVE_CASE_OFFICER_FROM_CASE: AuditFactory(
+                verb=AuditType.REMOVE_CASE_OFFICER_FROM_CASE,
+                payload={
+                    "case_officer": "some officer",
+                },
+            ),
+            AuditType.REMOVE_PARTY: AuditFactory(
+                verb=AuditType.REMOVE_PARTY,
+                payload={
+                    "party_name": "some party",
+                    "party_type": "end_user",
+                },
+            ),
+            AuditType.REMOVE_USER_FROM_CASE: AuditFactory(
+                verb=AuditType.REMOVE_USER_FROM_CASE,
+                payload={
+                    "removed_user_id": "some id",
+                    "removed_user_name": "some name",
+                    "removed_user_queue_id": "some id",
+                    "removed_user_queue_name": "some queue",
+                },
+            ),
+            AuditType.UPDATE_APPLICATION_END_USE_DETAIL: AuditFactory(
+                verb=AuditType.UPDATE_APPLICATION_END_USE_DETAIL,
+                payload={
+                    "end_use_detail": "some detail",
+                    "new_end_use_detail": "some detail",
+                    "old_end_use_detail": "some detail",
+                },
+            ),
+            AuditType.UPDATED_ORGANISATION: AuditFactory(
+                verb=AuditType.UPDATED_ORGANISATION,
+                payload={
+                    "key": "some key",
+                    "new": "some name",
+                    "old": "some old name",
+                },
+            ),
+            AuditType.UPDATED_SITE: AuditFactory(
+                verb=AuditType.UPDATED_SITE,
+                payload={
+                    "key": "some key",
+                    "new": "some name",
+                    "old": "some old name",
+                },
+            ),
+            AuditType.UPDATED_SITE_NAME: AuditFactory(
+                verb=AuditType.UPDATED_SITE_NAME,
+                payload={
+                    "key": "some key",
+                    "new": "some name",
+                    "old": "some old name",
+                },
+            ),
+            AuditType.UPLOAD_APPLICATION_DOCUMENT: AuditFactory(
+                verb=AuditType.UPLOAD_APPLICATION_DOCUMENT,
+                payload={
+                    "file_name": "somefile.txt",
+                },
+            ),
+            AuditType.UPLOAD_CASE_DOCUMENT: AuditFactory(
+                verb=AuditType.UPLOAD_CASE_DOCUMENT,
+                payload={
+                    "file_name": "somefile.txt",
+                },
+            ),
+            AuditType.UPLOAD_PARTY_DOCUMENT: AuditFactory(
+                verb=AuditType.UPLOAD_PARTY_DOCUMENT,
+                payload={
+                    "file_name": "somefile.txt",
+                    "party_name": "some party",
+                    "party_type": "end_user",
+                },
+            ),
+        }
 
     @classmethod
     def delete_test_data(cls):
@@ -177,6 +418,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.firearm_good_details.delete()
         cls.good.delete()
         cls.good_on_application.delete()
+        Audit.objects.all().delete()
 
     def test_users_baseuser_anonymised(self):
         updated_user = BaseUser.objects.get(id=self.base_user.id)
@@ -288,3 +530,217 @@ class TestAnonymiseDumps(TransactionTestCase):
         updated_good_on_application = GoodOnApplication.objects.get(id=self.good_on_application.id)
 
         assert self.good_on_application.comment != updated_good_on_application.comment
+
+    def test_audit_trail_anonymisation_add_case_officer_to_case_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ADD_CASE_OFFICER_TO_CASE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["case_officer"] != previous_audit.payload["case_officer"]
+
+    def test_audit_trail_anonymisation_add_party_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ADD_PARTY]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["party_name"] != previous_audit.payload["party_name"]
+        assert updated_audit.payload["party_type"] == previous_audit.payload["party_type"]
+
+    def test_audit_trail_anonymisation_approved_organisation_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.APPROVED_ORGANISATION]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["organisation_name"] != previous_audit.payload["organisation_name"]
+
+    def test_audit_trail_anonymisation_assign_user_to_case_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ASSIGN_USER_TO_CASE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["user"] != previous_audit.payload["user"]
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+        assert updated_audit.payload["queue"] == previous_audit.payload["queue"]
+
+    def test_audit_trail_anonymisation_create_refusal_criteria_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.CREATE_REFUSAL_CRITERIA]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+
+    def test_audit_trail_anonymisation_created_case_note_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.CREATED_CASE_NOTE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        # TODO: Review additional_text..
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+
+    def test_audit_trail_anonymisation_created_case_note_with_mentions_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.CREATED_CASE_NOTE_WITH_MENTIONS]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        # TODO: Review additional_text..
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+        assert updated_audit.payload["mention_users"] != previous_audit.payload["mention_users"]
+        assert len(updated_audit.payload["mention_users"]) == len(previous_audit.payload["mention_users"])
+
+    def test_audit_trail_anonymisation_created_organisation_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.CREATED_ORGANISATION]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["organisation_name"] != previous_audit.payload["organisation_name"]
+
+    def test_audit_trail_anonymisation_created_site_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.CREATED_SITE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["site_name"] != previous_audit.payload["site_name"]
+
+    def test_audit_trail_anonymisation_delete_application_document_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.DELETE_APPLICATION_DOCUMENT]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+
+    def test_audit_trail_anonymisation_delete_party_document_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.DELETE_PARTY_DOCUMENT]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+        assert updated_audit.payload["party_name"] != previous_audit.payload["party_name"]
+        assert updated_audit.payload["party_type"] == previous_audit.payload["party_type"]
+
+    def test_audit_trail_anonymisation_delete_party_document_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.DESTINATION_ADD_FLAGS]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["added_flags"] == previous_audit.payload["added_flags"]
+        assert updated_audit.payload["destination_name"] != previous_audit.payload["destination_name"]
+
+    def test_audit_trail_anonymisation_document_on_organisation_create_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.DOCUMENT_ON_ORGANISATION_CREATE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+        assert updated_audit.payload["document_type"] == previous_audit.payload["document_type"]
+
+    def test_audit_trail_anonymisation_document_on_organisation_delete_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.DOCUMENT_ON_ORGANISATION_DELETE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+        assert updated_audit.payload["document_type"] == previous_audit.payload["document_type"]
+
+    def test_audit_trail_anonymisation_ecju_query_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ECJU_QUERY]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["ecju_query"] != previous_audit.payload["ecju_query"]
+
+    def test_audit_trail_anonymisation_ecju_query_manually_closed_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ECJU_QUERY_MANUALLY_CLOSED]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["ecju_response"] != previous_audit.payload["ecju_response"]
+
+    def test_audit_trail_anonymisation_ecju_query_response_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.ECJU_QUERY_RESPONSE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["ecju_response"] != previous_audit.payload["ecju_response"]
+
+    def test_audit_trail_anonymisation_lu_advice_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.LU_ADVICE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+        assert updated_audit.payload["advice_type"] == previous_audit.payload["advice_type"]
+
+    def test_audit_trail_anonymisation_lu_countersign_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.LU_COUNTERSIGN]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+        assert updated_audit.payload["countersign_accepted"] == previous_audit.payload["countersign_accepted"]
+        assert updated_audit.payload["department"] == previous_audit.payload["department"]
+        assert updated_audit.payload["order"] == previous_audit.payload["order"]
+
+    def test_audit_trail_anonymisation_lu_create_meeting_note_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.LU_CREATE_MEETING_NOTE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+        assert updated_audit.payload["advice_type"] == previous_audit.payload["advice_type"]
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+
+    def test_audit_trail_anonymisation_lu_edit_advice_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.LU_EDIT_ADVICE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+        assert updated_audit.payload["advice_type"] == previous_audit.payload["advice_type"]
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+
+    def test_audit_trail_anonymisation_lu_edit_meeting_note_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.LU_EDIT_MEETING_NOTE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["additional_text"] == previous_audit.payload["additional_text"]
+        assert updated_audit.payload["advice_type"] == previous_audit.payload["advice_type"]
+        assert updated_audit.payload["firstname"] != previous_audit.payload["firstname"]
+        assert updated_audit.payload["lastname"] != previous_audit.payload["lastname"]
+
+    def test_audit_trail_anonymisation_register_organisation_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.REGISTER_ORGANISATION]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["organisation_name"] != previous_audit.payload["organisation_name"]
+        assert updated_audit.payload["email"] != previous_audit.payload["email"]
+
+    def test_audit_trail_anonymisation_rejected_organisation_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.REJECTED_ORGANISATION]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["organisation_name"] != previous_audit.payload["organisation_name"]
+
+    def test_audit_trail_anonymisation_remove_case_officer_from_case_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.REMOVE_CASE_OFFICER_FROM_CASE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["case_officer"] != previous_audit.payload["case_officer"]
+
+    def test_audit_trail_anonymisation_remove_party_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.REMOVE_PARTY]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["party_name"] != previous_audit.payload["party_name"]
+        assert updated_audit.payload["party_type"] == previous_audit.payload["party_type"]
+
+    def test_audit_trail_anonymisation_remove_user_from_case_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.REMOVE_USER_FROM_CASE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["removed_user_name"] != previous_audit.payload["removed_user_name"]
+        assert updated_audit.payload["removed_user_id"] == previous_audit.payload["removed_user_id"]
+        assert updated_audit.payload["removed_user_queue_id"] == previous_audit.payload["removed_user_queue_id"]
+        assert updated_audit.payload["removed_user_queue_name"] == previous_audit.payload["removed_user_queue_name"]
+
+    def test_audit_trail_anonymisation_update_application_end_use_detail(self):
+        previous_audit = self.audit_entries[AuditType.UPDATE_APPLICATION_END_USE_DETAIL]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["new_end_use_detail"] != previous_audit.payload["new_end_use_detail"]
+        assert updated_audit.payload["old_end_use_detail"] != previous_audit.payload["old_end_use_detail"]
+        assert updated_audit.payload["end_use_detail"] == previous_audit.payload["end_use_detail"]
+
+    def test_audit_trail_anonymisation_updated_organisation_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.UPDATED_ORGANISATION]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["new"] != previous_audit.payload["new"]
+        assert updated_audit.payload["old"] != previous_audit.payload["old"]
+        assert updated_audit.payload["key"] == previous_audit.payload["key"]
+
+    def test_audit_trail_anonymisation_updated_site_anonymised(self):
+        previous_audit = self.audit_entries[AuditType.UPDATED_SITE]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["new"] != previous_audit.payload["new"]
+        assert updated_audit.payload["old"] != previous_audit.payload["old"]
+        assert updated_audit.payload["key"] == previous_audit.payload["key"]
+
+    def test_audit_trail_anonymisation_updated_site_name(self):
+        previous_audit = self.audit_entries[AuditType.UPDATED_SITE_NAME]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["new"] != previous_audit.payload["new"]
+        assert updated_audit.payload["old"] != previous_audit.payload["old"]
+        assert updated_audit.payload["key"] == previous_audit.payload["key"]
+
+    def test_audit_trail_anonymisation_upload_application_document(self):
+        previous_audit = self.audit_entries[AuditType.UPLOAD_APPLICATION_DOCUMENT]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+
+    def test_audit_trail_anonymisation_upload_case_document(self):
+        previous_audit = self.audit_entries[AuditType.UPLOAD_CASE_DOCUMENT]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+
+    def test_audit_trail_anonymisation_upload_party_document(self):
+        previous_audit = self.audit_entries[AuditType.UPLOAD_PARTY_DOCUMENT]
+        updated_audit = Audit.objects.get(id=previous_audit.id)
+        assert updated_audit.payload["file_name"] != previous_audit.payload["file_name"]
+        assert updated_audit.payload["party_name"] != previous_audit.payload["party_name"]
+        assert updated_audit.payload["party_type"] == previous_audit.payload["party_type"]

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -597,7 +597,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         assert updated_audit.payload["party_name"] != previous_audit.payload["party_name"]
         assert updated_audit.payload["party_type"] == previous_audit.payload["party_type"]
 
-    def test_audit_trail_anonymisation_delete_party_document_anonymised(self):
+    def test_audit_trail_anonymisation_destination_add_flags_anonymised(self):
         previous_audit = self.audit_entries[AuditType.DESTINATION_ADD_FLAGS]
         updated_audit = Audit.objects.get(id=previous_audit.id)
         assert updated_audit.payload["added_flags"] == previous_audit.payload["added_flags"]

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -88,7 +88,9 @@ class TestAnonymiseDumps(TransactionTestCase):
         )
         cls.appeal = AppealFactory(grounds_for_appeal="appeal grounds")
         cls.case_note = CaseNoteFactory(text="case note text")
-        cls.advice = FinalAdviceFactory(text="final advice text", user=GovUserFactory(), note="advice note", proviso="advice proviso")
+        cls.advice = FinalAdviceFactory(
+            text="final advice text", user=GovUserFactory(), note="advice note", proviso="advice proviso"
+        )
 
     @classmethod
     def delete_test_data(cls):

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -88,7 +88,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         )
         cls.appeal = AppealFactory(grounds_for_appeal="appeal grounds")
         cls.case_note = CaseNoteFactory(text="case note text")
-        cls.advice = FinalAdviceFactory(text="final advice text", user=GovUserFactory())
+        cls.advice = FinalAdviceFactory(text="final advice text", user=GovUserFactory(), note="advice note", proviso="advice proviso")
 
     @classmethod
     def delete_test_data(cls):
@@ -167,6 +167,14 @@ class TestAnonymiseDumps(TransactionTestCase):
         assert str(self.case_note.id) in self.anonymised_sql
         assert self.case_note.text not in self.anonymised_sql
 
-    def test_advice_anonymised(self):
+    def test_advice_text_anonymised(self):
         assert str(self.advice.id) in self.anonymised_sql
         assert self.advice.text not in self.anonymised_sql
+
+    def test_advice_note_anonymised(self):
+        assert str(self.advice.id) in self.anonymised_sql
+        assert self.advice.note not in self.anonymised_sql
+
+    def test_advice_proviso_anonymised(self):
+        assert str(self.advice.id) in self.anonymised_sql
+        assert self.advice.proviso not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -6,7 +6,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 
 from api.appeals.tests.factories import AppealFactory
-from api.cases.tests.factories import CaseNoteFactory, FinalAdviceFactory
+from api.cases.tests.factories import CaseNoteFactory, EcjuQueryFactory, FinalAdviceFactory
 from api.document_data.models import DocumentData
 from api.organisations.tests.factories import SiteFactory, OrganisationFactory
 from api.addresses.tests.factories import AddressFactory
@@ -91,6 +91,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.advice = FinalAdviceFactory(
             text="final advice text", user=GovUserFactory(), note="advice note", proviso="advice proviso"
         )
+        cls.ecju_query = EcjuQueryFactory(question="ecju query question", response="ecju query response")
 
     @classmethod
     def delete_test_data(cls):
@@ -105,6 +106,7 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.appeal.delete()
         cls.case_note.delete()
         cls.advice.delete()
+        cls.ecju_query.delete()
 
     def test_users_baseuser_anonymised(self):
         assert str(self.base_user.id) in self.anonymised_sql
@@ -180,3 +182,11 @@ class TestAnonymiseDumps(TransactionTestCase):
     def test_advice_proviso_anonymised(self):
         assert str(self.advice.id) in self.anonymised_sql
         assert self.advice.proviso not in self.anonymised_sql
+
+    def test_ecju_query_question_anonymised(self):
+        assert str(self.ecju_query.id) in self.anonymised_sql
+        assert self.ecju_query.question not in self.anonymised_sql
+
+    def test_ecju_query_response_anonymised(self):
+        assert str(self.ecju_query.id) in self.anonymised_sql
+        assert self.ecju_query.response not in self.anonymised_sql

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -20,8 +20,8 @@ from api.cases.models import CaseNote, EcjuQuery, Advice
 from api.documents.tests.factories import DocumentFactory
 from api.documents.models import Document
 from api.document_data.models import DocumentData
-from api.goods.tests.factories import FirearmFactory, GoodFactory
-from api.goods.models import FirearmGoodDetails, Good
+from api.goods.tests.factories import GoodFactory
+from api.goods.models import Good
 from api.organisations.tests.factories import SiteFactory, OrganisationFactory
 from api.organisations.models import Site, Organisation
 from api.addresses.tests.factories import AddressFactory
@@ -154,9 +154,6 @@ class TestAnonymiseDumps(TransactionTestCase):
         )
         cls.ecju_query = EcjuQueryFactory(question="ecju query question", response="ecju query response")
         cls.document = DocumentFactory(name="document_name.txt", s3_key="document_s3_key.txt")
-        cls.firearm_good_details = FirearmFactory(
-            serial_numbers=["serial number 1", "serial number 2"], serial_number="serial number"
-        )
         cls.good = GoodFactory(description="some good description", organisation=OrganisationFactory())
         cls.good_on_application = GoodOnApplicationFactory(
             comment="some goa comment", application=StandardApplicationFactory(), good=cls.good
@@ -415,7 +412,6 @@ class TestAnonymiseDumps(TransactionTestCase):
         cls.advice.delete()
         cls.ecju_query.delete()
         cls.document.delete()
-        cls.firearm_good_details.delete()
         cls.good.delete()
         cls.good_on_application.delete()
         Audit.objects.all().delete()
@@ -509,18 +505,6 @@ class TestAnonymiseDumps(TransactionTestCase):
     def test_document_s3_key_anonymised(self):
         updated_document = Document.objects.get(id=self.document.id)
         assert self.document.s3_key != updated_document.s3_key
-
-    def test_firearm_good_details_serial_numbers_anonymised(self):
-        updated_firearm_good_details = FirearmGoodDetails.objects.get(id=self.firearm_good_details.id)
-        for value in self.firearm_good_details.serial_numbers:
-
-            assert value not in updated_firearm_good_details.serial_numbers
-        assert len(updated_firearm_good_details.serial_numbers) == len(self.firearm_good_details.serial_numbers)
-
-    def test_firearm_good_details_serial_number_anonymised(self):
-        updated_firearm_good_details = FirearmGoodDetails.objects.get(id=self.firearm_good_details.id)
-
-        assert self.firearm_good_details.serial_number != updated_firearm_good_details.serial_number
 
     def test_good_description_anonymised(self):
         updated_good = Good.objects.get(id=self.good.id)

--- a/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
+++ b/api/anonymised_db_dumps/tests/test_anonymised_dumps.py
@@ -101,7 +101,9 @@ class TestAnonymiseDumps(TransactionTestCase):
             serial_numbers=["serial number 1", "serial number 2"], serial_number="serial number"
         )
         cls.good = GoodFactory(description="some good description", organisation=OrganisationFactory())
-        cls.good_on_application = GoodOnApplicationFactory(comment="some goa comment", application=StandardApplicationFactory(), good=cls.good)
+        cls.good_on_application = GoodOnApplicationFactory(
+            comment="some goa comment", application=StandardApplicationFactory(), good=cls.good
+        )
 
     @classmethod
     def delete_test_data(cls):

--- a/api/audit_trail/audit_trail_anonymisers.py
+++ b/api/audit_trail/audit_trail_anonymisers.py
@@ -1,0 +1,46 @@
+import json
+import re
+
+from faker import Faker
+
+from django_db_anonymiser.db_anonymiser import faker as db_anonymiser_sanitizers
+
+fake = Faker("en-GB")
+
+
+def sanitize_mention_users(users):
+    sanitized_users = []
+    for user in users:
+        sanitized_users.append(fake.name())
+    return sanitized_users
+
+
+ALL_SANITIZERS = {
+    "case_officer": db_anonymiser_sanitizers.sanitize_name,
+    "party_name": db_anonymiser_sanitizers.sanitize_name,
+    "organisation_name": db_anonymiser_sanitizers.sanitize_company_name,
+    "user": db_anonymiser_sanitizers.sanitize_name,
+    "firstname": db_anonymiser_sanitizers.sanitize_first_name,
+    "lastname": db_anonymiser_sanitizers.sanitize_last_name,
+    "mention_users": sanitize_mention_users,
+    "site_name": db_anonymiser_sanitizers.sanitize_name,
+    "destination_name": db_anonymiser_sanitizers.sanitize_name,
+    "file_name": db_anonymiser_sanitizers.sanitize_filename,
+    "ecju_query": db_anonymiser_sanitizers.sanitize_text,
+    "ecju_response": db_anonymiser_sanitizers.sanitize_text,
+    "ecju_response": db_anonymiser_sanitizers.sanitize_text,
+    "email": db_anonymiser_sanitizers.sanitize_email,
+    "removed_user_name": db_anonymiser_sanitizers.sanitize_name,
+    "new_end_use_detail": db_anonymiser_sanitizers.sanitize_short_text,
+    "old_end_use_detail": db_anonymiser_sanitizers.sanitize_short_text,
+    "new": db_anonymiser_sanitizers.sanitize_name,
+    "old": db_anonymiser_sanitizers.sanitize_name,
+}
+
+
+def sanitize_payload(value):
+    payload = json.loads(value)
+    for key_to_sanitize, sanitizer in ALL_SANITIZERS.items():
+        if key_to_sanitize in payload:
+            payload[key_to_sanitize] = sanitizer(payload[key_to_sanitize])
+    return json.dumps(payload)

--- a/api/audit_trail/audit_trail_anonymisers.py
+++ b/api/audit_trail/audit_trail_anonymisers.py
@@ -16,7 +16,7 @@ def sanitize_mention_users(users):
 
 ALL_SANITIZERS = {
     "case_officer": db_anonymiser_sanitizers.sanitize_name,
-    "party_name": db_anonymiser_sanitizers.sanitize_name,
+    "party_name": db_anonymiser_sanitizers.sanitize_company_name,
     "organisation_name": db_anonymiser_sanitizers.sanitize_company_name,
     "user": db_anonymiser_sanitizers.sanitize_name,
     "firstname": db_anonymiser_sanitizers.sanitize_first_name,

--- a/api/audit_trail/audit_trail_anonymisers.py
+++ b/api/audit_trail/audit_trail_anonymisers.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 from faker import Faker
 
@@ -27,7 +26,6 @@ ALL_SANITIZERS = {
     "destination_name": db_anonymiser_sanitizers.sanitize_name,
     "file_name": db_anonymiser_sanitizers.sanitize_filename,
     "ecju_query": db_anonymiser_sanitizers.sanitize_text,
-    "ecju_response": db_anonymiser_sanitizers.sanitize_text,
     "ecju_response": db_anonymiser_sanitizers.sanitize_text,
     "email": db_anonymiser_sanitizers.sanitize_email,
     "removed_user_name": db_anonymiser_sanitizers.sanitize_name,

--- a/api/audit_trail/tests/test_audit_trail_anonymisers.py
+++ b/api/audit_trail/tests/test_audit_trail_anonymisers.py
@@ -51,8 +51,8 @@ def test_sanitize_payload():
         "old": "Susan Robinson",
         "old_end_use_detail": "Quibusdam repudiandae aspernatur nisi praesentium cum. "
         "Odit fugiat soluta necessitatibus impedit.",
-        "organisation_name": "Morgan-Evans",
-        "party_name": "Norman Gibbons",
+        "organisation_name": "Evans-Norman",
+        "party_name": "Jones, Bell and Burke",
         "removed_user_name": "Rhys Jackson",
         "site_name": "Denise Gibson",
         "unchanged": "unchanged value",

--- a/api/audit_trail/tests/test_audit_trail_anonymisers.py
+++ b/api/audit_trail/tests/test_audit_trail_anonymisers.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+from faker import Faker
+
+from api.audit_trail.audit_trail_anonymisers import sanitize_payload
+
+
+# NOTE: Force faker to use a seed when producing output so that we can assume a
+# deterministic set of results
+@pytest.fixture(autouse=True)
+def seed_faker():
+    Faker.seed(0)
+
+
+def test_sanitize_payload():
+    payload = {
+        "case_officer": "some case officer",
+        "party_name": "some party name",
+        "organisation_name": "some organisation name",
+        "user": "some user",
+        "firstname": "some first",
+        "lastname": "some last",
+        "mention_users": ["some user", "some other user"],
+        "site_name": "some site",
+        "destination_name": "some destination",
+        "file_name": "some.file.txt",
+        "ecju_query": "some query",
+        "ecju_response": "some response",
+        "email": "some.email@example.net",
+        "removed_user_name": "some name",
+        "new_end_use_detail": "some detail",
+        "old_end_use_detail": "some old detail",
+        "new": "some new",
+        "old": "some old",
+        "unchanged": "unchanged value",
+    }
+    sanitized_payload = sanitize_payload(json.dumps(payload))
+    assert json.loads(sanitized_payload) == {
+        "case_officer": "Dr. Leanne Smith",
+        "destination_name": "Gail Morgan",
+        "ecju_query": "At saepe quae. A laudantium sint doloribus eveniet sit "
+        "deleniti necessitatibus. Rem consequuntur molestiae at "
+        "voluptatibus. Voluptatum laudantium error enim commodi ex "
+        "ullam. Vitae nobis nesciunt ipsam nisi. Et doloribus delectus "
+        "reprehenderit alias voluptatem.",
+        "ecju_response": "Architecto perspiciatis consectetur corrupti aliquam "
+        "aspernatur praesentium. Placeat saepe minima maxime "
+        "doloremque dolor perspiciatis. Neque iste optio voluptatum "
+        "totam recusandae. Eveniet beatae nesciunt excepturi.",
+        "email": "dixondonna@thompson-pickering.com",
+        "file_name": "ea.key",
+        "firstname": "Chloe",
+        "lastname": "Smith",
+        "mention_users": ["Dr. Gerard Poole", "Garry Sutton-Richardson"],
+        "new": "Jodie Saunders",
+        "new_end_use_detail": "Ratione culpa cum minus. Nisi ipsam cupiditate iusto.",
+        "old": "Conor Metcalfe",
+        "old_end_use_detail": "Quibusdam repudiandae aspernatur nisi praesentium cum. "
+        "Odit fugiat soluta necessitatibus impedit.",
+        "organisation_name": "Jones Group",
+        "party_name": "Dawn Leonard",
+        "removed_user_name": "Dr. Martin Warren",
+        "site_name": "Deborah Williams",
+        "unchanged": "unchanged value",
+        "user": "Dr. Oliver Davey",
+    }

--- a/api/audit_trail/tests/test_audit_trail_anonymisers.py
+++ b/api/audit_trail/tests/test_audit_trail_anonymisers.py
@@ -37,31 +37,24 @@ def test_sanitize_payload():
     }
     sanitized_payload = sanitize_payload(json.dumps(payload))
     assert json.loads(sanitized_payload) == {
-        "case_officer": "Dr. Leanne Smith",
-        "destination_name": "Gail Morgan",
-        "ecju_query": "At saepe quae. A laudantium sint doloribus eveniet sit "
-        "deleniti necessitatibus. Rem consequuntur molestiae at "
-        "voluptatibus. Voluptatum laudantium error enim commodi ex "
-        "ullam. Vitae nobis nesciunt ipsam nisi. Et doloribus delectus "
-        "reprehenderit alias voluptatem.",
-        "ecju_response": "Architecto perspiciatis consectetur corrupti aliquam "
-        "aspernatur praesentium. Placeat saepe minima maxime "
-        "doloremque dolor perspiciatis. Neque iste optio voluptatum "
-        "totam recusandae. Eveniet beatae nesciunt excepturi.",
-        "email": "dixondonna@thompson-pickering.com",
-        "file_name": "ea.key",
-        "firstname": "Chloe",
-        "lastname": "Smith",
-        "mention_users": ["Dr. Gerard Poole", "Garry Sutton-Richardson"],
-        "new": "Jodie Saunders",
+        "case_officer": "Dr Rhys Thomas",
+        "destination_name": "Amelia Sheppard",
+        "ecju_query": "Nostrum totam vitae labore sint ea. Totam at saepe quae quos numquam nostrum. Doloribus eveniet sit deleniti necessitatibus dolores. Rem ipsum aspernatur eum. Voluptatum laudantium error enim commodi ex ullam.",
+        "ecju_response": "Molestias enim at reiciendis et doloribus delectus reprehenderit. Nostrum omnis labore. Perspiciatis consectetur corrupti aliquam. Tempore unde molestiae hic.",
+        "email": "zoe33@example.net",
+        "file_name": "consequuntur.docx",
+        "firstname": "Bradley",
+        "lastname": "Davey",
+        "mention_users": ["Malcolm Scott", "Jay Barker"],
+        "new": "Dr Sally Harper",
         "new_end_use_detail": "Ratione culpa cum minus. Nisi ipsam cupiditate iusto.",
-        "old": "Conor Metcalfe",
+        "old": "Susan Robinson",
         "old_end_use_detail": "Quibusdam repudiandae aspernatur nisi praesentium cum. "
         "Odit fugiat soluta necessitatibus impedit.",
-        "organisation_name": "Jones Group",
-        "party_name": "Dawn Leonard",
-        "removed_user_name": "Dr. Martin Warren",
-        "site_name": "Deborah Williams",
+        "organisation_name": "Morgan-Evans",
+        "party_name": "Norman Gibbons",
+        "removed_user_name": "Rhys Jackson",
+        "site_name": "Denise Gibson",
         "unchanged": "unchanged value",
-        "user": "Dr. Oliver Davey",
+        "user": "Tina Khan",
     }

--- a/api/cases/tests/factories.py
+++ b/api/cases/tests/factories.py
@@ -6,6 +6,7 @@ from api.cases.models import (
     CountersignAdvice,
     Case,
     CaseAssignment,
+    CaseNote,
     CaseStatus,
     CaseType,
     EcjuQuery,
@@ -17,7 +18,7 @@ from api.organisations.tests.factories import OrganisationFactory
 from api.goodstype.tests.factories import GoodsTypeFactory
 from api.staticdata.countries.factories import CountryFactory
 from api.teams.tests.factories import TeamFactory, DepartmentFactory
-from api.users.tests.factories import GovUserFactory
+from api.users.tests.factories import BaseUserFactory, GovUserFactory
 
 
 class BaseAdviceFactory(factory.django.DjangoModelFactory):
@@ -115,3 +116,11 @@ class EcjuQueryFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = EcjuQuery
+
+
+class CaseNoteFactory(factory.django.DjangoModelFactory):
+    case = factory.SubFactory(CaseFactory)
+    user = factory.SubFactory(BaseUserFactory)
+
+    class Meta:
+        model = CaseNote

--- a/api/cases/tests/factories.py
+++ b/api/cases/tests/factories.py
@@ -21,10 +21,20 @@ from api.teams.tests.factories import TeamFactory, DepartmentFactory
 from api.users.tests.factories import BaseUserFactory, GovUserFactory
 
 
+class CaseFactory(factory.django.DjangoModelFactory):
+    case_type = factory.Iterator(CaseType.objects.all())
+    status = factory.Iterator(CaseStatus.objects.all())
+    organisation = factory.SubFactory(OrganisationFactory)
+
+    class Meta:
+        model = Case
+
+
 class BaseAdviceFactory(factory.django.DjangoModelFactory):
     text = factory.Faker("word")
     note = factory.Faker("word")
     type = AdviceType.APPROVE
+    case = factory.SubFactory(CaseFactory)
 
     @factory.post_generation
     def denial_reasons(self, create, extracted, **kwargs):
@@ -69,15 +79,6 @@ class GoodCountryDecisionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = GoodCountryDecision
-
-
-class CaseFactory(factory.django.DjangoModelFactory):
-    case_type = factory.Iterator(CaseType.objects.all())
-    status = factory.Iterator(CaseStatus.objects.all())
-    organisation = factory.SubFactory(OrganisationFactory)
-
-    class Meta:
-        model = Case
 
 
 class CaseSIELFactory(CaseFactory):

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -44,3 +44,5 @@ strategy:
     contact_telephone: faker.phone_number
   site:
     name: faker.name
+  appeals_appeal:
+    grounds_for_appeal: faker.text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -2,6 +2,7 @@ config:
   addons:
     - django_db_anonymiser.db_anonymiser
     - api.goods
+    - api.audit_trail
   extra_parameters:
     pg_dump:
         - "--exclude-table-data=document_data_documentdata"
@@ -66,3 +67,5 @@ strategy:
     description: faker.short_text
   applications_goodonapplication:
     comment: faker.text
+  audit_trail_audit:
+    payload: audit_trail_anonymisers.payload

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -52,3 +52,6 @@ strategy:
     text: faker.text
     note: faker.text
     proviso: faker.text
+  cases_ecjuquery:
+    question: faker.text
+    response: faker.text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -60,9 +60,6 @@ strategy:
   documents_document:
     name: faker.filename
     s3_key: faker.filename
-  goods_firearmgooddetails:
-    serial_number: goods_anonymisers.serial_number
-    serial_numbers: goods_anonymisers.serial_numbers
   good:
     description: faker.short_text
   applications_goodonapplication:

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -64,3 +64,5 @@ strategy:
     serial_numbers: goods_anonymisers.serial_numbers
   good:
     description: faker.short_text
+  applications_goodonapplication:
+    comment: faker.text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -50,3 +50,5 @@ strategy:
     text: faker.text
   advice:
     text: faker.text
+    note: faker.text
+    proviso: faker.text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -62,3 +62,5 @@ strategy:
   goods_firearmgooddetails:
     serial_number: goods_anonymisers.serial_number
     serial_numbers: goods_anonymisers.serial_numbers
+  good:
+    description: faker.short_text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -1,6 +1,7 @@
 config:
   addons:
     - django_db_anonymiser.db_anonymiser
+    - api.goods
   extra_parameters:
     pg_dump:
         - "--exclude-table-data=document_data_documentdata"
@@ -55,3 +56,9 @@ strategy:
   cases_ecjuquery:
     question: faker.text
     response: faker.text
+  documents_document:
+    name: faker.filename
+    s3_key: faker.filename
+  goods_firearmgooddetails:
+    serial_number: goods_anonymisers.serial_number
+    serial_numbers: goods_anonymisers.serial_numbers

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -46,3 +46,5 @@ strategy:
     name: faker.name
   appeals_appeal:
     grounds_for_appeal: faker.text
+  cases_casenote:
+    text: faker.text

--- a/api/conf/anonymise_model_config.yaml
+++ b/api/conf/anonymise_model_config.yaml
@@ -48,3 +48,5 @@ strategy:
     grounds_for_appeal: faker.text
   cases_casenote:
     text: faker.text
+  advice:
+    text: faker.text

--- a/api/goods/goods_anonymisers.py
+++ b/api/goods/goods_anonymisers.py
@@ -1,0 +1,15 @@
+import re
+
+from faker import Faker
+
+fake = Faker("en-GB")
+
+
+def sanitize_serial_number(value):
+    return "serial-number-" + str(fake.random_number(digits=5))
+
+
+def sanitize_serial_numbers(value):
+    serial_numbers = re.findall(r'"(.*?)"', value)
+    sanitized_serial_numbers = [f'"{sanitize_serial_number(item)}"' for item in serial_numbers]
+    return f"{{{','.join(sanitized_serial_numbers)}}}"

--- a/api/goods/tests/test_goods_anonymisers.py
+++ b/api/goods/tests/test_goods_anonymisers.py
@@ -1,0 +1,20 @@
+import pytest
+
+from faker import Faker
+
+from api.goods.goods_anonymisers import sanitize_serial_number, sanitize_serial_numbers
+
+
+# NOTE: Force faker to use a seed when producing output so that we can assume a
+# deterministic set of results
+@pytest.fixture(autouse=True)
+def seed_faker():
+    Faker.seed(0)
+
+
+def test_sanitize_serial_number():
+    assert sanitize_serial_number("12345") == "serial-number-50494"
+
+
+def test_sanitize_serial_numbers():
+    assert sanitize_serial_numbers('{"12345","6789"}') == '{"serial-number-50494","serial-number-99346"}'


### PR DESCRIPTION
### Aim

This change tightens up the anonymisation rules applied when creating anonymised DB dumps for lite-api.

Various fields (potentially) containing PII have been added to the anonymisation configuration.  Also the tests which prove that the anonymiser management command works (and follows our rules) have been improved so that they load the anonymised dump back in to the test database.  Previously, these test would assert that specific strings were not present in the created dump SQL string at all - now they assert that they are not present in the specific DB records that were anonymised.  This makes the tests much tighter.

**TODO:** point at latest `main` commit for django_db_anonymiser after companion PR merged; https://github.com/uktrade/django-db-anonymiser/pull/2
