### PR TITLE
LTD-4937 Update denial csv file serializers to remove temp code

### DIFF
--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -98,35 +98,13 @@ class DenialViewSetTests(DataTestClient):
             ],
         )
 
-    def test_create_validation_error(self):
+    def test_create_error_missing_required_headers(self):
         url = reverse("external_data:denial-list")
         file_path = os.path.join(settings.BASE_DIR, "external_data/tests/denial_invalid.csv")
         with open(file_path, "rb") as f:
             content = f.read()
         response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.json(),
-            {
-                "errors": {
-                    "csv_file": [
-                        "[Row 2] reference: This field may not be null.",
-                        "[Row 3] reference: This field may not be null.",
-                        "[Row 4] reference: This field may not be null.",
-                    ]
-                }
-            },
-        )
-
-    def test_create_error_missing_required_headers(self):
-        url = reverse("external_data:denial-list")
-        # missing the 'reference' header
-        content = """
-        regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-        AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123
-        """
-        response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"errors": {"csv_file": ["Missing required headers in CSV file"]}})
 

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -19,12 +19,7 @@ class DenialViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         if self.action == "create":
-            # TODO: this is for backwards compatibility and should be removed
-            # once the lite-routing test data has been updated
-            if bool("regime_reg_ref" not in str(self.request.data["csv_file"])):  # type: ignore
-                return serializers.DenialFromCSVFileOldSerializer
-            else:
-                return serializers.DenialFromCSVFileSerializer
+            return serializers.DenialFromCSVFileSerializer
         return serializers.DenialEntitySerializer
 
     def perform_create(self, serializer):


### PR DESCRIPTION
This is to remove the old denial csv file serializer which is no longer needed now that lite-routing has been updated with correct test data. The lite-routing sha update is also included in this PR.