### PR TITLE
Remove relation

### DIFF
--- a/api/applications/libraries/get_applications.py
+++ b/api/applications/libraries/get_applications.py
@@ -47,7 +47,6 @@ def get_application(pk, organisation_id=None):
         "goods__regime_entries__subsection__regime",
         "goods__good__report_summary_prefix",
         "goods__good__report_summary_subject",
-        "goods__audit_trail",
         "goods__goodonapplicationdocument_set",
         "goods__goodonapplicationdocument_set__user",
         "goods__good_on_application_internal_documents",

--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
 from django.utils import timezone
@@ -16,7 +15,7 @@ from api.applications.enums import (
 )
 from api.appeals.models import Appeal
 from api.applications.managers import BaseApplicationManager
-from api.audit_trail.models import Audit, AuditType
+from api.audit_trail.models import AuditType
 from api.audit_trail import service as audit_trail_service
 from api.cases.enums import CaseTypeEnum
 from api.cases.models import Case, CaseQueue
@@ -512,12 +511,6 @@ class GoodOnApplication(AbstractGoodOnApplication, Clonable):
     # Exhibition applications are the only applications that contain the following as such may be null
     item_type = models.CharField(choices=ItemType.choices, max_length=10, null=True, blank=True, default=None)
     other_item_type = models.CharField(max_length=100, null=True, blank=True, default=None)
-    audit_trail = GenericRelation(
-        Audit,
-        related_query_name="good_on_application",
-        content_type_field="action_object_content_type",
-        object_id_field="action_object_object_id",
-    )
     control_list_entries = models.ManyToManyField(ControlListEntry, through=GoodOnApplicationControlListEntry)
     regime_entries = models.ManyToManyField(RegimeEntry, through=GoodOnApplicationRegimeEntry)
 

--- a/api/applications/tests/test_audit_trail.py
+++ b/api/applications/tests/test_audit_trail.py
@@ -1,15 +1,22 @@
+from api.audit_trail.models import Audit
 from api.audit_trail.tests.factories import AuditFactory
+
 from test_helpers.clients import DataTestClient
 
 
 class GoodOnApplicationAuditTrailTests(DataTestClient):
     def test_removing_object_keeps_audit_trail(self):
         application = self.create_draft_standard_application(self.organisation)
+        Audit.objects.all().delete()
+
         good_on_application = application.goods.first()
         audit = AuditFactory(
             action_object=good_on_application,
         )
+        self.assertEqual(Audit.objects.count(), 1)
 
         good_on_application.delete()
-        audit.refresh_from_db()
+
+        self.assertEqual(Audit.objects.count(), 1)
+        audit = Audit.objects.get(pk=audit.pk)
         self.assertIsNone(audit.action_object)

--- a/api/applications/tests/test_audit_trail.py
+++ b/api/applications/tests/test_audit_trail.py
@@ -1,0 +1,15 @@
+from api.audit_trail.tests.factories import AuditFactory
+from test_helpers.clients import DataTestClient
+
+
+class GoodOnApplicationAuditTrailTests(DataTestClient):
+    def test_removing_object_keeps_audit_trail(self):
+        application = self.create_draft_standard_application(self.organisation)
+        good_on_application = application.goods.first()
+        audit = AuditFactory(
+            action_object=good_on_application,
+        )
+
+        good_on_application.delete()
+        audit.refresh_from_db()
+        self.assertIsNone(audit.action_object)


### PR DESCRIPTION
### Aim

Stops audit entries that are related to a `GoodOnApplication` from being removed when a `GoodOnApplication` object is deleted.
