### PR TITLE
LTD-4933-es-search-model-changes

### DIFF
--- a/api/data_workspace/tests/test_external_data_views.py
+++ b/api/data_workspace/tests/test_external_data_views.py
@@ -30,7 +30,6 @@ class DataWorkspaceExternalDataViewTests(DataTestClient):
             "country",
             "item_list_codes",
             "item_description",
-            "consignee_name",
             "end_use",
             "data",
             "is_revoked",

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -72,11 +72,6 @@ postcode_normalizer = analysis.normalizer(
     filter=["lowercase", "asciifolding"],
 )
 
-
-class Denial(InnerDoc):
-    regime_reg_ref = fields.KeywordField()
-
-
 class DenialEnitytDocument(Document):
     id = fields.KeywordField()
     name = fields.TextField()
@@ -96,12 +91,6 @@ class DenialEnitytDocument(Document):
         properties={
             "regime_reg_ref": fields.TextField(
                 attr="regime_reg_ref",
-                fields={
-                    "raw": fields.KeywordField(),
-                },
-            ),
-            "notifying_government": fields.TextField(
-                attr="notifying_government",
                 fields={
                     "raw": fields.KeywordField(),
                 },

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
-from elasticsearch_dsl import analysis
-
+from elasticsearch_dsl import analysis, InnerDoc
 from api.external_data import models
 from api.search.application.documents import lowercase_normalizer
 
@@ -74,26 +73,72 @@ postcode_normalizer = analysis.normalizer(
 )
 
 
-class DenialDocumentType(Document):
+class Denial(InnerDoc):
+    regime_reg_ref = fields.KeywordField()
+
+
+class DenialEnitytDocument(Document):
     id = fields.KeywordField()
     name = fields.TextField()
     address = fields.TextField(
         analyzer=address_analyzer_no_ngram,
     )
-    reference = fields.KeywordField()
-    regime_reg_ref = fields.KeywordField()
-    notifying_government = fields.TextField()
     country = fields.TextField(
         fields={
             "raw": fields.KeywordField(normalizer=lowercase_normalizer),
         },
     )
-    item_list_codes = fields.TextField()
-    item_description = fields.TextField()
-    consignee_name = fields.TextField()
-    end_use = fields.TextField()
     data = DataField()
     is_revoked = fields.BooleanField()
+
+    denial = fields.ObjectField(
+        attr="denial",
+        properties={
+            "regime_reg_ref": fields.TextField(
+                attr="regime_reg_ref",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "notifying_government": fields.TextField(
+                attr="notifying_government",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "reference": fields.TextField(
+                attr="reference",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "notifying_government": fields.TextField(
+                attr="notifying_government",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "item_list_codes": fields.TextField(
+                attr="item_list_codes",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "item_description": fields.TextField(
+                attr="item_description",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "end_use": fields.TextField(
+                attr="end_use",
+                fields={
+                    "raw": fields.KeywordField(),
+                },
+            ),
+            "is_revoked": fields.BooleanField(),
+        },
+    )
 
     class Index:
         name = settings.ELASTICSEARCH_DENIALS_INDEX_ALIAS
@@ -142,4 +187,4 @@ class SanctionDocumentType(Document):
 
 
 if settings.LITE_API_ENABLE_ES:
-    registry.register_document(DenialDocumentType)
+    registry.register_document(DenialEnitytDocument)

--- a/api/external_data/management/commands/ingest_denials.py
+++ b/api/external_data/management/commands/ingest_denials.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from api.applications.models import DenialMatchOnApplication
-from api.external_data.serializers import DenialEntitySerializer
+from api.external_data.serializers import DenialEntitySerializer, DenialSerializer
 from rest_framework import serializers
 
 from elasticsearch_dsl import connections
@@ -27,18 +27,21 @@ def get_json_content_and_delete(filename):
 
 class Command(BaseCommand):
 
-    required_headers = [
-        "reference",
-        "regime_reg_ref",
+    required_headers_denial_entity = [
         "name",
         "address",
-        "notifying_government",
         "country",
+        "spire_entity_id",
+    ]
+
+    required_headers_denial = [
+        "reference",
+        "regime_reg_ref",
+        "notifying_government",
         "item_list_codes",
         "item_description",
         "end_use",
         "reason_for_refusal",
-        "spire_entity_id",
     ]
 
     def add_arguments(self, parser):
@@ -48,7 +51,7 @@ class Command(BaseCommand):
     def rebuild_index(self):
         connection = connections.get_connection()
         connection.indices.delete(index=settings.ELASTICSEARCH_DENIALS_INDEX_ALIAS, ignore=[404])
-        documents.DenialEnitytDocument.init()
+        documents.DenialEntityDocument.init()
 
     @staticmethod
     def add_bulk_errors(errors, row_number, line_errors):
@@ -78,20 +81,30 @@ class Command(BaseCommand):
                 ).exists()
                 if exists:
                     continue
-            serializer = DenialEntitySerializer(
-                data={
-                    "data": row,
-                    **{field: row.pop(field, None) for field in self.required_headers},
-                }
-            )
-            if serializer.is_valid():
-                serializer.save()
+            denial_entity_data = {field: row.pop(field, None) for field in self.required_headers_denial_entity}
+            denial_data = {field: row.pop(field, None) for field in self.required_headers_denial}
+            denial_entity_data["data"] = row
+            denial_serializer = DenialSerializer(data=denial_data)
+            denial_entity_serializer = DenialEntitySerializer(data=denial_entity_data)
+
+            is_valid_denial = denial_serializer.is_valid()
+            is_valid_entity_denial = denial_entity_serializer.is_valid()
+
+            if is_valid_denial and is_valid_entity_denial:
+                denial = denial_serializer.save()
+                denial_entity = denial_entity_serializer.save()
+                denial_entity.denial = denial
+                denial_entity.save()
                 log.info(
                     "Saved row number -> %s",
                     i,
                 )
             else:
-                self.add_bulk_errors(errors=errors, row_number=i + 1, line_errors=serializer.errors)
+                self.add_bulk_errors(
+                    errors=errors,
+                    row_number=i + 1,
+                    line_errors={**denial_serializer.errors, **denial_entity_serializer.errors},
+                )
 
         if errors:
             log.exception(

--- a/api/external_data/management/commands/ingest_denials.py
+++ b/api/external_data/management/commands/ingest_denials.py
@@ -36,7 +36,6 @@ class Command(BaseCommand):
         "country",
         "item_list_codes",
         "item_description",
-        "consignee_name",
         "end_use",
         "reason_for_refusal",
         "spire_entity_id",

--- a/api/external_data/management/commands/ingest_denials.py
+++ b/api/external_data/management/commands/ingest_denials.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     def rebuild_index(self):
         connection = connections.get_connection()
         connection.indices.delete(index=settings.ELASTICSEARCH_DENIALS_INDEX_ALIAS, ignore=[404])
-        documents.DenialDocumentType.init()
+        documents.DenialEnitytDocument.init()
 
     @staticmethod
     def add_bulk_errors(errors, row_number, line_errors):

--- a/api/external_data/management/commands/tests/test_ingest_denials.py
+++ b/api/external_data/management/commands/tests/test_ingest_denials.py
@@ -81,16 +81,16 @@ def test_populate_denials(mock_json_content, mock_delete_file, json_file_data):
     call_command("ingest_denials", "json_file", rebuild=True)
     assert DenialEntity.objects.all().count() == 3
     denial_record = DenialEntity.objects.all()[0]
-    assert denial_record.reference == "DN001\/0003"
+    assert denial_record.denial.reference == "DN001\/0003"
     assert denial_record.name == "Test1 case"
     assert denial_record.address == "somewhere\nmid\nlatter\nCairo"
-    assert denial_record.notifying_government == "United Kingdom"
+    assert denial_record.denial.notifying_government == "United Kingdom"
     assert denial_record.country == "United States"
-    assert denial_record.item_list_codes == "123456"
-    assert denial_record.item_description == "phone"
-    assert denial_record.end_use == "locating phone"
-    assert denial_record.regime_reg_ref == "12"
-    assert denial_record.reason_for_refusal == "reason a"
+    assert denial_record.denial.item_list_codes == "123456"
+    assert denial_record.denial.item_description == "phone"
+    assert denial_record.denial.end_use == "locating phone"
+    assert denial_record.denial.regime_reg_ref == "12"
+    assert denial_record.denial.reason_for_refusal == "reason a"
     assert denial_record.spire_entity_id == 1234
 
     mock_delete_file.assert_called_with(document_id="json_file", s3_key="json_file")

--- a/api/external_data/serializers.py
+++ b/api/external_data/serializers.py
@@ -11,17 +11,40 @@ from api.external_data.helpers import get_denial_entity_type
 from api.flags.enums import SystemFlags
 
 
+class DenialSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Denial
+        fields = (
+            "id",
+            "created_by_user",
+            "reference",
+            "regime_reg_ref",
+            "notifying_government",
+            "item_list_codes",
+            "item_description",
+            "end_use",
+            "is_revoked",
+            "is_revoked_comment",
+            "reason_for_refusal",
+        )
+        extra_kwargs = {
+            "is_revoked": {"required": False},
+            "is_revoked_comment": {"required": False},
+            "reason_for_refusal": {"required": False},
+        }
+
+
 class DenialEntitySerializer(serializers.ModelSerializer):
     entity_type = serializers.SerializerMethodField()
-    regime_reg_ref = serializers.CharField(source="denial.regime_reg_ref")
-    reference = serializers.CharField(source="denial.reference")
-    item_list_codes = serializers.CharField(source="denial.item_list_codes")
-    notifying_government = serializers.CharField(source="denial.notifying_government")
-    item_description = serializers.CharField(source="denial.item_description")
-    end_use = serializers.CharField(source="denial.end_use")
-    is_revoked = serializers.BooleanField(source="denial.is_revoked")
-    is_revoked_comment = serializers.CharField(source="denial.is_revoked_comment")
-    reason_for_refusal = serializers.CharField(source="denial.reason_for_refusal")
+    regime_reg_ref = serializers.CharField(source="denial.regime_reg_ref", required=False)
+    reference = serializers.CharField(source="denial.reference", required=False)
+    item_list_codes = serializers.CharField(source="denial.item_list_codes", required=False)
+    notifying_government = serializers.CharField(source="denial.notifying_government", required=False)
+    item_description = serializers.CharField(source="denial.item_description", required=False)
+    end_use = serializers.CharField(source="denial.end_use", required=False)
+    is_revoked = serializers.BooleanField(source="denial.is_revoked", required=False)
+    is_revoked_comment = serializers.CharField(source="denial.is_revoked_comment", required=False)
+    reason_for_refusal = serializers.CharField(source="denial.reason_for_refusal", required=False)
 
     class Meta:
         model = models.DenialEntity
@@ -36,7 +59,6 @@ class DenialEntitySerializer(serializers.ModelSerializer):
             "country",
             "item_list_codes",
             "item_description",
-            "consignee_name",
             "end_use",
             "data",
             "is_revoked",
@@ -53,7 +75,9 @@ class DenialEntitySerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         validated_data = super().validate(data)
-        if validated_data.get("is_revoked") and not validated_data.get("is_revoked_comment"):
+        if validated_data.get("denial", {}).get("is_revoked") and not validated_data.get("denial", {}).get(
+            "is_revoked_comment"
+        ):
             raise serializers.ValidationError({"is_revoked_comment": "This field is required"})
         return validated_data
 
@@ -61,9 +85,15 @@ class DenialEntitySerializer(serializers.ModelSerializer):
         # This is required because the flattened columns are required to support the older denial screen
         # Serialisers don't support dotted fileds so we need to override. is_revoked and is_revoked_comments
         # are the only updates we support so this is ok.
-        instance.denial.is_revoked = validated_data["denial"]["is_revoked"]
-        instance.denial.is_revoked_comment = validated_data["denial"]["is_revoked_comment"]
-        instance.denial.save()
+
+        if validated_data.get("denial", {}).get("is_revoked"):
+            instance.denial.is_revoked = validated_data["denial"]["is_revoked"]
+            instance.denial.is_revoked_comment = validated_data["denial"]["is_revoked_comment"]
+            instance.denial.save()
+        elif validated_data.get("denial", {}).get("is_revoked") is False:
+            instance.denial.is_revoked = validated_data["denial"]["is_revoked"]
+            instance.denial.is_revoked_comment = ""
+            instance.denial.save()
         return instance
 
     def get_entity_type(self, obj):
@@ -74,18 +104,21 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
 
     csv_file = serializers.CharField()
 
-    required_headers = [
-        "reference",
-        "regime_reg_ref",
+    required_headers_denial_entity = [
         "name",
         "address",
-        "notifying_government",
         "country",
+        "spire_entity_id",
+    ]
+
+    required_headers_denial = [
+        "reference",
+        "regime_reg_ref",
+        "notifying_government",
         "item_list_codes",
         "item_description",
         "end_use",
         "reason_for_refusal",
-        "spire_entity_id",
     ]
 
     @transaction.atomic
@@ -94,7 +127,7 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
         reader = csv.DictReader(csv_file)
 
         # Check if required headers are present
-        if not (set(self.required_headers)).issubset(set(reader.fieldnames)):  # type: ignore
+        if not (set(self.required_headers_denial_entity + self.required_headers_denial)).issubset(set(reader.fieldnames)):  # type: ignore
             raise serializers.ValidationError("Missing required headers in CSV file")
 
         logging_counts = {"denial": {"created": 0, "updated": 0}, "denial_entity": {"created": 0, "updated": 0}}
@@ -105,22 +138,30 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
         errors = []
         for i, row in enumerate(reader, start=1):
             denial_entity_data = {
-                **{field: row[field] for field in self.required_headers},
+                **{field: row[field] for field in self.required_headers_denial_entity},
                 "created_by": self.context["request"].user,
             }
+
+            denial_data = {**{field: row[field].strip() for field in self.required_headers_denial}}
+
             # Create a serializer instance to validate data
             serializer = DenialEntitySerializer(data=denial_entity_data)
-            if serializer.is_valid() and isinstance(serializer.validated_data, dict):
+            denial_serializer = DenialSerializer(data=denial_data)
+            is_valid_denial_data = denial_serializer.is_valid()
+
+            if len(denial_serializer.errors) == 1 and denial_serializer.errors.get("regime_reg_ref"):
+                # This is a bit of a hack presently we care about uniqueness but do want to validate the fields
+                # Hence we override the check
+
+                if (
+                    hasattr(denial_serializer.errors["regime_reg_ref"][0], "code")
+                    and denial_serializer.errors["regime_reg_ref"][0].code == "unique"
+                ):
+                    is_valid_denial_data = True
+
+            if serializer.is_valid() and isinstance(serializer.validated_data, dict) and is_valid_denial_data:
                 # Try to update an existing Denial record or create a new one
-                regime_reg_ref = serializer.validated_data["regime_reg_ref"]
-                denial_data = {
-                    "reference": serializer.validated_data["reference"],
-                    "notifying_government": serializer.validated_data["notifying_government"],
-                    "item_list_codes": serializer.validated_data["item_list_codes"],
-                    "item_description": serializer.validated_data["item_description"],
-                    "end_use": serializer.validated_data["end_use"],
-                    "reason_for_refusal": serializer.validated_data["reason_for_refusal"],
-                }
+                regime_reg_ref = denial_serializer.data["regime_reg_ref"]
                 denial, is_denial_created = models.Denial.objects.update_or_create(
                     regime_reg_ref=regime_reg_ref, defaults=denial_data
                 )
@@ -135,12 +176,13 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
                 # We assume that a DenialEntity object already exists if we can
                 # match on all of the following fields
                 denial_entity_lookup_fields = {
-                    "reference": serializer.validated_data["reference"],
-                    "regime_reg_ref": regime_reg_ref,
                     "name": serializer.validated_data["name"],
                     "address": serializer.validated_data["address"],
                 }
                 # Link the validated DenialEntity data with the Denial
+
+                denial_entity_created_data = serializer.validated_data
+                denial_entity_created_data["denial"] = denial
                 denial_entity, is_denial_entity_created = models.DenialEntity.objects.update_or_create(
                     defaults=serializer.validated_data, denial=denial, **denial_entity_lookup_fields
                 )
@@ -152,7 +194,7 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
                     logging_counts["denial_entity"]["updated"] += 1
                     logging_regime_reg_ref_values["denial_entity"]["updated"].append(denial_entity.regime_reg_ref)
             else:
-                self.add_bulk_errors(errors, i, serializer.errors)
+                self.add_bulk_errors(errors, i, {**serializer.errors, **denial_serializer.errors})
 
         if errors:
             raise serializers.ValidationError(errors)
@@ -201,7 +243,7 @@ class DenialSearchSerializer(DocumentSerializer):
     end_use = serializers.ReadOnlyField(source="denial.end_use")
 
     class Meta:
-        document = documents.DenialEnitytDocument
+        document = documents.DenialEntityDocument
         fields = (
             "id",
             "address",

--- a/api/external_data/serializers.py
+++ b/api/external_data/serializers.py
@@ -175,20 +175,20 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
 
 class DenialSearchSerializer(DocumentSerializer):
     entity_type = serializers.SerializerMethodField()
+    regime_reg_ref = serializers.ReadOnlyField(source="denial.regime_reg_ref")
+    reference = serializers.ReadOnlyField(source="denial.reference")
+    notifying_government = serializers.ReadOnlyField(source="denial.notifying_government")
+    item_list_codes = serializers.ReadOnlyField(source="denial.item_list_codes")
+    item_description = serializers.ReadOnlyField(source="denial.item_description")
+    end_use = serializers.ReadOnlyField(source="denial.end_use")
 
     class Meta:
-        document = documents.DenialDocumentType
+        document = documents.DenialEnitytDocument
         fields = (
             "id",
             "address",
             "country",
-            "end_use",
-            "item_description",
-            "item_list_codes",
             "name",
-            "notifying_government",
-            "reference",
-            "regime_reg_ref",
         )
 
     def get_entity_type(self, obj):

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -32,64 +32,82 @@ class DenialViewSetTests(DataTestClient):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(models.DenialEntity.objects.count(), 4)
+        self.assertEqual(models.Denial.objects.count(), 4)
         self.assertEqual(
-            list(models.DenialEntity.objects.values(*serializers.DenialFromCSVFileSerializer.required_headers, "data")),
+            list(
+                models.DenialEntity.objects.values(
+                    *serializers.DenialFromCSVFileSerializer.required_headers_denial_entity, "data"
+                )
+            ),
             [
                 {
-                    "reference": "DN2000/0000",
-                    "regime_reg_ref": "AB-CD-EF-000",
                     "name": "Organisation Name",
                     "address": "1000 Street Name, City Name",
-                    "notifying_government": "Country Name",
                     "country": "Country Name",
-                    "item_list_codes": "0A00100",
-                    "item_description": "Medium Size Widget",
-                    "end_use": "Used in industry",
-                    "reason_for_refusal": "Risk of outcome",
                     "spire_entity_id": 123,
                     "data": {},
                 },
                 {
-                    "reference": "DN2000/0010",
-                    "regime_reg_ref": "AB-CD-EF-300",
                     "name": "Organisation Name 3",
                     "address": "2001 Street Name, City Name 3",
-                    "notifying_government": "Country Name 3",
                     "country": "Country Name 3",
-                    "item_list_codes": "0A00201",
-                    "item_description": "Unspecified Size Widget",
-                    "end_use": "Used in other industry",
-                    "reason_for_refusal": "Risk of outcome 3",
                     "spire_entity_id": 125,
                     "data": {},
                 },
                 {
-                    "reference": "DN2010/0001",
-                    "regime_reg_ref": "AB-XY-EF-900",
                     "name": "The Widget Company",
                     "address": "2 Example Road, Example City",
-                    "notifying_government": "Example Country",
                     "country": "Country Name X",
-                    "item_list_codes": "catch all",
-                    "item_description": "Extra Large Size Widget",
-                    "end_use": "Used in unknown industry",
-                    "reason_for_refusal": "Risk of outcome 4",
                     "spire_entity_id": 126,
                     "data": {},
                 },
                 {
-                    "reference": "DN3000/0000",
-                    "regime_reg_ref": "AB-CD-EF-100",
                     "name": "Organisation Name XYZ",
                     "address": "2000 Street Name, City Name 2",
-                    "notifying_government": "Country Name 2",
                     "country": "Country Name 2",
+                    "spire_entity_id": 124,
+                    "data": {},
+                },
+            ],
+        )
+        self.assertEqual(
+            list(models.Denial.objects.values(*serializers.DenialFromCSVFileSerializer.required_headers_denial)),
+            [
+                {
+                    "reference": "DN2000/0000",
+                    "regime_reg_ref": "AB-CD-EF-000",
+                    "notifying_government": "Country Name",
+                    "item_list_codes": "0A00100",
+                    "item_description": "Medium Size Widget",
+                    "end_use": "Used in industry",
+                    "reason_for_refusal": "Risk of outcome",
+                },
+                {
+                    "reference": "DN2000/0010",
+                    "regime_reg_ref": "AB-CD-EF-300",
+                    "notifying_government": "Country Name 3",
+                    "item_list_codes": "0A00201",
+                    "item_description": "Unspecified Size Widget",
+                    "end_use": "Used in other industry",
+                    "reason_for_refusal": "Risk of outcome 3",
+                },
+                {
+                    "reference": "DN2010/0001",
+                    "regime_reg_ref": "AB-XY-EF-900",
+                    "notifying_government": "Example Country",
+                    "item_list_codes": "catch all",
+                    "item_description": "Extra Large Size Widget",
+                    "end_use": "Used in unknown industry",
+                    "reason_for_refusal": "Risk of outcome 4",
+                },
+                {
+                    "reference": "DN3000/0000",
+                    "regime_reg_ref": "AB-CD-EF-100",
+                    "notifying_government": "Country Name 2",
                     "item_list_codes": "0A00200",
                     "item_description": "Large Size Widget",
                     "end_use": "Used in other industry",
                     "reason_for_refusal": "Risk of outcome 2",
-                    "spire_entity_id": 124,
-                    "data": {},
                 },
             ],
         )
@@ -110,10 +128,12 @@ class DenialViewSetTests(DataTestClient):
         reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
         DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,123
         """
+
         response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(models.Denial.objects.count(), 1)
         self.assertEqual(models.DenialEntity.objects.count(), 1)
+
         self.assertEqual(
             list(models.Denial.objects.values(*denial_data_fields)),
             [
@@ -129,19 +149,16 @@ class DenialViewSetTests(DataTestClient):
             ],
         )
         self.assertEqual(
-            list(models.DenialEntity.objects.values(*serializers.DenialFromCSVFileSerializer.required_headers, "data")),
+            list(
+                models.DenialEntity.objects.values(
+                    *serializers.DenialFromCSVFileSerializer.required_headers_denial_entity, "data"
+                )
+            ),
             [
                 {
-                    "reference": "DN2000/0000",
-                    "regime_reg_ref": "AB-CD-EF-000",
                     "name": "Organisation Name",
                     "address": "1000 Street Name, City Name",
-                    "notifying_government": "Country Name",
                     "country": "Country Name",
-                    "item_list_codes": "0A00100",
-                    "item_description": "Medium Size Widget",
-                    "end_use": "Used in industry",
-                    "reason_for_refusal": "Risk of outcome",
                     "spire_entity_id": 123,
                     "data": {},
                 },
@@ -149,7 +166,7 @@ class DenialViewSetTests(DataTestClient):
         )
         updated_content = """
         reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
-        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name 2,Country Name 2,0A00200,Medium Size Widget 2,Used in industry 2,Risk of outcome 2,124
+        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name 2,Country Name 2,0A00200,Medium Size Widget 2, Used in industry 2,Risk of outcome 2,124
         """
         response = self.client.post(url, {"csv_file": updated_content}, **self.gov_headers)
         self.assertEqual(response.status_code, 201)
@@ -166,26 +183,23 @@ class DenialViewSetTests(DataTestClient):
                     "item_description": "Medium Size Widget 2",
                     "end_use": "Used in industry 2",
                     "reason_for_refusal": "Risk of outcome 2",
-                },
+                }
             ],
         )
         self.assertEqual(
-            list(models.DenialEntity.objects.values(*serializers.DenialFromCSVFileSerializer.required_headers, "data")),
+            list(
+                models.DenialEntity.objects.values(
+                    *serializers.DenialFromCSVFileSerializer.required_headers_denial_entity, "data"
+                )
+            ),
             [
                 {
-                    "reference": "DN2000/0000",
-                    "regime_reg_ref": "AB-CD-EF-000",
                     "name": "Organisation Name",
                     "address": "1000 Street Name, City Name",
-                    "notifying_government": "Country Name 2",
                     "country": "Country Name 2",
-                    "item_list_codes": "0A00200",
-                    "item_description": "Medium Size Widget 2",
-                    "end_use": "Used in industry 2",
-                    "reason_for_refusal": "Risk of outcome 2",
                     "spire_entity_id": 124,
                     "data": {},
-                },
+                }
             ],
         )
 
@@ -246,9 +260,9 @@ class DenialSearchViewTests(DataTestClient):
 
         # Set one of them as revoked
         denial_entity = models.DenialEntity.objects.get(name="Organisation Name")
-        denial_entity.is_revoked = True
-        denial_entity.save()
-
+        denial_entity.denial.is_revoked = True
+        denial_entity.denial.save()
+        # This needs to be fixed we need to rebuild index if child value is updated.
         # Then only 2 denial entity objects will be returned when searching
         url = reverse("external_data:denial_search-list")
 

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -36,7 +36,7 @@ class SanctionViewSet(viewsets.ModelViewSet):
 
 
 class DenialSearchView(DocumentViewSet):
-    document = documents.DenialDocumentType
+    document = documents.DenialEnitytDocument
     serializer_class = serializers.DenialSearchSerializer
     authentication_classes = (GovAuthentication,)
     pagination_class = MaxPageNumberPagination
@@ -56,7 +56,7 @@ class DenialSearchView(DocumentViewSet):
     ordering = "_score"
 
     def filter_queryset(self, queryset):
-        queryset = queryset.filter("term", is_revoked=False)
+        queryset = queryset.filter("term", denial__is_revoked=False)
         return super().filter_queryset(queryset)
 
 

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -36,7 +36,7 @@ class SanctionViewSet(viewsets.ModelViewSet):
 
 
 class DenialSearchView(DocumentViewSet):
-    document = documents.DenialEnitytDocument
+    document = documents.DenialEntityDocument
     serializer_class = serializers.DenialSearchSerializer
     authentication_classes = (GovAuthentication,)
     pagination_class = MaxPageNumberPagination
@@ -56,7 +56,7 @@ class DenialSearchView(DocumentViewSet):
     ordering = "_score"
 
     def filter_queryset(self, queryset):
-        queryset = queryset.filter("term", denial__is_revoked=False)
+        queryset = queryset.filter("term", is_revoked=False)
         return super().filter_queryset(queryset)
 
 


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-4933

Changes denial search to use new fields from Denial Table 

Also the serialiser which is used to View on the UI and update on the UI has been updated to use the fields from Denial rather then Denial Entity. 

I've had to go alot further in this PR then I would expected.  The CSV loader and ingest_denials breaks as we change the default entity serializer as it become ready_only. This is deliberately done like this so we don't break the UI and require further changes. 
  

- We have already ingested a clean set of DenialEntity Objects that were release last week. Which fixed all the duplicates. 
- This PR deals with copying them across to Denial Model  through we are certain there's no duplicates (confirmed by testing locally)
- Wrapped in a transaction just incase so we can roll back and not copy any data into Denials. 
