### PR TITLE
LTD-4887: Update page size to have precedents populated for all products

### DIFF
--- a/api/cases/tests/test_good_precedents_view.py
+++ b/api/cases/tests/test_good_precedents_view.py
@@ -135,8 +135,9 @@ class GoodPrecedentsListViewTests(DataTestClient):
                     "destinations": expected_destinations,
                     "wassenaar": True,
                     "submitted_at": application.submitted_at.astimezone(timezone("UTC")).strftime(
-                        "%Y-%m-%dT%H:%M:%S.%fZ"
-                    ),
+                        "%Y-%m-%dT%H:%M:%S.%f"
+                    )[:-3]
+                    + "Z",
                     "goods_starting_point": "",
                     "regime_entries": [
                         {

--- a/api/cases/views/views.py
+++ b/api/cases/views/views.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.generics import ListCreateAPIView, UpdateAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.views import APIView
 
+
 from api.applications.models import GoodOnApplication
 from api.users.models import BaseNotification, ExporterUser
 from api.applications.serializers.advice import (
@@ -1263,4 +1264,17 @@ class GoodOnPrecedentList(ListAPIView):
                 "application__queues",
                 "control_list_entries",
             )
+        )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+
+        serializer = self.get_serializer(queryset, many=True)
+        return JsonResponse(
+            {
+                "count": queryset.count(),
+                "total_pages": 1,
+                "results": serializer.data,
+            },
+            status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## Change description

The endpoint that returns goods precedents using a default page_size of 25. In case of applications that has more goods than this size then only 25 of them are populated with previous assessments.

Increase this to 200 to cover more number of products.


[LTD-4887](https://uktrade.atlassian.net/browse/LTD-4887)


[LTD-4887]: https://uktrade.atlassian.net/browse/LTD-4887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ