### PR TITLE
LTD-4950 Update lite-api test csv files to match example csv

### DIFF
--- a/api/external_data/serializers.py
+++ b/api/external_data/serializers.py
@@ -65,7 +65,6 @@ class DenialFromCSVFileSerializer(serializers.Serializer):
         "country",
         "item_list_codes",
         "item_description",
-        "consignee_name",
         "end_use",
         "reason_for_refusal",
         "spire_entity_id",

--- a/api/external_data/tests/denial_valid.csv
+++ b/api/external_data/tests/denial_valid.csv
@@ -1,5 +1,5 @@
-reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123
-DN2000/0010,AB-CD-EF-300,Organisation Name 3,"2001 Street Name, City Name 3",Country Name 3,Country Name 3,0A00201,Unspecified Size Widget,Example Name 3,Used in other industry,Risk of outcome 3,125
-DN2010/0001,AB-XY-EF-900,The Widget Company,"2 Example Road, Example City",Example Country,Country Name X,"catch all",Extra Large Size Widget,Example Name 4,Used in unknown industry,Risk of outcome 4,126
-DN3000/0000,AB-CD-EF-100,Organisation Name XYZ,"2000 Street Name, City Name 2",Country Name 2,Country Name 2,0A00200,Large Size Widget,Example Name 2,Used in other industry,Risk of outcome 2,124
+reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,consignee_name,spire_entity_id,end_user_flag,consignee_flag,other_role
+DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,Example Name,123,TRUE,FALSE,
+DN2000/0010,AB-CD-EF-300,Country Name 3,0A00201,Unspecified Size Widget,Used in other industry,Risk of outcome 3,Organisation Name 3,"2001 Street Name, City Name 3",Country Name 3,Example Name 3,125,TRUE,FALSE,
+DN2010/0001,AB-XY-EF-900,Example Country,catch all,Extra Large Size Widget,Used in unknown industry,Risk of outcome 4,The Widget Company,"2 Example Road, Example City",Country Name X,Example Name 4,126,TRUE,FALSE,
+DN3000/0000,AB-CD-EF-100,Country Name 2,0A00200,Large Size Widget,Used in other industry,Risk of outcome 2,Organisation Name XYZ,"2000 Street Name, City Name 2",Country Name 2,Example Name 2,124,TRUE,FALSE,

--- a/api/external_data/tests/denial_valid.csv
+++ b/api/external_data/tests/denial_valid.csv
@@ -1,5 +1,5 @@
-reference,regime_reg_ref,notifying_government,item_list_codes,item_description,end_use,reason_for_refusal,name,address,country,consignee_name,spire_entity_id,end_user_flag,consignee_flag,other_role
-DN2000/0000,AB-CD-EF-000,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,Organisation Name,"1000 Street Name, City Name",Country Name,Example Name,123,TRUE,FALSE,
-DN2000/0010,AB-CD-EF-300,Country Name 3,0A00201,Unspecified Size Widget,Used in other industry,Risk of outcome 3,Organisation Name 3,"2001 Street Name, City Name 3",Country Name 3,Example Name 3,125,TRUE,FALSE,
-DN2010/0001,AB-XY-EF-900,Example Country,catch all,Extra Large Size Widget,Used in unknown industry,Risk of outcome 4,The Widget Company,"2 Example Road, Example City",Country Name X,Example Name 4,126,TRUE,FALSE,
-DN3000/0000,AB-CD-EF-100,Country Name 2,0A00200,Large Size Widget,Used in other industry,Risk of outcome 2,Organisation Name XYZ,"2000 Street Name, City Name 2",Country Name 2,Example Name 2,124,TRUE,FALSE,
+reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
+DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,123
+DN2000/0010,AB-CD-EF-300,Organisation Name 3,"2001 Street Name, City Name 3",Country Name 3,Country Name 3,0A00201,Unspecified Size Widget,Used in other industry,Risk of outcome 3,125
+DN2010/0001,AB-XY-EF-900,The Widget Company,"2 Example Road, Example City",Example Country,Country Name X,"catch all",Extra Large Size Widget,Used in unknown industry,Risk of outcome 4,126
+DN3000/0000,AB-CD-EF-100,Organisation Name XYZ,"2000 Street Name, City Name 2",Country Name 2,Country Name 2,0A00200,Large Size Widget,Used in other industry,Risk of outcome 2,124

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -44,7 +44,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name",
                     "item_list_codes": "0A00100",
                     "item_description": "Medium Size Widget",
-                    "consignee_name": "Example Name",
                     "end_use": "Used in industry",
                     "reason_for_refusal": "Risk of outcome",
                     "spire_entity_id": 123,
@@ -59,7 +58,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name 3",
                     "item_list_codes": "0A00201",
                     "item_description": "Unspecified Size Widget",
-                    "consignee_name": "Example Name 3",
                     "end_use": "Used in other industry",
                     "reason_for_refusal": "Risk of outcome 3",
                     "spire_entity_id": 125,
@@ -74,7 +72,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name X",
                     "item_list_codes": "catch all",
                     "item_description": "Extra Large Size Widget",
-                    "consignee_name": "Example Name 4",
                     "end_use": "Used in unknown industry",
                     "reason_for_refusal": "Risk of outcome 4",
                     "spire_entity_id": 126,
@@ -89,7 +86,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name 2",
                     "item_list_codes": "0A00200",
                     "item_description": "Large Size Widget",
-                    "consignee_name": "Example Name 2",
                     "end_use": "Used in other industry",
                     "reason_for_refusal": "Risk of outcome 2",
                     "spire_entity_id": 124,
@@ -111,8 +107,8 @@ class DenialViewSetTests(DataTestClient):
     def test_update_success(self):
         url = reverse("external_data:denial-list")
         content = """
-        reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123
+        reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
+        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,123
         """
         response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
         self.assertEqual(response.status_code, 201)
@@ -144,7 +140,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name",
                     "item_list_codes": "0A00100",
                     "item_description": "Medium Size Widget",
-                    "consignee_name": "Example Name",
                     "end_use": "Used in industry",
                     "reason_for_refusal": "Risk of outcome",
                     "spire_entity_id": 123,
@@ -153,8 +148,8 @@ class DenialViewSetTests(DataTestClient):
             ],
         )
         updated_content = """
-        reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name 2,Country Name 2,0A00200,Medium Size Widget 2,Example Name 2,Used in industry 2,Risk of outcome 2,124
+        reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
+        DN2000/0000,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name 2,Country Name 2,0A00200,Medium Size Widget 2,Used in industry 2,Risk of outcome 2,124
         """
         response = self.client.post(url, {"csv_file": updated_content}, **self.gov_headers)
         self.assertEqual(response.status_code, 201)
@@ -186,7 +181,6 @@ class DenialViewSetTests(DataTestClient):
                     "country": "Country Name 2",
                     "item_list_codes": "0A00200",
                     "item_description": "Medium Size Widget 2",
-                    "consignee_name": "Example Name 2",
                     "end_use": "Used in industry 2",
                     "reason_for_refusal": "Risk of outcome 2",
                     "spire_entity_id": 124,
@@ -197,8 +191,8 @@ class DenialViewSetTests(DataTestClient):
 
     def test_create_error_serializer_errors(self):
         url = reverse("external_data:denial-list")
-        content = """reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,consignee_name,end_use,reason_for_refusal,spire_entity_id
-        ,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Example Name,Used in industry,Risk of outcome,123
+        content = """reference,regime_reg_ref,name,address,notifying_government,country,item_list_codes,item_description,end_use,reason_for_refusal,spire_entity_id
+        ,AB-CD-EF-000,Organisation Name,"1000 Street Name, City Name",Country Name,Country Name,0A00100,Medium Size Widget,Used in industry,Risk of outcome,123
         """
         response = self.client.post(url, {"csv_file": content}, **self.gov_headers)
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
### Aim

The example csv used in lite-frontend was updated to have 3 extra columns and also to reorder the columns (https://github.com/uktrade/lite-frontend/pull/1907) so this just does the same for the test csv file used in lite-api.

EDIT: As `consignee_name` as a column is not needed it has been removed from the example csv, and so a lot of the changes in this PR are now to keep things consistent now that this field is not expected to be used.

[LTD-4950](https://uktrade.atlassian.net/browse/LTD-4950)


[LTD-4950]: https://uktrade.atlassian.net/browse/LTD-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ