### PR TITLE
denial-on-application-factories

### DIFF
--- a/api/applications/tests/factories.py
+++ b/api/applications/tests/factories.py
@@ -141,6 +141,16 @@ class DenialMatchOnApplicationFactory(factory.django.DjangoModelFactory):
         model = DenialMatchOnApplication
 
 
+class DenialExactMatchOnApplicationFactory(DenialMatchOnApplicationFactory):
+    category = "exact"
+    application = factory.SubFactory(StandardApplicationFactory)
+
+
+class DenialPartialMatchOnApplicationFactory(DenialMatchOnApplicationFactory):
+    category = "partial"
+    application = factory.SubFactory(StandardApplicationFactory)
+
+
 class SanctionMatchFactory(factory.django.DjangoModelFactory):
     party_on_application = factory.SubFactory(PartyOnApplicationFactory)
     elasticsearch_reference = factory.LazyAttribute(lambda n: faker.word())


### PR DESCRIPTION
This is adding new factories to API to reduce coupling between dependant Repos. 

i.e lite_routing hence this will allow basic model changes without impacting these repos test data. 