### PR TITLE
LTD-5154: Add dedicated endpoint to archive/restore a good

### DIFF
--- a/api/goods/enums.py
+++ b/api/goods/enums.py
@@ -14,6 +14,12 @@ class GoodStatus:
         (VERIFIED, "Verified"),
     ]
 
+    _archivable_statuses = [SUBMITTED, VERIFIED]
+
+    @classmethod
+    def archivable_statuses(cls):
+        return cls._archivable_statuses
+
 
 class ItemType:
     EQUIPMENT = "equipment"

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -847,6 +847,13 @@ class TinyGoodDetailsSerializer(serializers.ModelSerializer):
         )
 
 
+class GoodArchiveRestoreSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Good
+        fields = ("is_archived",)
+
+
 class GoodArchiveHistorySerializer(serializers.Serializer):
     is_archived = serializers.SerializerMethodField()
     actioned_on = serializers.SerializerMethodField()

--- a/api/goods/tests/test_edit.py
+++ b/api/goods/tests/test_edit.py
@@ -7,6 +7,7 @@ from rest_framework.reverse import reverse
 from reversion.models import Version
 
 from api.goods.enums import (
+    GoodStatus,
     GoodPvGraded,
     PvGrading,
     MilitaryUse,
@@ -571,7 +572,11 @@ class GoodsEditDraftGoodTests(DataTestClient):
         self.assertEqual(good.design_details, "design details")
 
     def test_edit_archive_status(self):
-        good = GoodFactory(organisation=self.organisation, item_category=ItemCategory.GROUP1_COMPONENTS)
+        good = GoodFactory(
+            organisation=self.organisation,
+            status=GoodStatus.SUBMITTED,
+            item_category=ItemCategory.GROUP1_COMPONENTS,
+        )
         url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
 
         for version_count, is_archived in enumerate([True, False], start=1):
@@ -613,7 +618,7 @@ class GoodsEditDraftGoodTests(DataTestClient):
         ]
     )
     def test_only_archive_field_can_be_updated(self, initial, data, expected):
-        good = GoodFactory(organisation=self.organisation, **initial)
+        good = GoodFactory(organisation=self.organisation, status=GoodStatus.SUBMITTED, **initial)
         url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
 
         response = self.client.put(url, data, **self.exporter_headers)
@@ -622,6 +627,39 @@ class GoodsEditDraftGoodTests(DataTestClient):
 
         good.refresh_from_db()
         actual = {"name": good.name, "is_archived": good.is_archived}
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                GoodStatus.DRAFT,
+                {"is_archived": True},
+                status.HTTP_404_NOT_FOUND,
+                {"is_archived": None},
+            ],
+            [
+                GoodStatus.SUBMITTED,
+                {"is_archived": True},
+                status.HTTP_200_OK,
+                {"is_archived": True},
+            ],
+            [
+                GoodStatus.VERIFIED,
+                {"is_archived": True},
+                status.HTTP_200_OK,
+                {"is_archived": True},
+            ],
+        ]
+    )
+    def test_good_with_archivable_status_can_only_be_archived(self, good_status, data, expected_status_code, expected):
+        good = GoodFactory(organisation=self.organisation, status=good_status)
+        url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
+
+        response = self.client.put(url, data, **self.exporter_headers)
+        self.assertEqual(response.status_code, expected_status_code)
+
+        good.refresh_from_db()
+        actual = {"is_archived": good.is_archived}
         self.assertEqual(actual, expected)
 
 

--- a/api/goods/tests/test_edit.py
+++ b/api/goods/tests/test_edit.py
@@ -572,7 +572,7 @@ class GoodsEditDraftGoodTests(DataTestClient):
 
     def test_edit_archive_status(self):
         good = GoodFactory(organisation=self.organisation, item_category=ItemCategory.GROUP1_COMPONENTS)
-        url = reverse("goods:good_details", kwargs={"pk": str(good.id)})
+        url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
 
         for version_count, is_archived in enumerate([True, False], start=1):
             request_data = {"is_archived": is_archived}
@@ -580,7 +580,7 @@ class GoodsEditDraftGoodTests(DataTestClient):
             response = self.client.put(url, request_data, **self.exporter_headers)
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             response = response.json()
-            self.assertEqual(response["good"]["is_archived"], is_archived)
+            self.assertEqual(response["is_archived"], is_archived)
 
             good.refresh_from_db()
             self.assertEqual(good.is_archived, is_archived)
@@ -592,6 +592,37 @@ class GoodsEditDraftGoodTests(DataTestClient):
             # Ensure user is recorded in each revision
             for version in versions:
                 self.assertEqual(version.revision.user, self.exporter_user.baseuser_ptr)
+
+    @parameterized.expand(
+        [
+            [
+                {"name": "Rifle", "is_archived": None},
+                {"is_archived": True},
+                {"name": "Rifle", "is_archived": True},
+            ],
+            [
+                {"name": "Rifle", "is_archived": True},
+                {"is_archived": False},
+                {"name": "Rifle", "is_archived": False},
+            ],
+            [
+                {"name": "Rifle", "is_archived": None},
+                {"name": "Rifle updated", "is_archived": False},
+                {"name": "Rifle", "is_archived": False},
+            ],
+        ]
+    )
+    def test_only_archive_field_can_be_updated(self, initial, data, expected):
+        good = GoodFactory(organisation=self.organisation, **initial)
+        url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
+
+        response = self.client.put(url, data, **self.exporter_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = response.json()
+
+        good.refresh_from_db()
+        actual = {"name": good.name, "is_archived": good.is_archived}
+        self.assertEqual(actual, expected)
 
 
 class GoodsAttachingTests(DataTestClient):

--- a/api/goods/tests/test_views.py
+++ b/api/goods/tests/test_views.py
@@ -228,3 +228,16 @@ class GoodViewTests(DataTestClient):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response_data), count)
+
+    def test_cannot_archive_good_from_other_organisation(self):
+        good = GoodFactory(organisation=self.organisation, status=GoodStatus.SUBMITTED)
+        url = reverse("goods:archive_restore", kwargs={"pk": str(good.id)})
+
+        headers = self.exporter_headers.copy()
+        headers["HTTP_ORGANISATION_ID"] = str(good.id)
+
+        response = self.client.put(url, {"is_archived": True}, **headers)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        good.refresh_from_db()
+        self.assertIsNone(good.is_archived)

--- a/api/goods/urls.py
+++ b/api/goods/urls.py
@@ -6,7 +6,6 @@ app_name = "goods"
 
 urlpatterns = [
     path("", views.GoodList.as_view(), name="goods"),
-    path("archived-goods/", views.ArchivedGoodList.as_view(), name="archived_goods"),
     path("<uuid:pk>/", views.GoodOverview.as_view(), name="good"),
     path("<uuid:pk>/attaching/", views.GoodAttaching.as_view(), name="good_attaching"),
     path("<uuid:pk>/details/", views.GoodTAUDetails.as_view(), name="good_details"),
@@ -39,4 +38,6 @@ urlpatterns = [
         views.DocumentGoodOnApplicationInternalDetailView.as_view(),
         name="document_internal_good_on_application_detail",
     ),
+    path("archived-goods/", views.ArchivedGoodList.as_view(), name="archived_goods"),
+    path("<uuid:pk>/archive-restore/", views.GoodArchiveRestore.as_view(), name="archive_restore"),
 ]

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -197,8 +197,14 @@ class ArchivedGoodList(ListAPIView):
 
 class GoodArchiveRestore(UpdateAPIView):
     authentication_classes = (ExporterAuthentication,)
-    queryset = Good.objects.all()
     serializer_class = GoodArchiveRestoreSerializer
+
+    def get_queryset(self):
+        organisation = get_request_user_organisation_id(self.request)
+
+        return Good.objects.filter(
+            organisation=organisation,
+        )
 
 
 class GoodDocumentAvailabilityCheck(APIView):

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -204,6 +204,7 @@ class GoodArchiveRestore(UpdateAPIView):
 
         return Good.objects.filter(
             organisation=organisation,
+            status__in=GoodStatus.archivable_statuses(),
         )
 
 

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -4,7 +4,7 @@ from django.db.models import Q, Count
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status
-from rest_framework.generics import ListAPIView, ListCreateAPIView
+from rest_framework.generics import ListAPIView, ListCreateAPIView, UpdateAPIView
 from rest_framework.views import APIView
 
 from api.applications.models import (
@@ -46,6 +46,7 @@ from api.goods.serializers import (
     GoodDocumentAvailabilitySerializer,
     GoodDocumentSensitivitySerializer,
     TinyGoodDetailsSerializer,
+    GoodArchiveRestoreSerializer,
 )
 from api.applications.serializers.good import (
     GoodOnApplicationInternalDocumentCreateSerializer,
@@ -192,6 +193,12 @@ class ArchivedGoodList(ListAPIView):
         queryset = queryset.prefetch_related("control_list_entries")
 
         return queryset.order_by("-updated_at")
+
+
+class GoodArchiveRestore(UpdateAPIView):
+    authentication_classes = (ExporterAuthentication,)
+    queryset = Good.objects.all()
+    serializer_class = GoodArchiveRestoreSerializer
 
 
 class GoodDocumentAvailabilityCheck(APIView):


### PR DESCRIPTION
## Change description

Exporter has a choice to archive/restore a good and this is only allowed for goods that are submitted/verified on an application.

However we have a restriction that goods cannot be edited once they are submitted on an application. Removing this restriction can cause various issues so to avoid this add a dedicated endpoint which only allows archiving/restoring a particular good.

Add tests to ensure that only archive status can be updated using this endpoint.

