### PR TITLE
Ltd 4894 save team on advice objects

### DIFF
--- a/api/applications/serializers/advice.py
+++ b/api/applications/serializers/advice.py
@@ -56,6 +56,7 @@ class AdviceViewSerializer(serializers.Serializer):
     footnote = serializers.CharField()
     user = PrimaryKeyRelatedSerializerField(queryset=GovUser.objects.all(), serializer=GovUserListSerializer)
     created_at = serializers.DateTimeField()
+    team = TeamReadOnlySerializer()
 
     good = GoodField()
     goods_type = serializers.UUIDField(source="goods_type_id")

--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -541,6 +541,11 @@ class Advice(TimestampableModel):
         except Advice.DoesNotExist:
             pass
 
+        has_no_team_set = self.team is None
+        has_user = self.user is not None
+        if has_no_team_set and has_user:
+            self.team = self.user.team
+
         super(Advice, self).save(*args, **kwargs)
 
         # We retain the denial reasons from the previous object because we're effectively really doing an edit here by

--- a/api/cases/tests/test_view_advice.py
+++ b/api/cases/tests/test_view_advice.py
@@ -33,6 +33,8 @@ class ViewCaseAdviceTests(DataTestClient):
         self.assertEqual(data["user"]["last_name"], self.gov_user.last_name)
         self.assertEqual(data["user"]["team"]["name"], self.gov_user.team.name)
         self.assertEqual(data["good"], str(self.good.id))
+        self.assertEqual(data["team"]["id"], str(self.gov_user.team.id))
+        self.assertEqual(data["team"]["name"], str(self.gov_user.team.name))
 
     def test_view_all_advice(self):
         user_advice = UserAdviceFactory(user=self.gov_user, case=self.standard_case, good=self.good)


### PR DESCRIPTION
### Aim

This ensures that a team is saved against all advice objects even when not explicitly.

There will be a follow up to migrate all existing objects to have a team.

[LTD-4894](https://uktrade.atlassian.net/browse/LTD-4894)


[LTD-4894]: https://uktrade.atlassian.net/browse/LTD-4894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ