### PR TITLE
LTD-5071-forward-slash-breaking-search

### DIFF
--- a/api/applications/tests/test_matching_denials.py
+++ b/api/applications/tests/test_matching_denials.py
@@ -17,9 +17,12 @@ class ApplicationDenialMatchesOnApplicationTests(DataTestClient):
         file_path = os.path.join(settings.BASE_DIR, "external_data/tests/denial_valid.csv")
         with open(file_path, "rb") as f:
             content = f.read()
+            f.seek(0)
+            self.total_denials = len(f.readlines()) - 1
+
         response = self.client.post(reverse("external_data:denial-list"), {"csv_file": content}, **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(models.DenialEntity.objects.count(), 5)
+        self.assertEqual(models.DenialEntity.objects.count(), self.total_denials)
 
     @pytest.mark.xfail(reason="This test is flaky and should be rewritten")
     # Occasionally causes this error:
@@ -45,7 +48,7 @@ class ApplicationDenialMatchesOnApplicationTests(DataTestClient):
     def test_revoke_denial_without_comment_failure(self):
         response = self.client.get(reverse("external_data:denial-list"), **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 5)
+        self.assertEqual(response.json()["count"], self.total_denials)
 
         denials = response.json()["results"]
 
@@ -62,7 +65,7 @@ class ApplicationDenialMatchesOnApplicationTests(DataTestClient):
     def test_revoke_denial_success(self):
         response = self.client.get(reverse("external_data:denial-list"), **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 5)
+        self.assertEqual(response.json()["count"], self.total_denials)
 
         denials = response.json()["results"]
 
@@ -82,7 +85,7 @@ class ApplicationDenialMatchesOnApplicationTests(DataTestClient):
     def test_revoke_denial_active_success(self):
         response = self.client.get(reverse("external_data:denial-list"), **self.gov_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 5)
+        self.assertEqual(response.json()["count"], self.total_denials)
 
         denials = response.json()["results"]
 

--- a/api/core/search/filter_backends.py
+++ b/api/core/search/filter_backends.py
@@ -13,6 +13,20 @@ class QueryStringSearchFilterBackend(BaseSearchFilterBackend):
 
     search_param = "search"
 
+    def get_search_query_params(self, request):
+        """Get search query params.
+
+        :param request: Django REST framework request.
+        :type request: rest_framework.request.Request
+        :return: List of search query params.
+        :rtype: list
+        """
+        query_params = request.query_params.copy()
+        # This is required as query_string is unable to handle a single /
+        query_string = query_params.get(self.search_param, "").replace("/", "//")
+        query_params[self.search_param] = query_string
+        return query_params.getlist(self.search_param, [])
+
     query_backends = [
         QueryStringQueryBackend,
     ]

--- a/api/core/search/validators.py
+++ b/api/core/search/validators.py
@@ -12,6 +12,9 @@ class QueryStringValidationMixin:
         query_params = self.request.GET.copy()
         search_term = query_params.get("search")
 
+        # This is required as query_string is unable to handle a single /
+        search_term = search_term.replace("/", "//")
+
         # Validation is only required if we are using QueryStringSearchFilterBackend
 
         if filter_backends.QueryStringSearchFilterBackend not in self.filter_backends:

--- a/api/external_data/tests/denial_valid.csv
+++ b/api/external_data/tests/denial_valid.csv
@@ -4,3 +4,5 @@ DN2000/0010,AB-CD-EF-300,Organisation Name 3,"2001 Street Name, City Name 3",Cou
 ,AB-XY-EF-900,The Widget Company,"2 Example Road, Example City",Example Country,Country Name X,"catch all",Extra Large Size Widget,Used in unknown industry,Risk of outcome 4,end_user
 DN3000/0000,AB-CD-EF-100,Organisation Name XYZ,"2000 Street Name, City Name 2",Country Name 2,Country Name 2,0A00200,Large Size Widget,Used in other industry,Risk of outcome 2,third_party
 DN4000/0000,AB-CD-EF-200,UK Issued,"2000 main road, some place",United Kingdom,Country Name 3,0A00300,Large Size Widget,Used in other industry,Risk of outcome 2,third_party
+DN4102/0001,AB-CD-EF-400,Forward slash,"30/1 ltd",Country Name 4,Country Name 4,0A00504,Large Size Widget,Used in other industry,Risk of outcome 2,third_party
+DN4103/0001,AB-CD-EF-500,c/o ltd,"forward slash",Country Name 5,Country Name 6,0A0050,Large Size Widget,Used in other industry,Risk of outcome 2,third_party

--- a/api/search/product/tests/test_helpers.py
+++ b/api/search/product/tests/test_helpers.py
@@ -49,7 +49,7 @@ test_applications_data = [
             {
                 "good": {
                     "name": "Thermal camera",
-                    "part_number": "IMG-1300",
+                    "part_number": "IMG/1300",
                     "is_good_controlled": True,
                     "control_list_entries": ["6A005"],
                 },

--- a/api/search/product/tests/test_views.py
+++ b/api/search/product/tests/test_views.py
@@ -110,7 +110,8 @@ class ProductSearchTests(BaseProductSearchTests):
         [
             ({"search": "ABC"}, 0),
             ({"search": "ABC-123"}, 1),
-            ({"search": "IMG-1300"}, 1),
+            ({"search": "IMG/1300"}, 1),
+            ({"search": "IMG-1300"}, 0),
             ({"search": "867-"}, 0),
             ({"search": "867-5309"}, 1),
             ({"search": "H2SO4"}, 1),


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5071

This has been tested on the case highlighted in the Jira and can confirm we can now match cases when we have a forward slash in the search parameters.

Originally this was in a frontend PR to test it quickly but that felt a bit hackey hence why it's been implemented as a backend change.  