### PR TITLE
[F680] F680 caseworker fixes

### DIFF
--- a/api/applications/helpers.py
+++ b/api/applications/helpers.py
@@ -19,7 +19,7 @@ from api.applications.serializers.standard_application import (
     StandardApplicationUpdateSerializer,
     StandardApplicationViewSerializer,
 )
-from api.applications.serializers.f680 import F680ApplicationCreateSerializer
+from api.applications.serializers.f680 import F680ApplicationCreateSerializer, F680ApplicationViewSerializer
 from api.applications.serializers.good import GoodOnStandardLicenceSerializer
 from api.cases.enums import CaseTypeSubTypeEnum, CaseTypeEnum, AdviceType, AdviceLevel
 from api.core.exceptions import BadRequestError
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 def get_application_view_serializer(application: BaseApplication):
     if application.case_type.sub_type == CaseTypeSubTypeEnum.STANDARD:
         return StandardApplicationViewSerializer
+    if application.case_type.sub_type == CaseTypeSubTypeEnum.F680:
+        return F680ApplicationViewSerializer
     else:
         raise BadRequestError(
             {

--- a/api/applications/libraries/get_applications.py
+++ b/api/applications/libraries/get_applications.py
@@ -1,4 +1,4 @@
-from api.applications.models import BaseApplication, StandardApplication
+from api.applications.models import BaseApplication, StandardApplication, F680Application
 from api.cases.enums import CaseTypeSubTypeEnum
 from api.core.exceptions import NotFoundError
 
@@ -9,64 +9,9 @@ def get_application(pk, organisation_id=None):
         kwargs["organisation_id"] = str(organisation_id)
 
     application_type = _get_application_type(pk)
-    if application_type != CaseTypeSubTypeEnum.STANDARD:
-        raise NotImplementedError(f"get_application does not support this application type: {application_type}")
 
-    qs = StandardApplication.objects.select_related(
-        "baseapplication_ptr",
-        "baseapplication_ptr__end_user",
-        "baseapplication_ptr__end_user__party",
-        "case_officer",
-        "case_officer__team",
-        "case_type",
-        "organisation",
-        "organisation__primary_site",
-        "status",
-        "submitted_by",
-        "submitted_by__baseuser_ptr",
-    ).prefetch_related(
-        "goods",
-        "goods__control_list_entries",
-        "goods__good",
-        "goods__good__control_list_entries",
-        "goods__good__flags",
-        "goods__good__flags__team",
-        "goods__good__gooddocument_set",
-        "goods__good__firearm_details",
-        "goods__good__pv_grading_details",
-        "goods__good__goods_on_application",
-        "goods__good__goods_on_application__application",
-        "goods__good__goods_on_application__application__queues",
-        "goods__good__goods_on_application__good",
-        "goods__good__goods_on_application__good__flags",
-        "goods__good__goods_on_application__regime_entries",
-        "goods__good__goods_on_application__regime_entries__subsection",
-        "goods__good__goods_on_application__regime_entries__subsection__regime",
-        "goods__regime_entries",
-        "goods__regime_entries__subsection",
-        "goods__regime_entries__subsection__regime",
-        "goods__good__report_summary_prefix",
-        "goods__good__report_summary_subject",
-        "goods__audit_trail",
-        "goods__goodonapplicationdocument_set",
-        "goods__goodonapplicationdocument_set__user",
-        "goods__good_on_application_internal_documents",
-        "goods__good_on_application_internal_documents__document",
-        "denial_matches",
-        "denial_matches__denial",
-        "application_sites",
-        "application_sites__site",
-        "application_sites__site__address",
-        "application_sites__site__address__country",
-        "external_application_sites",
-        "applicationdocument_set",
-        "goods__report_summary_prefix",
-        "goods__report_summary_subject",
-        "goods__firearm_details",
-        "goods__assessed_by",
-    )
-    obj = qs.get(pk=pk, **kwargs)
-    return obj
+    model_class = _get_application_model_class(application_type)
+    return model_class.objects.get_application(pk, **kwargs)
 
 
 def _get_application_type(pk):
@@ -74,3 +19,14 @@ def _get_application_type(pk):
         return BaseApplication.objects.values_list("case_type__sub_type", flat=True).get(pk=pk)
     except BaseApplication.DoesNotExist:
         raise NotFoundError({"application_type": "Application type not found - " + str(pk)})
+
+
+def _get_application_model_class(application_type):
+    model_classes = {
+        CaseTypeSubTypeEnum.STANDARD: StandardApplication,
+        CaseTypeSubTypeEnum.F680: F680Application,
+    }
+    try:
+        return model_classes[application_type]
+    except KeyError:
+        raise NotImplementedError(f"get_application does not support this application type: {application_type}")

--- a/api/applications/managers.py
+++ b/api/applications/managers.py
@@ -12,3 +12,132 @@ class BaseApplicationManager(InheritanceManager):
     def submitted(self, organisation):
         draft = get_case_status_by_status(CaseStatusEnum.DRAFT)
         return self.get_queryset().filter(organisation=organisation).exclude(status=draft).order_by("-submitted_at")
+
+    def get_application(self, pk, **kwargs):
+        raise NotImplementedError(f"get_application not implemented for {self.__class__.__name__}")
+
+
+class StandardApplicationManager(BaseApplicationManager):
+    def get_application(self, pk, **kwargs):
+        qs = (
+            self.get_queryset()
+            .select_related(
+                "baseapplication_ptr",
+                "baseapplication_ptr__end_user",
+                "baseapplication_ptr__end_user__party",
+                "case_officer",
+                "case_officer__team",
+                "case_type",
+                "organisation",
+                "organisation__primary_site",
+                "status",
+                "submitted_by",
+                "submitted_by__baseuser_ptr",
+            )
+            .prefetch_related(
+                "goods",
+                "goods__control_list_entries",
+                "goods__good",
+                "goods__good__control_list_entries",
+                "goods__good__flags",
+                "goods__good__flags__team",
+                "goods__good__gooddocument_set",
+                "goods__good__firearm_details",
+                "goods__good__pv_grading_details",
+                "goods__good__goods_on_application",
+                "goods__good__goods_on_application__application",
+                "goods__good__goods_on_application__application__queues",
+                "goods__good__goods_on_application__good",
+                "goods__good__goods_on_application__good__flags",
+                "goods__good__goods_on_application__regime_entries",
+                "goods__good__goods_on_application__regime_entries__subsection",
+                "goods__good__goods_on_application__regime_entries__subsection__regime",
+                "goods__regime_entries",
+                "goods__regime_entries__subsection",
+                "goods__regime_entries__subsection__regime",
+                "goods__good__report_summary_prefix",
+                "goods__good__report_summary_subject",
+                "goods__audit_trail",
+                "goods__goodonapplicationdocument_set",
+                "goods__goodonapplicationdocument_set__user",
+                "goods__good_on_application_internal_documents",
+                "goods__good_on_application_internal_documents__document",
+                "denial_matches",
+                "denial_matches__denial",
+                "application_sites",
+                "application_sites__site",
+                "application_sites__site__address",
+                "application_sites__site__address__country",
+                "external_application_sites",
+                "applicationdocument_set",
+                "goods__report_summary_prefix",
+                "goods__report_summary_subject",
+                "goods__firearm_details",
+                "goods__assessed_by",
+            )
+        )
+        obj = qs.get(pk=pk, **kwargs)
+        return obj
+
+
+class F680ApplicationManager(BaseApplicationManager):
+    def get_application(self, pk, **kwargs):
+        qs = (
+            self.get_queryset()
+            .select_related(
+                "baseapplication_ptr",
+                "baseapplication_ptr__end_user",
+                "baseapplication_ptr__end_user__party",
+                "case_officer",
+                "case_officer__team",
+                "case_type",
+                "organisation",
+                "organisation__primary_site",
+                "status",
+                "submitted_by",
+                "submitted_by__baseuser_ptr",
+            )
+            .prefetch_related(
+                "goods",
+                "goods__control_list_entries",
+                "goods__good",
+                "goods__good__control_list_entries",
+                "goods__good__flags",
+                "goods__good__flags__team",
+                "goods__good__gooddocument_set",
+                "goods__good__firearm_details",
+                "goods__good__pv_grading_details",
+                "goods__good__goods_on_application",
+                "goods__good__goods_on_application__application",
+                "goods__good__goods_on_application__application__queues",
+                "goods__good__goods_on_application__good",
+                "goods__good__goods_on_application__good__flags",
+                "goods__good__goods_on_application__regime_entries",
+                "goods__good__goods_on_application__regime_entries__subsection",
+                "goods__good__goods_on_application__regime_entries__subsection__regime",
+                "goods__regime_entries",
+                "goods__regime_entries__subsection",
+                "goods__regime_entries__subsection__regime",
+                "goods__good__report_summary_prefix",
+                "goods__good__report_summary_subject",
+                "goods__audit_trail",
+                "goods__goodonapplicationdocument_set",
+                "goods__goodonapplicationdocument_set__user",
+                "goods__good_on_application_internal_documents",
+                "goods__good_on_application_internal_documents__document",
+                "denial_matches",
+                "denial_matches__denial",
+                "application_sites",
+                "application_sites__site",
+                "application_sites__site__address",
+                "application_sites__site__address__country",
+                "external_application_sites",
+                "applicationdocument_set",
+                "goods__report_summary_prefix",
+                "goods__report_summary_subject",
+                "goods__firearm_details",
+                "goods__assessed_by",
+            )
+        )
+        obj = qs.get(pk=pk, **kwargs)
+        return obj

--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -18,7 +18,7 @@ from api.applications.enums import (
     F680ProductMTCRRatingType,
 )
 from api.appeals.models import Appeal
-from api.applications.managers import BaseApplicationManager
+from api.applications.managers import BaseApplicationManager, StandardApplicationManager, F680ApplicationManager
 from api.audit_trail.models import Audit, AuditType
 from api.audit_trail import service as audit_trail_service
 from api.cases.enums import CaseTypeEnum
@@ -305,6 +305,8 @@ class StandardApplication(BaseApplication):
     f1686_approval_date = models.DateField(blank=False, null=True)
     other_security_approval_details = models.TextField(default=None, blank=True, null=True)
 
+    objects = StandardApplicationManager()
+
 
 class F680Application(BaseApplication):
     is_list_X_company = models.BooleanField(
@@ -346,6 +348,8 @@ class F680Application(BaseApplication):
     foreign_technology_information = models.BooleanField(default=None, blank=True, null=True)
     foreign_technology_information_details = models.TextField(default="", blank=True)
     other_information = models.TextField(default="", blank=True)
+
+    objects = F680ApplicationManager()
 
 
 class ApplicationDocument(Document):

--- a/api/applications/serializers/f680.py
+++ b/api/applications/serializers/f680.py
@@ -1,11 +1,25 @@
+from django.db.models import Q
 from rest_framework import serializers
 from rest_framework.relations import PrimaryKeyRelatedField
 
 from api.applications.models import F680Application
+from api.applications.mixins.serializers import PartiesSerializerMixin
+from api.appeals.serializers import AppealSerializer
+from api.audit_trail.models import Audit
+from api.audit_trail.enums import AuditType
 from api.cases.models import CaseType
+from api.licences.models import Licence
+from api.licences.serializers.view_licence import CaseLicenceViewSerializer
 from api.organisations.models import Organisation
 from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.serializers import CaseSubStatusSerializer
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+from .denial import DenialMatchOnApplicationViewSerializer
+from .good import GoodOnApplicationViewSerializer
+
+from .generic_application import (
+    GenericApplicationViewSerializer,
+)
 
 
 class F680ApplicationCreateSerializer(serializers.ModelSerializer):
@@ -31,3 +45,81 @@ class F680ApplicationCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data["status"] = get_case_status_by_status(CaseStatusEnum.DRAFT)
         return super().create(validated_data)
+
+
+class F680ApplicationViewSerializer(PartiesSerializerMixin, GenericApplicationViewSerializer):
+    goods = GoodOnApplicationViewSerializer(many=True, read_only=True)
+    destinations = serializers.SerializerMethodField()
+    denial_matches = serializers.SerializerMethodField()
+    additional_documents = serializers.SerializerMethodField()
+    licence = serializers.SerializerMethodField()
+    sanction_matches = serializers.SerializerMethodField()
+    is_amended = serializers.SerializerMethodField()
+    appeal = AppealSerializer()
+    sub_status = CaseSubStatusSerializer()
+
+    class Meta:
+        model = F680Application
+        fields = (
+            GenericApplicationViewSerializer.Meta.fields
+            + PartiesSerializerMixin.Meta.fields
+            + (
+                "goods",
+                "activity",
+                "usage",
+                "destinations",
+                "denial_matches",
+                "additional_documents",
+                "is_military_end_use_controls",
+                "military_end_use_controls_ref",
+                "is_informed_wmd",
+                "informed_wmd_ref",
+                "is_suspected_wmd",
+                "suspected_wmd_ref",
+                "is_eu_military",
+                "is_compliant_limitations_eu",
+                "compliant_limitations_eu_ref",
+                "intended_end_use",
+                "licence",
+                "sanction_matches",
+                "is_amended",
+                "appeal_deadline",
+                "appeal",
+                "sub_status",
+            )
+        )
+
+    def get_licence(self, instance):
+        licence = Licence.objects.filter(case=instance).first()
+        if licence:
+            return CaseLicenceViewSerializer(licence).data
+
+    def get_denial_matches(self, instance):
+        denial_matches = instance.denial_matches.filter(denial__is_revoked=False)
+        return DenialMatchOnApplicationViewSerializer(denial_matches, many=True).data
+
+    def get_is_amended(self, instance):
+        """Determines whether an application is major/minor edited using Audit logs
+        and returns True if either of the amends are done, False otherwise"""
+        audit_qs = Audit.objects.filter(target_object_id=instance.id)
+        is_reference_name_updated = audit_qs.filter(verb=AuditType.UPDATED_APPLICATION_NAME).exists()
+        is_product_removed = audit_qs.filter(verb=AuditType.REMOVE_GOOD_FROM_APPLICATION).exists()
+        app_letter_ref_updated = audit_qs.filter(
+            Q(
+                verb__in=[
+                    AuditType.ADDED_APPLICATION_LETTER_REFERENCE,
+                    AuditType.UPDATE_APPLICATION_LETTER_REFERENCE,
+                    AuditType.REMOVED_APPLICATION_LETTER_REFERENCE,
+                ]
+            )
+        )
+        # in case of doing major edits then the status is set as "Applicant editing"
+        # Here we are detecting the transition from "Submitted" -> "Applicant editing"
+        for item in audit_qs.filter(verb=AuditType.UPDATED_STATUS):
+            status = item.payload["status"]
+            if status["old"] == CaseStatusEnum.get_text(CaseStatusEnum.SUBMITTED) and status[
+                "new"
+            ] == CaseStatusEnum.get_text(CaseStatusEnum.APPLICANT_EDITING):
+                return True
+
+        return any([is_reference_name_updated, app_letter_ref_updated, is_product_removed])


### PR DESCRIPTION
### Aim

These changes make it so that the case details page will be able to show F680 cases without errors.

The code is very much not DRY - `F680ApplicationViewSerializer` has a lot of overlap with `StandardApplicationViewSerializer`.  However this is something that we can look to tackle properly when working on F680s for real.