### PR TITLE
LTD-4890-fix-broken-timestamp

### DIFF
--- a/api/audit_trail/streams/service.py
+++ b/api/audit_trail/streams/service.py
@@ -1,9 +1,7 @@
 """
 MVP activity stream. To be extended appropriately as requirements are drawn up.
 """
-import time
 from datetime import datetime
-
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
@@ -143,7 +141,7 @@ def get_stream(timestamp):
         verb__in=STREAMED_AUDITS,
     ).order_by("created_at")
     if timestamp > 0:
-        audit_qs = audit_qs.filter(created_at__gte=timezone.make_aware(datetime.fromtimestamp(timestamp)))
+        audit_qs = audit_qs.filter(created_at__gte=datetime.fromtimestamp(timestamp, timezone.utc))
     audit_qs = audit_qs[: settings.STREAM_PAGE_SIZE]
 
     if not audit_qs:
@@ -189,4 +187,4 @@ def get_stream(timestamp):
             countries = []
             stream.append(case_record_json(audit.target_object_id, audit.created_at, countries))
 
-    return {"data": stream, "next_timestamp": int(time.mktime(last_created_at.timetuple())) + 1}
+    return {"data": stream, "next_timestamp": int(last_created_at.timestamp()) + 1}

--- a/api/audit_trail/tests/test_streams.py
+++ b/api/audit_trail/tests/test_streams.py
@@ -1,5 +1,4 @@
-from datetime import timedelta
-
+from datetime import timedelta, datetime
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -77,7 +76,7 @@ class AuditTrailStreamTestCase(DataTestClient):
     def test_duplicate_timestamp_appended(self):
         self.case = self.create_standard_application_case(self.organisation)
 
-        now = timezone.now()
+        now = datetime.now(timezone.utc)
         Audit.objects.create(
             created_at=now - timedelta(days=1),
             actor=self.user,


### PR DESCRIPTION
This test started breaking after we moved to BST. 

From what I can tell we pass back next_time stamp 
https://github.com/uktrade/lite-api/blob/dev/api/audit_trail/streams/service.py#L192C63-L192C78

This appears to be sequence of events 

1) created_at in  UTC 
2) time.mktime(last_created_at.timetuple()) which was doing created_at -1 to make BST 
3) timezone.make_aware(datetime.fromtimestamp(timestamp) which was doing another -1 to make timezone suitable resulting in -2 hours. 

from what I can tell datetime.fromtimestamp was alway timezone aware since it depends on django settings however  time.mktime is timezone aware on circle CI but not in docker since it depends on TZ settings and this being picked up correctly. 

time.daylight = 1 on circle-ci and  time.daylight = 0 on docker both TZ is are set to Europe/London but I think due to OS files one can understand it as BST/GMT and other can't. Probably a way to fix that but didn't bother with that as UTC is a better option here. 


This wouldn't have been an issue since before we were in UTC time and all worked ok. 

I think a better option is to make everything UTC based since this function doesn't need to be timezone aware as long as we send back the timestamp of the next item to search for. 

