### PR TITLE
Ensure team is taken into account when filtering user advice

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -528,6 +528,7 @@ class Advice(TimestampableModel):
                     case=self.case,
                     good=self.good,
                     user=self.user,
+                    team=self.user.team,
                     level=AdviceLevel.USER,
                     goods_type=self.goods_type,
                     country=self.country,

--- a/api/cases/tests/test_edit_advice.py
+++ b/api/cases/tests/test_edit_advice.py
@@ -48,6 +48,28 @@ class EditCaseAdviceTests(DataTestClient):
         # Assert that there's only one piece of advice
         self.assertEqual(Advice.objects.count(), 1)
 
+    def test_edit_standard_case_advice_same_user_on_different_teams_saves_for_each_team(self):
+        """
+        Tests that a gov user can create two pieces of advice on the same
+        case item (be that a good or destination) as long as they change team
+        """
+        data = {
+            "type": AdviceType.APPROVE,
+            "text": "I Am Easy to Find",
+            "note": "I Am Easy to Find",
+            "country": "GB",
+            "level": AdviceLevel.USER,
+        }
+
+        self.client.post(self.url, **self.gov_headers, data=[data])
+
+        self.gov_user.team = Team.objects.exclude(pk=self.gov_user.team.pk).first()
+        self.gov_user.save()
+        self.assertIsNotNone(self.gov_user.team)
+        self.client.post(self.url, **self.gov_headers, data=[data])
+
+        self.assertEqual(Advice.objects.count(), 2)
+
     def test_edit_standard_case_advice_updates_denial_reasons(self):
         data = {
             "type": AdviceType.REFUSE,


### PR DESCRIPTION
### Aim

Fixes an issue whereby a user could change team and then give advice and their previous advice would be removed.

This is because the code views this as an "edit" but instead we should take into account the users team as well and only "edit" in the case where the user and the team match.

[LTD-4900](https://uktrade.atlassian.net/browse/LTD-4900)


[LTD-4900]: https://uktrade.atlassian.net/browse/LTD-4900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ