### PR TITLE
LTD-3456 Update letter template name from DIT to DBT

### DIFF
--- a/api/letter_templates/templates/letter_templates/dbt_letter_base.html
+++ b/api/letter_templates/templates/letter_templates/dbt_letter_base.html
@@ -10,7 +10,7 @@
   <div class="header">
     <div class="header-1">
         <div>
-            <img src="{% static 'images/dbt.png' %}">
+            <img class="dbt-logo" src="{% static 'images/dbt.png' %}">
         </div>
 
 

--- a/api/letter_templates/templates/letter_templates/dbt_letter_base.html
+++ b/api/letter_templates/templates/letter_templates/dbt_letter_base.html
@@ -10,7 +10,7 @@
   <div class="header">
     <div class="header-1">
         <div>
-            <img src="{% static 'images/dit.png' %}">
+            <img src="{% static 'images/dbt.png' %}">
         </div>
 
 
@@ -36,7 +36,7 @@
     <div class="header-2 header-subtext">
         <p>
             Export Control Joint Unit<br/>
-            Department for International Trade<br/>
+            Department for Business and Trade<br/>
             Old Admiralty Building<br/>
             London<br/>
             SW1A 2DY<br/>

--- a/api/letter_templates/templates/letter_templates/ecju_base.html
+++ b/api/letter_templates/templates/letter_templates/ecju_base.html
@@ -7,7 +7,7 @@
     Our Ref: {{ case_reference }}<br>
     Your Ref: {{ details.user_reference }}<br>
   </p>
-  <img src="{% static 'images/dit.png' %}">
+  <img class="dbt-logo" src="{% static 'images/dbt.png' %}">
 
   <div id="addresses">
     <div id="recipient-address">
@@ -24,9 +24,9 @@
     </div>
     <div id="sender-address">
       <p>{{ case_officer_name }}</p>
-      <p>Export Control Organisation</p>
+      <p>Export Control Joint Unit</p>
       <p>
-        Department for International Trade<br>
+        Department for Business and Trade<br>
         Old Admiralty Building<br>
         London<br>
         SW1A 2DY<br>
@@ -37,8 +37,8 @@
         Enquiries +44 (0) 20 4551 0011
       </p>
       <p>
-        www.trade.gov.uk<br>
-        exportcontrol.help@trade.gov.uk
+        https://www.gov.uk/dbt<br>
+        exportcontrol.help@businessandtrade.gov.uk
       </p>
     </div>
   </div>

--- a/api/letter_templates/templates/letter_templates/nlr.html
+++ b/api/letter_templates/templates/letter_templates/nlr.html
@@ -36,7 +36,7 @@
 
     8. As explained in the guidance, if now, or at any time in the future, you become aware or have any grounds for suspecting that the items you wish to export might be used in any way in connection with nuclear, chemical or biological weapons, or missiles to deliver them, as set out in Article 4 of Council Regulation (EC) No 428/2009 (for exports from Great Britain) or Council Regulation (EC) No 428/2009 as it has effect in Northern Ireland by virtue of the Protocol on Ireland/Northern Ireland in the EU withdrawal agreement (for exports from Northern Ireland), and/or Article 6 of the Export Control Order 2008 as amended (WMD purposes end-use control supplementing the dual-use Regulation), then you should tell us of the circumstances and apply for a licence.
 
-    <h2>Restrictions not operated by the Export Control Organisation</h2>
+    <h2>Restrictions not operated by the Export Control Joint Unit</h2>
 
     9. This application has been assessed against all relevant legislation for which the Export Control Joint Unit (ECJU) has responsibility. However, it has not been assessed against other restrictions on exports (for example on antique goods or pharmaceutical products) not administered by ECJU. For further details of these restrictions, please see:
 
@@ -67,7 +67,7 @@
     Yours sincerely,
 
     {{ case_officer_name }}
-    Export Control Organisation
+    Export Control Joint Unit
 
     The following items do not require a licence:
   {% endfilter %}

--- a/api/letter_templates/templates/letter_templates/siel.html
+++ b/api/letter_templates/templates/letter_templates/siel.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="document">
     <h1>Standard Individual Export Licence</h1>
-    <img src="{% static 'images/dit.png' %}">
+    <img src="{% static 'images/dbt.png' %}">
 
     <table id="first-page-table" class="fixed-layout">
       <!--
@@ -94,11 +94,11 @@
           <span class="cell__heading">6. Address of the issuing authority</span>
           <span class="cell__uppercase">
               <span class="cell__uppercase">
-				  Department for International Trade<br>
-				  Export Control Organisation<br>
+				  Export Control Joint Unit<br>
+				  Department for Business and Trade<br>
           Old Admiralty Building<br>
           London<br>
-          SW1A 2BL<br>
+          SW1A 2DY<br>
           United Kingdom
                 </span>
           </span>

--- a/api/letter_templates/templates/letter_templates/siel.html
+++ b/api/letter_templates/templates/letter_templates/siel.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="document">
     <h1>Standard Individual Export Licence</h1>
-    <img src="{% static 'images/dbt.png' %}">
+    <img class="dbt-logo" src="{% static 'images/dbt.png' %}">
 
     <table id="first-page-table" class="fixed-layout">
       <!--

--- a/api/letter_templates/templates/letter_templates/siel.html
+++ b/api/letter_templates/templates/letter_templates/siel.html
@@ -581,7 +581,7 @@
 				  3. This licence may be modified or revoked at any time by the Secretary of State
 			  </div>
 			  <div class="terms-and-conditions-paragraph">
-				  4. This licence is valid when printed only if signed and stamped by an official of the Department for International Trade.
+				  4. This licence is valid when printed only if signed and stamped by an official of the Department for Business and Trade.
 			  </div>
 			  <div class="terms-and-conditions-heading">
 				  General Notes

--- a/pii-secret-exclude.txt
+++ b/pii-secret-exclude.txt
@@ -98,6 +98,7 @@ docs/swagger.yaml
 api/applications/tests/test_copy_application.py
 api/applications/migrations/0010_auto_20200303_1626.py
 api/letter_templates/templates/letter_templates/ecju_base.html
+api/letter_templates/templates/letter_templates/dbt_letter_base.html
 api/external_data/tests/denial_invalid.csv
 api/external_data/management/commands/tests/test_ingest_un_consolidated_list.py
 gov_notify/tests/test_enums.py


### PR DESCRIPTION
### Aim

This PR changes references to "Department for International Trade" and "DIT" to "Department for Business and Trade" and "DBT" respectively in the following places in the caseworker application:
- No licence required letter template
- Refusal letter template
- SIEL template
- Inform letter template

Please also see the companion PR: https://github.com/uktrade/lite-frontend/pull/1834

I have also corrected any errors that stood out to me as unacceptable, these include:
- References to "Export Control Organisation" (should be "Export Control Joint Unit"). There are already references to Export Control Joint Unit in the letter so using Export Control Organisation is not only outdated it is confusing, hence including in this PR
- Using the old postcode (should be "SW1A 2DY")

More can be done to improve the letters themselves but this is out of scope for this work.

[LTD-3456](https://uktrade.atlassian.net/browse/LTD-3456)


[LTD-3456]: https://uktrade.atlassian.net/browse/LTD-3456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ