### PR TITLE
[LTD-5121] Rename superseded by amendment status

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -390,7 +390,7 @@ class StandardApplication(BaseApplication, Clonable):
             ignore_case_status=True,
         )
         system_user = BaseUser.objects.get(id=SystemUser.id)
-        self.case_ptr.change_status(system_user, get_case_status_by_status(CaseStatusEnum.SUPERSEDED_BY_AMENDMENT))
+        self.case_ptr.change_status(system_user, get_case_status_by_status(CaseStatusEnum.SUPERSEDED_BY_EXPORTER_EDIT))
         return amendment_application
 
 

--- a/api/applications/tests/test_models.py
+++ b/api/applications/tests/test_models.py
@@ -31,6 +31,7 @@ from api.organisations.tests.factories import OrganisationFactory
 from api.staticdata.control_list_entries.models import ControlListEntry
 from api.staticdata.report_summaries.models import ReportSummary, ReportSummaryPrefix, ReportSummarySubject
 from api.staticdata.statuses.models import CaseStatus, CaseSubStatus
+from api.staticdata.statuses.enums import CaseStatusEnum
 from api.users.models import ExporterUser
 
 
@@ -92,7 +93,7 @@ class TestStandardApplication(DataTestClient):
         assert amendment_application.status.status == "draft"
         assert amendment_application.amendment_of == original_application.case_ptr
         original_application.refresh_from_db()
-        assert original_application.status.status == "superseded_by_amendment"
+        assert original_application.status.status == CaseStatusEnum.SUPERSEDED_BY_EXPORTER_EDIT
         assert original_application.queues.all().count() == 0
         audit_entries = Audit.objects.all()
         supersede_audit_entry = audit_entries[1]
@@ -106,7 +107,9 @@ class TestStandardApplication(DataTestClient):
         assert amendment_audit_entry.verb == "exporter_created_amendment"
         assert amendment_audit_entry.actor == exporter_user
         status_change_audit_entry = audit_entries[0]
-        assert status_change_audit_entry.payload == {"status": {"new": "Superseded by amendment", "old": "ogd_advice"}}
+        assert status_change_audit_entry.payload == {
+            "status": {"new": "Superseded by exporter edit", "old": "ogd_advice"}
+        }
         assert status_change_audit_entry.verb == "updated_status"
 
     def test_clone(self):

--- a/api/applications/views/tests/test_amendments.py
+++ b/api/applications/views/tests/test_amendments.py
@@ -6,6 +6,7 @@ from api.applications import models as application_models
 from api.applications.models import StandardApplication
 from api.applications.tests.factories import StandardApplicationFactory, GoodOnApplicationFactory
 from api.organisations.tests.factories import OrganisationFactory
+from api.staticdata.statuses.enums import CaseStatusEnum
 
 from test_helpers.clients import DataTestClient
 
@@ -31,7 +32,7 @@ class TestCreateApplicationAmendment(DataTestClient):
         self.assertEqual(amendment_application.name, self.application.name)
         self.assertEqual(amendment_application.amendment_of_id, self.application.id)
         self.application.refresh_from_db()
-        self.assertEqual(self.application.status.status, "superseded_by_exporter_edit")
+        self.assertEqual(self.application.status.status, CaseStatusEnum.SUPERSEDED_BY_EXPORTER_EDIT)
 
     @mock.patch.object(application_models.GoodOnApplication, "clone")
     def test_create_amendment_partial_failure(self, mocked_good_on_application_clone):

--- a/api/applications/views/tests/test_amendments.py
+++ b/api/applications/views/tests/test_amendments.py
@@ -31,7 +31,7 @@ class TestCreateApplicationAmendment(DataTestClient):
         self.assertEqual(amendment_application.name, self.application.name)
         self.assertEqual(amendment_application.amendment_of_id, self.application.id)
         self.application.refresh_from_db()
-        self.assertEqual(self.application.status.status, "superseded_by_amendment")
+        self.assertEqual(self.application.status.status, "superseded_by_exporter_edit")
 
     @mock.patch.object(application_models.GoodOnApplication, "clone")
     def test_create_amendment_partial_failure(self, mocked_good_on_application_clone):

--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -36,7 +36,7 @@ class CaseStatusEnum:
     OGD_CONSOLIDATION = "ogd_consolidation"
     FINAL_REVIEW_COUNTERSIGN = "final_review_countersign"
     FINAL_REVIEW_SECOND_COUNTERSIGN = "final_review_second_countersign"
-    SUPERSEDED_BY_AMENDMENT = "superseded_by_amendment"
+    SUPERSEDED_BY_EXPORTER_EDIT = "superseded_by_exporter_edit"
 
     _system_status = [DRAFT]
 
@@ -57,7 +57,7 @@ class CaseStatusEnum:
         REVOKED,
         SURRENDERED,
         WITHDRAWN,
-        SUPERSEDED_BY_AMENDMENT,
+        SUPERSEDED_BY_EXPORTER_EDIT,
     ]
 
     goods_query_statuses = [CLC, PV]
@@ -110,7 +110,7 @@ class CaseStatusEnum:
         (WITHDRAWN, "Withdrawn"),
         (OGD_ADVICE, "OGD Advice"),
         (OGD_CONSOLIDATION, "OGD Consolidation"),
-        (SUPERSEDED_BY_AMENDMENT, "Superseded by amendment"),
+        (SUPERSEDED_BY_EXPORTER_EDIT, "Superseded by exporter edit"),
         (FINAL_REVIEW_COUNTERSIGN, "Final review countersign"),
         (FINAL_REVIEW_SECOND_COUNTERSIGN, "Final review second countersign"),
     ]
@@ -149,7 +149,7 @@ class CaseStatusEnum:
         SUSPENDED: 31,
         SURRENDERED: 32,
         DEREGISTERED: 33,
-        SUPERSEDED_BY_AMENDMENT: 34,
+        SUPERSEDED_BY_EXPORTER_EDIT: 34,
     }
 
     @classmethod
@@ -259,7 +259,7 @@ class CaseStatusIdEnum:
     OGD_CONSOLIDATION = UUID("00000000-0000-0000-0000-000000000031")
     FINAL_REVIEW_COUNTERSIGN = UUID("00000000-0000-0000-0000-000000000032")
     FINAL_REVIEW_SECOND_COUNTERSIGN = UUID("00000000-0000-0000-0000-000000000033")
-    SUPERSEDED_BY_AMENDMENT = UUID("00000000-0000-0000-0000-000000000034")
+    SUPERSEDED_BY_EXPORTER_EDIT = UUID("00000000-0000-0000-0000-000000000034")
 
 
 class CaseSubStatusIdEnum:

--- a/api/staticdata/statuses/migrations/0014_rename_superseded_by_amendment_status.py
+++ b/api/staticdata/statuses/migrations/0014_rename_superseded_by_amendment_status.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def rename_case_status_superseded_by_amendment(apps, schema_editor):
+    CaseStatus = apps.get_model("statuses", "CaseStatus")
+
+    STATUS__SUPERSEDED_BY_AMENDMENT = "00000000-0000-0000-0000-000000000034"
+
+    status = CaseStatus.objects.get(
+        id=STATUS__SUPERSEDED_BY_AMENDMENT,
+    )
+    status.status = "superseded_by_exporter_edit"
+    status.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("statuses", "0013_add_superseded_by_amendment_status"),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_case_status_superseded_by_amendment, migrations.RunPython.noop),
+    ]

--- a/api/staticdata/statuses/migrations/0015_rename_superseded_by_amendment_status.py
+++ b/api/staticdata/statuses/migrations/0015_rename_superseded_by_amendment_status.py
@@ -15,7 +15,7 @@ def rename_case_status_superseded_by_amendment(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("statuses", "0013_add_superseded_by_amendment_status"),
+        ("statuses", "0014_remove_casestatus_is_read_only_and_more"),
     ]
 
     operations = [

--- a/api/staticdata/statuses/migrations/tests/test_0014_rename_superseded_by_amendment_status.py
+++ b/api/staticdata/statuses/migrations/tests/test_0014_rename_superseded_by_amendment_status.py
@@ -1,7 +1,6 @@
 import pytest
 from django.forms.models import model_to_dict
 
-from django_test_migrations.migrator import Migrator
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 

--- a/api/staticdata/statuses/migrations/tests/test_0014_rename_superseded_by_amendment_status.py
+++ b/api/staticdata/statuses/migrations/tests/test_0014_rename_superseded_by_amendment_status.py
@@ -6,19 +6,19 @@ from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
 @pytest.mark.django_db()
-class TestSupersededByAmendment(MigratorTestCase):
+class TestRenameSupersededByAmendment(MigratorTestCase):
 
-    migrate_from = ("statuses", "0012_add_draft_rejection_sub_status")
-    migrate_to = ("statuses", "0013_add_superseded_by_amendment_status")
+    migrate_from = ("statuses", "0013_add_superseded_by_amendment_status")
+    migrate_to = ("statuses", "0014_rename_superseded_by_amendment_status")
 
     def test_migration_0013_add_superseded_by_amendment_status(self):
         CaseStatus = self.new_state.apps.get_model("statuses", "CaseStatus")
 
-        STATUS__SUPERSEDED_BY_AMENDMENT = "00000000-0000-0000-0000-000000000034"
-        superseded_by_amendment_status = CaseStatus.objects.get(id=STATUS__SUPERSEDED_BY_AMENDMENT)
-        attributes = model_to_dict(superseded_by_amendment_status)
+        STATUS__SUPERSEDED_BY_EXPORTER_EDIT = "00000000-0000-0000-0000-000000000034"
+        superseded_by_exporter_edit_status = CaseStatus.objects.get(id=STATUS__SUPERSEDED_BY_EXPORTER_EDIT)
+        attributes = model_to_dict(superseded_by_exporter_edit_status)
         assert attributes == {
-            "status": "superseded_by_amendment",
+            "status": "superseded_by_exporter_edit",
             "priority": 34,
             "workflow_sequence": None,
             "is_read_only": True,

--- a/api/staticdata/statuses/migrations/tests/test_0015_rename_superseded_by_amendment_status.py
+++ b/api/staticdata/statuses/migrations/tests/test_0015_rename_superseded_by_amendment_status.py
@@ -7,8 +7,8 @@ from django_test_migrations.contrib.unittest_case import MigratorTestCase
 @pytest.mark.django_db()
 class TestRenameSupersededByAmendment(MigratorTestCase):
 
-    migrate_from = ("statuses", "0013_add_superseded_by_amendment_status")
-    migrate_to = ("statuses", "0014_rename_superseded_by_amendment_status")
+    migrate_from = ("statuses", "0014_remove_casestatus_is_read_only_and_more")
+    migrate_to = ("statuses", "0015_rename_superseded_by_amendment_status")
 
     def test_migration_0013_add_superseded_by_amendment_status(self):
         CaseStatus = self.new_state.apps.get_model("statuses", "CaseStatus")
@@ -20,7 +20,5 @@ class TestRenameSupersededByAmendment(MigratorTestCase):
             "status": "superseded_by_exporter_edit",
             "priority": 34,
             "workflow_sequence": None,
-            "is_read_only": True,
-            "is_terminal": True,
             "next_workflow_status": None,
         }


### PR DESCRIPTION
### Aim

This change renames the status "Superseded by amendment" to "Superseded by exporter edit" as per the Jira.  This is for the purpose of better explaining things to users.

[LTD-5121](https://uktrade.atlassian.net/browse/LTD-5121)


[LTD-5121]: https://uktrade.atlassian.net/browse/LTD-5121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ