### PR TITLE
LTD-5003: Update part number search to look for exact matches

### DIFF
--- a/api/search/product/documents.py
+++ b/api/search/product/documents.py
@@ -19,7 +19,7 @@ address_analyzer = analysis.analyzer(
 
 part_number_analyzer = analysis.analyzer(
     "part_number_analyzer",
-    tokenizer=analysis.tokenizer("part_number_path_hierarchy", "path_hierarchy", delimiter="-"),
+    tokenizer=analysis.tokenizer("part_number_path_hierarchy", "path_hierarchy"),
     filter=["lowercase", "trim"],
 )
 

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -108,17 +108,20 @@ class ProductSearchTests(BaseProductSearchTests):
     @pytest.mark.elasticsearch
     @parameterized.expand(
         [
-            ({"search": "ABC"}, 1, "ABC-123"),
-            ({"search": "H2SO4"}, 1, "H2SO4"),
+            ({"search": "ABC"}, 0),
+            ({"search": "ABC-123"}, 1),
+            ({"search": "IMG-1300"}, 1),
+            ({"search": "867-"}, 0),
+            ({"search": "867-5309"}, 1),
+            ({"search": "H2SO4"}, 1),
         ]
     )
-    def test_product_search_by_part_number(self, query, expected_count, expected_part_number):
+    def test_product_search_by_part_number(self, query, expected_count):
         response = self.client.get(self.product_search_url, query, **self.gov_headers)
         self.assertEqual(response.status_code, 200)
 
         response = response.json()
         self.assertEqual(response["count"], expected_count)
-        self.assertIn(expected_part_number, [item["part_number"] for item in response["results"]])
 
     @pytest.mark.elasticsearch
     @parameterized.expand(


### PR DESCRIPTION
## Change description

Currently part number search in products uses a delimiter '-' when analyzing the search string. Because of this if a part number contains hyphens then it splits into multiple tokens and matches on individual tokens as well. This can bring multiple results and not possible to get an exact match.

Users are expecting for an exact match so consider the whole search string without using any delimiters.

[LTD-5003](https://uktrade.atlassian.net/browse/LTD-5003)


[LTD-5003]: https://uktrade.atlassian.net/browse/LTD-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ