### PR TITLE
LTD-4940-remove-backward-compatablity 

### DIFF
--- a/api/applications/serializers/denial.py
+++ b/api/applications/serializers/denial.py
@@ -10,15 +10,10 @@ from api.external_data.serializers import DenialEntitySerializer
 class DenialMatchOnApplicationViewSerializer(serializers.ModelSerializer):
     category = ChoiceField(choices=DenialMatchCategory.choices)
     denial_entity = DenialEntitySerializer(read_only=True)
-    denial = serializers.SerializerMethodField()
 
     class Meta:
         model = DenialMatchOnApplication
-        fields = ("id", "application", "denial", "denial_entity", "category")
-
-    def get_denial(self, instance):
-        # This field is for backward compatablity to be remove once FE has been updated.
-        return DenialEntitySerializer(instance.denial_entity).data
+        fields = ("id", "application", "denial_entity", "category")
 
 
 class DenialMatchOnApplicationCreateSerializer(serializers.ModelSerializer):

--- a/api/applications/tests/test_matching_denials.py
+++ b/api/applications/tests/test_matching_denials.py
@@ -129,29 +129,3 @@ class ApplicationDenialMatchesOnApplicationTests(DataTestClient):
         # remove one match
         response = self.client.delete(url, {"objects": [denial_matches[0]["id"]]}, **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_view_denial_notifications_on_the_application_backward_compatible(self):
-        data = []
-        for index in range(10):
-            denial_entity = DenialEntityFactory()
-            data.append(
-                {
-                    "application": self.application.id,
-                    "denial": denial_entity.id,
-                    "category": "exact" if (index % 2) else "partial",
-                }
-            )
-
-        url = reverse("applications:application_denial_matches", kwargs={"pk": self.application.id})
-        response = self.client.post(url, data, **self.gov_headers)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        response = self.client.get(url, **self.gov_headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        denial_matches = response.json()["denial_matches"]
-        self.assertEqual(len(denial_matches), 10)
-        self.assertEqual(denial_matches[0]["denial"], denial_matches[0]["denial_entity"])
-
-        # remove one match
-        response = self.client.delete(url, {"objects": [denial_matches[0]["id"]]}, **self.gov_headers)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/applications/views/denials.py
+++ b/api/applications/views/denials.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status
@@ -26,20 +25,11 @@ class ApplicationDenialMatchesOnApplication(APIView):
         return JsonResponse(data={"denial_matches": denial_matches_data})
 
     def post(self, request, pk):
-        data = deepcopy(request.data)
 
-        # This is for backward compatablity to be remove once FE has been updated.
-        for denial_match_item in data:
-            if denial_match_item.get("denial"):
-                denial_match_item["denial_entity"] = denial_match_item.pop("denial")
-        serializer = denial.DenialMatchOnApplicationCreateSerializer(data=data, many=True)
+        serializer = denial.DenialMatchOnApplicationCreateSerializer(data=request.data, many=True)
         if serializer.is_valid():
             serializer.save()
-            return_data = serializer.data
-            # This is for backward compatablity to be remove once FE has been updated.
-            for return_item in return_data:
-                return_item.update({"denial": return_item["denial_entity"]})
-            return JsonResponse(data={"denial_matches": return_data}, status=status.HTTP_201_CREATED)
+            return JsonResponse(data={"denial_matches": serializer.data}, status=status.HTTP_201_CREATED)
 
         return JsonResponse(data={"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/api/data_workspace/tests/test_application_views.py
+++ b/api/data_workspace/tests/test_application_views.py
@@ -175,5 +175,5 @@ class DataWorkspaceApplicationViewTests(DataTestClient):
         response = self.client.options(self.denial_on_applications)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         actual_keys = response.json()["actions"]["GET"].keys()
-        expected_keys = {"id", "denial_entity", "application", "category", "denial"}
+        expected_keys = {"id", "denial_entity", "application", "category"}
         self.assertEqual(expected_keys, actual_keys)


### PR DESCRIPTION
This code was added to allow the FE to be updated independently to the model changes.  
Once this PR is merged this code is no longer required. 

https://github.com/uktrade/lite-frontend/pull/1994
