### PR TITLE
Ltd 4935 handle empty strings

### DIFF
--- a/api/external_data/migrations/0023_set_denial_entity_type.py
+++ b/api/external_data/migrations/0023_set_denial_entity_type.py
@@ -30,10 +30,11 @@ def set_denial_entity_type(apps, schema_editor):
 
     DenialEntity = apps.get_model("external_data", "DenialEntity")
 
-    for denial_entity in DenialEntity.objects.filter(entity_type__isnull=True):
+    entities_with_null_entity_type = DenialEntity.objects.filter(entity_type__isnull=True)
+    entities_with_empty_entity_type = DenialEntity.objects.filter(entity_type="")
 
+    for denial_entity in entities_with_null_entity_type, entities_with_empty_entity_type:
         denial_entity_type = get_denial_entity_type(denial_entity.data)
-
         if denial_entity_type in ["end_user", "consignee", "third_party"]:
             denial_entity.entity_type = denial_entity_type
             denial_entity.save()

--- a/api/external_data/migrations/0023_set_denial_entity_type.py
+++ b/api/external_data/migrations/0023_set_denial_entity_type.py
@@ -30,11 +30,10 @@ def set_denial_entity_type(apps, schema_editor):
 
     DenialEntity = apps.get_model("external_data", "DenialEntity")
 
-    entities_with_null_entity_type = DenialEntity.objects.filter(entity_type__isnull=True)
-    entities_with_empty_entity_type = DenialEntity.objects.filter(entity_type="")
+    for denial_entity in DenialEntity.objects.filter(entity_type=""):
 
-    for denial_entity in entities_with_null_entity_type, entities_with_empty_entity_type:
         denial_entity_type = get_denial_entity_type(denial_entity.data)
+
         if denial_entity_type in ["end_user", "consignee", "third_party"]:
             denial_entity.entity_type = denial_entity_type
             denial_entity.save()

--- a/api/external_data/tests/test_0023_set_denial_entity_type.py
+++ b/api/external_data/tests/test_0023_set_denial_entity_type.py
@@ -18,7 +18,7 @@ test_data = [
         "reason_for_refusal": "Risk of outcome",
         "spire_entity_id": 123,
         "data": {"END_USER_FLAG": "true", "CONSIGNEE_FLAG": "false", "OTHER_ROLE": ""},
-        "entity_type": None,
+        "entity_type": "",
     },
     {
         "reference": "DN2000/0010",
@@ -34,7 +34,7 @@ test_data = [
         "reason_for_refusal": "Risk of outcome 3",
         "spire_entity_id": 125,
         "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "true", "OTHER_ROLE": ""},
-        "entity_type": None,
+        "entity_type": "",
     },
     {
         "reference": "DN2000/0000",
@@ -50,38 +50,6 @@ test_data = [
         "reason_for_refusal": "Risk of outcome",
         "spire_entity_id": 123,
         "data": {"END_USER_FLAG": "true", "CONSIGNEE_FLAG": "true", "OTHER_ROLE": ""},
-        "entity_type": None,
-    },
-    {
-        "reference": "DN3000/0000",
-        "regime_reg_ref": "AB-CD-EF-100",
-        "name": "Organisation Name XYZ",
-        "address": "2000 Street Name, City Name 2",
-        "notifying_government": "Country Name 2",
-        "country": "Country Name 2",
-        "item_list_codes": "0A00200",
-        "item_description": "Large Size Widget",
-        "consignee_name": "Example Name 2",
-        "end_use": "Used in other industry",
-        "reason_for_refusal": "Risk of outcome 2",
-        "spire_entity_id": 124,
-        "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "false", "OTHER_ROLE": "other"},
-        "entity_type": None,
-    },
-    {
-        "reference": "DN2000/0000",
-        "regime_reg_ref": "AB-CD-EF-000",
-        "name": "Organisation Name",
-        "address": "1000 Street Name, City Name",
-        "notifying_government": "Country Name",
-        "country": "Country Name",
-        "item_list_codes": "0A00100",
-        "item_description": "Medium Size Widget",
-        "consignee_name": "Example Name",
-        "end_use": "Used in industry",
-        "reason_for_refusal": "Risk of outcome",
-        "spire_entity_id": 123,
-        "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "true", "OTHER_ROLE": ""},
         "entity_type": "",
     },
     {
@@ -116,7 +84,7 @@ class TestDenialEntityTypeSet(MigratorTestCase):
     def test_0023_set_denial_entity_type(self):
         DenialEntity = self.new_state.apps.get_model("external_data", "DenialEntity")
 
-        assert DenialEntity.objects.all().count() == 6
-        assert DenialEntity.objects.filter(entity_type=DenialEntityType.END_USER).count() == 2
-        assert DenialEntity.objects.filter(entity_type=DenialEntityType.CONSIGNEE).count() == 1
-        assert DenialEntity.objects.filter(entity_type=DenialEntityType.THIRD_PARTY).count() == 2
+        self.assertEqual(DenialEntity.objects.all().count(), 4)
+        self.assertEqual(DenialEntity.objects.filter(entity_type=DenialEntityType.END_USER).count(), 2)
+        self.assertEqual(DenialEntity.objects.filter(entity_type=DenialEntityType.CONSIGNEE).count(), 1)
+        self.assertEqual(DenialEntity.objects.filter(entity_type=DenialEntityType.THIRD_PARTY).count(), 1)

--- a/api/external_data/tests/test_0023_set_denial_entity_type.py
+++ b/api/external_data/tests/test_0023_set_denial_entity_type.py
@@ -68,6 +68,38 @@ test_data = [
         "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "false", "OTHER_ROLE": "other"},
         "entity_type": None,
     },
+    {
+        "reference": "DN2000/0000",
+        "regime_reg_ref": "AB-CD-EF-000",
+        "name": "Organisation Name",
+        "address": "1000 Street Name, City Name",
+        "notifying_government": "Country Name",
+        "country": "Country Name",
+        "item_list_codes": "0A00100",
+        "item_description": "Medium Size Widget",
+        "consignee_name": "Example Name",
+        "end_use": "Used in industry",
+        "reason_for_refusal": "Risk of outcome",
+        "spire_entity_id": 123,
+        "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "true", "OTHER_ROLE": ""},
+        "entity_type": "",
+    },
+    {
+        "reference": "DN3000/0000",
+        "regime_reg_ref": "AB-CD-EF-100",
+        "name": "Organisation Name XYZ",
+        "address": "2000 Street Name, City Name 2",
+        "notifying_government": "Country Name 2",
+        "country": "Country Name 2",
+        "item_list_codes": "0A00200",
+        "item_description": "Large Size Widget",
+        "consignee_name": "Example Name 2",
+        "end_use": "Used in other industry",
+        "reason_for_refusal": "Risk of outcome 2",
+        "spire_entity_id": 124,
+        "data": {"END_USER_FLAG": "false", "CONSIGNEE_FLAG": "false", "OTHER_ROLE": "other"},
+        "entity_type": "",
+    },
 ]
 
 
@@ -84,7 +116,7 @@ class TestDenialEntityTypeSet(MigratorTestCase):
     def test_0023_set_denial_entity_type(self):
         DenialEntity = self.new_state.apps.get_model("external_data", "DenialEntity")
 
-        assert DenialEntity.objects.all().count() == 4
+        assert DenialEntity.objects.all().count() == 6
         assert DenialEntity.objects.filter(entity_type=DenialEntityType.END_USER).count() == 2
         assert DenialEntity.objects.filter(entity_type=DenialEntityType.CONSIGNEE).count() == 1
-        assert DenialEntity.objects.filter(entity_type=DenialEntityType.THIRD_PARTY).count() == 1
+        assert DenialEntity.objects.filter(entity_type=DenialEntityType.THIRD_PARTY).count() == 2


### PR DESCRIPTION
### Aim

Similar to the previous pull request on this ref but now it filters the db objects it's looking for by an empty string.  This is because the entity_type field has been populated with an empty string in the db from the previous migration.  Issue was noticed when checking dev environment but this should fix it.

[LTD-4935](https://uktrade.atlassian.net/browse/LTD-4935)


[LTD-4935]: https://uktrade.atlassian.net/browse/LTD-4935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ