### PR TITLE
LTD-5012-complex-denial-searching 

### DIFF
--- a/api/core/search/filter_backends.py
+++ b/api/core/search/filter_backends.py
@@ -1,6 +1,6 @@
 from django_elasticsearch_dsl_drf.filter_backends import BaseSearchFilterBackend
 
-from api.search.product.query_backends import QueryStringQueryBackend
+from .query_backends import QueryStringQueryBackend
 
 
 class QueryStringSearchFilterBackend(BaseSearchFilterBackend):

--- a/api/core/search/query_backends.py
+++ b/api/core/search/query_backends.py
@@ -32,7 +32,7 @@ class QueryStringQueryBackend(BaseSearchQueryBackend):
         Note, that multiple searches are not supported (would not raise
         an exception, but would simply take only the first):
 
-            /search/products/?search=sniper AND rifles&search=short AND gun
+            /search/my_items/?search=item1 AND item2 &search=item3 AND item4
 
         In the view-set fields shall be defined in a very simple way. The
         only accepted argument would be boost (per field) for now.

--- a/api/core/search/query_backends.py
+++ b/api/core/search/query_backends.py
@@ -37,6 +37,7 @@ class QueryStringQueryBackend(BaseSearchQueryBackend):
         In the view-set fields shall be defined in a very simple way. The
         only accepted argument would be boost (per field) for now.
         """
+
         if hasattr(view, "query_string_search_fields"):
             view_search_fields = copy.copy(
                 getattr(view, "query_string_search_fields"),

--- a/api/core/search/validators.py
+++ b/api/core/search/validators.py
@@ -1,0 +1,36 @@
+from . import filter_backends
+from rest_framework.exceptions import ValidationError
+
+
+class QueryStringValidationMixin:
+    """
+    Query String validation mixin is used to verify if query string
+    passed in from a client is well formed prior to executing against ES.
+    """
+
+    def validate_search_terms(self):
+        query_params = self.request.GET.copy()
+        search_term = query_params.get("search")
+
+        # Validation is only required if we are using QueryStringSearchFilterBackend
+
+        if filter_backends.QueryStringSearchFilterBackend not in self.filter_backends:
+            return True
+
+        # create a query with the given query params
+        query = {
+            "query": {
+                "query_string": {
+                    "fields": ["*"],
+                    "query": f"{search_term}",
+                }
+            }
+        }
+
+        response = self.document._index.validate_query(body=query)
+        return response["valid"]
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        if not self.validate_search_terms():
+            raise ValidationError({"search": "Invalid search string"})

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -62,7 +62,7 @@ address_analyzer = analysis.analyzer(
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",
     tokenizer="whitespace",
-    filter=["lowercase", "asciifolding", "trim", address_stop_words_filter],
+    filter=["lowercase", "asciifolding", "trim"],
 )
 
 postcode_normalizer = analysis.normalizer(

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -62,7 +62,7 @@ address_analyzer = analysis.analyzer(
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",
     tokenizer="whitespace",
-    filter=["lowercase", "asciifolding", "trim"],
+    filter=["lowercase", "asciifolding", "trim", address_stop_words_filter],
 )
 
 postcode_normalizer = analysis.normalizer(

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -391,25 +391,15 @@ class DenialSearchViewTests(DataTestClient):
     @pytest.mark.elasticsearch
     @parameterized.expand(
         [
-<<<<<<< HEAD
-            ({"search": "name:Organisation Name"}, 3),
-            ({"search": "name:The Widget Company"}, 1),
-            ({"search": "name:XYZ"}, 1),
-            ({"search": "address:Street Name"}, 3),
-            ({"search": "address:Example"}, 1),
-            ({"search": "name:UK Issued"}, 0),
-            ({"search": "denial_cle:catch all"}, 1),
-=======
             ({"search": "name:Organisation Name"}, ["AB-CD-EF-000", "AB-CD-EF-300", "AB-CD-EF-100"]),
             ({"search": "name:The Widget Company"}, ["AB-XY-EF-900"]),
             ({"search": "name:XYZ"}, ["AB-CD-EF-100"]),
             ({"search": "address:Street Name"}, ["AB-CD-EF-000", "AB-CD-EF-300", "AB-CD-EF-100"]),
             ({"search": "address:Example"}, ["AB-XY-EF-900"]),
             ({"search": "name:UK Issued"}, []),
-            ({"search": "item_list_codes:catch all"}, ["AB-XY-EF-900"]),
+            ({"search": "denial_cle:catch all"}, ["AB-XY-EF-900"]),
             ({"search": "name:(Widget) OR address:(2001)"}, ["AB-CD-EF-300", "AB-XY-EF-900"]),
             ({"search": "name:(Organisation) AND address:(2000)"}, ["AB-CD-EF-100"]),
->>>>>>> 76174110 (refactor)
         ]
     )
     def test_denial_entity_search(self, query, expected_items):

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -50,11 +50,7 @@ class DenialSearchView(DocumentViewSet):
         filter_backends.HighlightBackend,
     ]
 
-<<<<<<< HEAD
-    search_fields = ["name", "address", "denial_cle"]
-=======
     search_fields = ["name", "address" "item_list_codes"]
->>>>>>> 76174110 (refactor)
 
     filter_fields = {
         "country": {
@@ -96,8 +92,6 @@ class DenialSearchView(DocumentViewSet):
 
     def filter_queryset(self, queryset):
         queryset = queryset.filter("term", is_revoked=False).exclude("term", notifying_government="United Kingdom")
-        qs = super().filter_queryset(queryset)
-        print(qs.to_dict())
         return super().filter_queryset(queryset)
 
     def validate_search_terms(self):

--- a/api/external_data/views.py
+++ b/api/external_data/views.py
@@ -6,7 +6,7 @@ from rest_framework.views import APIView
 
 from django_elasticsearch_dsl_drf import filter_backends
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
-from api.search.product import filter_backends as custom_filter_backends
+from api.core.search import filter_backends as custom_filter_backends
 
 from django.conf import settings
 
@@ -50,7 +50,11 @@ class DenialSearchView(DocumentViewSet):
         filter_backends.HighlightBackend,
     ]
 
+<<<<<<< HEAD
     search_fields = ["name", "address", "denial_cle"]
+=======
+    search_fields = ["name", "address" "item_list_codes"]
+>>>>>>> 76174110 (refactor)
 
     filter_fields = {
         "country": {
@@ -58,6 +62,13 @@ class DenialSearchView(DocumentViewSet):
             "field": "country.raw",
         }
     }
+
+    query_string_search_fields = {
+        "name": None,
+        "address": None,
+        "item_list_codes": None,
+    }
+
     ordering = "_score"
     highlight_fields = {
         "name": {
@@ -85,8 +96,9 @@ class DenialSearchView(DocumentViewSet):
 
     def filter_queryset(self, queryset):
         queryset = queryset.filter("term", is_revoked=False).exclude("term", notifying_government="United Kingdom")
+        qs = super().filter_queryset(queryset)
+        print(qs.to_dict())
         return super().filter_queryset(queryset)
-
 
     def validate_search_terms(self):
         query_params = self.request.GET.copy()
@@ -104,13 +116,6 @@ class DenialSearchView(DocumentViewSet):
 
         response = self.document._index.validate_query(body=query)
         return response["valid"]
-
-    def get(self, request):
-        search = Search(index=settings.ELASTICSEARCH_DENIALS_INDEX_ALIAS)
-        query_params = request.GET.copy()
-        search_term = query_params.get("search")
-        results = search.query("search_term", search_term).execute()
-        return Response(results)
 
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)

--- a/api/search/product/views.py
+++ b/api/search/product/views.py
@@ -13,7 +13,7 @@ from django.db.models.fields import IntegerField
 from api.core.authentication import GovAuthentication
 from api.search.product.documents import ProductDocumentType
 from api.search.product import serializers
-from api.search.product import filter_backends as custom_filter_backends
+from api.core.search import filter_backends as custom_filter_backends
 
 from collections import OrderedDict
 


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5012)

This fundamentally changes how we search denials it allows more complex queries which can be customised by the user. 

To validate the default results UAT vs Test Env will use the same data and compare old vs new search/ This will allow us to validate this is sensible to roll out. 

Also dependant on UI PR
https://github.com/uktrade/lite-frontend/pull/1975
