### PR TITLE
LTD-5041 and LTD-5014 changes to address analyzer in denials search

### DIFF
--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -52,6 +52,7 @@ address_stop_words_filter = analysis.token_filter(
     ],
     ignore_case=True,
 )
+
 special_chars_filter = analysis.char_filter(
     "special_chars_filter",
     type="pattern_replace",

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -53,15 +53,15 @@ address_stop_words_filter = analysis.token_filter(
     ignore_case=True,
 )
 
+address_analyzer = analysis.analyzer(
+    "address_analyzer",
+    tokenizer="whitespace",
+    filter=["lowercase", "asciifolding", "trim", address_stop_words_filter, ngram_filter],
+)
+
 # Previously the tokenizer was whitespace, but this was changed to standard
 # as the whitespace tokenizer was splitting on hyphens and including commas in the tokens
 # standard tokenizer will remove these characters
-
-address_analyzer = analysis.analyzer(
-    "address_analyzer",
-    tokenizer="standard",
-    filter=["lowercase", "asciifolding", "trim", address_stop_words_filter, ngram_filter],
-)
 
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -52,15 +52,23 @@ address_stop_words_filter = analysis.token_filter(
     ],
     ignore_case=True,
 )
+special_chars_filter = analysis.char_filter(
+    "remove_special_chars",
+    type="pattern_replace",
+    pattern="[^a-zA-Z0-9 ]",
+    replacement=" ",
+)
 
 address_analyzer = analysis.analyzer(
     "address_analyzer",
+    char_filter=[special_chars_filter],
     tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter, ngram_filter],
 )
 
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",
+    char_filter=[special_chars_filter],
     tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter],
 )

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -53,7 +53,7 @@ address_stop_words_filter = analysis.token_filter(
     ignore_case=True,
 )
 special_chars_filter = analysis.char_filter(
-    "remove_special_chars",
+    "special_chars_filter",
     type="pattern_replace",
     pattern="[^a-zA-Z0-9 ]",
     replacement=" ",

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -53,23 +53,18 @@ address_stop_words_filter = analysis.token_filter(
     ignore_case=True,
 )
 
-special_chars_filter = analysis.char_filter(
-    "special_chars_filter",
-    type="pattern_replace",
-    pattern="[^a-zA-Z0-9 ]",
-    replacement=" ",
-)
+# Previously the tokenizer was whitespace, but this was changed to standard
+# as the whitespace tokenizer was splitting on hyphens and including commas in the tokens
+# standard tokenizer will remove these characters
 
 address_analyzer = analysis.analyzer(
     "address_analyzer",
-    char_filter=[special_chars_filter],
     tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter, ngram_filter],
 )
 
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",
-    char_filter=[special_chars_filter],
     tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter],
 )

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -55,13 +55,13 @@ address_stop_words_filter = analysis.token_filter(
 
 address_analyzer = analysis.analyzer(
     "address_analyzer",
-    tokenizer="whitespace",
+    tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter, ngram_filter],
 )
 
 address_analyzer_no_ngram = analysis.analyzer(
     "address_analyzer",
-    tokenizer="whitespace",
+    tokenizer="standard",
     filter=["lowercase", "asciifolding", "trim", address_stop_words_filter],
 )
 

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -467,18 +467,21 @@ class DenialSearchViewTests(DataTestClient):
     @parameterized.expand(
         [
             (
-                {"search": "address:(Street Name)"},
+                {"search": "address:(Street Name, Springfield)"},
                 [
                     "1000 Street <mark>Name</mark>, City <mark>Name</mark>",
                     "2001 Street <mark>Name</mark>, City <mark>Name</mark> 3",
                     "2000 Street <mark>Name</mark>, City <mark>Name</mark> 2",
                 ],
             ),
-            ({"search": "address:(Example)"}, ["2 <mark>Example</mark> Road, <mark>Example</mark> City"]),
+            (
+                {"search": "address:(\Example\ Avenue, Townsville)"},
+                ["2 <mark>Example</mark> Road, <mark>Example</mark> City"],
+            ),
             ({"search": "address:(road,)"}, []),
         ]
     )
-    def test_denial_search_tokenizer(self, query, expected_items):
+    def test_denial_search_tokenizer_ignores_commas(self, query, expected_items):
         call_command("search_index", models=["external_data.denialentity"], action="rebuild", force=True)
         url = reverse("external_data:denial-list")
         file_path = os.path.join(settings.BASE_DIR, "external_data/tests/denial_valid.csv")
@@ -494,6 +497,7 @@ class DenialSearchViewTests(DataTestClient):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         search_results = [r["address"] for r in response_json["results"]]
+
         self.assertEqual(search_results, expected_items)
 
     @pytest.mark.elasticsearch

--- a/api/external_data/tests/test_views.py
+++ b/api/external_data/tests/test_views.py
@@ -481,7 +481,7 @@ class DenialSearchViewTests(DataTestClient):
             ({"search": "address:(road,)"}, []),
         ]
     )
-    def test_denial_search_tokenizer_ignores_commas(self, query, expected_items):
+    def test_denial_search_with_chars(self, query, expected_items):
         call_command("search_index", models=["external_data.denialentity"], action="rebuild", force=True)
         url = reverse("external_data:denial-list")
         file_path = os.path.join(settings.BASE_DIR, "external_data/tests/denial_valid.csv")


### PR DESCRIPTION
### Aim

Remove commas in search queries which prevent matches being returned and remove highlighting on stop words.

[LTD-5041](https://uktrade.atlassian.net/browse/LTD-5041)
[LTD-5014](https://uktrade.atlassian.net/browse/LTD-5014)

[LTD-5041]: https://uktrade.atlassian.net/browse/LTD-5041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LTD-5014]: https://uktrade.atlassian.net/browse/LTD-5014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ