### PR TITLE
[LTD-4893] Fix bug relating to submission of re-opened applications

### DIFF
--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -885,6 +885,8 @@ def _get_goods_context(application, final_advice, licence=None):
     # Ensure that for each proviso final advice record, we add a record to the goods
     #  context
     for advice in final_advice:
+        # Ignore final advice records where we have no associated good on application
+        # - either our mapping value is missing or is an empty list so skip it.
         if not good_ids_to_goods_on_application.get(advice.good_id):
             continue
         # Grab the next GoodOnApplication for this Good.id - this ensures that

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -885,11 +885,12 @@ def _get_goods_context(application, final_advice, licence=None):
     # Ensure that for each proviso final advice record, we add a record to the goods
     #  context
     for advice in final_advice:
-        if advice.good_id in good_ids_to_goods_on_application:
-            # Grab the next GoodOnApplication for this Good.id - this ensures that
-            #  each GoodOnApplication is present once on the end licence
-            good_on_application = good_ids_to_goods_on_application[advice.good_id].pop(0)
-            goods_context[advice.type].append(_get_good_on_application_context_with_advice(good_on_application, advice))
+        if not good_ids_to_goods_on_application.get(advice.good_id):
+            continue
+        # Grab the next GoodOnApplication for this Good.id - this ensures that
+        #  each GoodOnApplication is present once on the end licence
+        good_on_application = good_ids_to_goods_on_application[advice.good_id].pop(0)
+        goods_context[advice.type].append(_get_good_on_application_context_with_advice(good_on_application, advice))
 
     # Because we append goods that are approved with proviso to the approved goods below
     # we need to make sure only to keep approved goods that are not in proviso goods


### PR DESCRIPTION
### Aim

This change fixes an issue where a re-opened application could not be submitted.

The issue manifests in the following situation;
- The case has two GoodOnApplication objects pointing to the same Good.
- The case has had final advice.
- The application is re-opened for editing.
- One of the GoodOnApplication records has been removed.

This would result in an IndexError at the point of generating the application document during submission.

This change fixes the issue by skipping any final advice where a matching GoodOnApplication cannot be found.

[LTD-4893](https://uktrade.atlassian.net/browse/LTD-4893)


[LTD-4893]: https://uktrade.atlassian.net/browse/LTD-4893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ