### PR TITLE
LTD-4879 Update api to check is_onward_incorporated on application creation

### DIFF
--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -141,7 +141,7 @@ def _validate_security_approvals(draft, errors, is_mandatory):
     return errors
 
 
-def _validate_ultimate_end_users(draft, errors, is_mandatory, open_application=False):
+def _validate_ultimate_end_users(draft, errors, is_mandatory):
     """
     Checks all ultimate end users have documents if is_mandatory is True.
     Also checks that at least one ultimate_end_user is present if there is an incorporated good
@@ -152,20 +152,14 @@ def _validate_ultimate_end_users(draft, errors, is_mandatory, open_application=F
         errors["ultimate_end_user_documents"] = [ultimate_end_user_documents_error]
 
     if is_mandatory:
-        if open_application:
-            ultimate_end_user_required = True in [
-                goodstype.is_good_incorporated for goodstype in list(draft.goods_type.all())
-            ]
-        else:
-            ultimate_end_user_required = GoodOnApplication.objects.filter(
-                application=draft, is_good_incorporated=True
-            ).exists()
+        ultimate_end_user_required = GoodOnApplication.objects.filter(
+            application=draft, is_good_incorporated=True
+        ).exists()
 
         if ultimate_end_user_required:
             if len(draft.ultimate_end_users.values_list()) == 0:
                 errors["ultimate_end_users"] = ["To submit the application, add an ultimate end-user"]
-            # goods_types are used in open applications and we don't have end_users in them currently.
-            elif not open_application:
+            else:
                 # We make sure that an ultimate end user is not also the end user
                 for ultimate_end_user in draft.ultimate_end_users.values_list("id", flat=True):
                     if "end_user" not in errors and str(ultimate_end_user) == str(draft.end_user.party.id):

--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from api.applications.enums import ApplicationExportType, GoodsTypeCategory
 from api.applications.models import (
     ApplicationDocument,
@@ -152,10 +154,9 @@ def _validate_ultimate_end_users(draft, errors, is_mandatory):
         errors["ultimate_end_user_documents"] = [ultimate_end_user_documents_error]
 
     if is_mandatory:
-        ultimate_end_user_required = (
-            GoodOnApplication.objects.filter(application=draft, is_good_incorporated=True).exists()
-            | GoodOnApplication.objects.filter(application=draft, is_onward_incorporated=True).exists()
-        )
+        ultimate_end_user_required = GoodOnApplication.objects.filter(
+            Q(application=draft), Q(is_good_incorporated=True) | Q(is_onward_incorporated=True)
+        ).exists()
 
         if ultimate_end_user_required:
             if len(draft.ultimate_end_users.values_list()) == 0:

--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -152,9 +152,10 @@ def _validate_ultimate_end_users(draft, errors, is_mandatory):
         errors["ultimate_end_user_documents"] = [ultimate_end_user_documents_error]
 
     if is_mandatory:
-        ultimate_end_user_required = GoodOnApplication.objects.filter(
-            application=draft, is_good_incorporated=True
-        ).exists()
+        ultimate_end_user_required = (
+            GoodOnApplication.objects.filter(application=draft, is_good_incorporated=True).exists()
+            | GoodOnApplication.objects.filter(application=draft, is_onward_incorporated=True).exists()
+        )
 
         if ultimate_end_user_required:
             if len(draft.ultimate_end_users.values_list()) == 0:

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -688,6 +688,8 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
         destination_country_code="GB",
         good_cles=None,
         good_kwargs=None,
+        is_good_incorporated=True,
+        is_onward_incorporated=False,
     ):
         application = self.create_draft_standard_application(
             organisation, reference_name, safe_document, num_products=0, ultimate_end_users=True
@@ -706,7 +708,8 @@ class DataTestClient(APITestCase, URLPatternsTestCase):
             application=application,
             quantity=17,
             value=18,
-            is_good_incorporated=True,
+            is_good_incorporated=is_good_incorporated,
+            is_onward_incorporated=is_onward_incorporated,
         ).save()
 
         self.create_document_for_party(application.ultimate_end_users.first().party, safe=safe_document)


### PR DESCRIPTION
### Aim

Recently we updated the logic that shows "Ultimate end-user" information in the "Check your answers" page to also look at the `is_onward_incorporated` field of a good on application. This check was missing from the application creation logic in `creators.py` so it makes sense to update this also to use that field in the same way.

[LTD-4879](https://uktrade.atlassian.net/browse/LTD-4879)


[LTD-4879]: https://uktrade.atlassian.net/browse/LTD-4879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ