### PR TITLE
LTD-4766 Change ultimate recipient to ultimate end-user

### DIFF
--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -221,7 +221,7 @@ def _validate_ultimate_end_users(draft, errors, is_mandatory, open_application=F
 
         if ultimate_end_user_required:
             if len(draft.ultimate_end_users.values_list()) == 0:
-                errors["ultimate_end_users"] = [strings.Applications.Standard.NO_ULTIMATE_END_USERS_SET]
+                errors["ultimate_end_users"] = ["To submit the application, add an ultimate end-user"]
             # goods_types are used in open applications and we don't have end_users in them currently.
             elif not open_application:
                 # We make sure that an ultimate end user is not also the end user

--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -228,7 +228,7 @@ def _validate_ultimate_end_users(draft, errors, is_mandatory, open_application=F
                 for ultimate_end_user in draft.ultimate_end_users.values_list("id", flat=True):
                     if "end_user" not in errors and str(ultimate_end_user) == str(draft.end_user.party.id):
                         errors["ultimate_end_users"] = [
-                            strings.Applications.Standard.MATCHING_END_USER_AND_ULTIMATE_END_USER
+                            "To submit the application, an ultimate end-user cannot be the same as the end user"
                         ]
 
     return errors

--- a/api/applications/tests/test_standard_application_submit.py
+++ b/api/applications/tests/test_standard_application_submit.py
@@ -203,7 +203,7 @@ class StandardApplicationTests(DataTestClient):
 
         self.assertContains(
             response,
-            text=strings.Applications.Standard.NO_ULTIMATE_END_USERS_SET,
+            text="To submit the application, add an ultimate end-user",
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/api/applications/tests/test_standard_application_submit.py
+++ b/api/applications/tests/test_standard_application_submit.py
@@ -217,7 +217,7 @@ class StandardApplicationTests(DataTestClient):
 
         self.assertNotContains(
             response,
-            text=strings.Applications.Standard.NO_ULTIMATE_END_USER_DOCUMENT_SET,
+            text="To submit the application, attach a document to the ultimate end-users",
         )
 
     def test_submit_draft_without_third_party_documents_success(self):


### PR DESCRIPTION
### Aim

As lite-content is being deprecated, instead of updating the strings there, it was decided to update the places where those strings are used with updated string literals instead. The alternative is to update them in lite-content and then update the sha to point to an updated lite-content, which we want to avoid if possible.

[LTD-4766](https://uktrade.atlassian.net/browse/LTD-4766)


[LTD-4766]: https://uktrade.atlassian.net/browse/LTD-4766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ