### PR TITLE
Allow good document stream for non draft statuses

### DIFF
--- a/api/goods/tests/test_goods_documents.py
+++ b/api/goods/tests/test_goods_documents.py
@@ -233,4 +233,4 @@ class GoodDocumentStreamTests(DataTestClient):
         )
         response = self.client.get(url, **self.exporter_headers)
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -32,7 +32,6 @@ from api.goods.libraries.save_good import create_or_update_good
 from api.goods.models import Good, GoodDocument
 from api.goods.permissions import (
     IsDocumentInOrganisation,
-    IsGoodDraft,
 )
 from api.goods.serializers import (
     GoodAttachingSerializer,
@@ -478,15 +477,16 @@ class GoodDocumentDetail(APIView):
         """
         Returns a list of documents on the specified good
         """
+
         good = get_good(pk)
 
         if good.organisation_id != get_request_user_organisation_id(request):
             raise PermissionDenied()
 
-        if good.status != GoodStatus.DRAFT:
-            return JsonResponse(
-                data={"errors": "This good is already on a submitted application"}, status=status.HTTP_400_BAD_REQUEST
-            )
+        # if good.status != GoodStatus.DRAFT:
+        #    return JsonResponse(
+        #        data={"errors": "This good is already on a submitted application"}, status=status.HTTP_400_BAD_REQUEST
+        #    )
 
         good_document = get_good_document(good, doc_pk)
         serializer = GoodDocumentViewSerializer(good_document)
@@ -546,10 +546,7 @@ class GoodDocumentStream(DocumentStreamAPIView):
     parent_filter_id_lookup_field = "good_id"
     lookup_url_kwarg = "doc_pk"
     queryset = GoodDocument.objects.all()
-    permission_classes = (
-        IsDocumentInOrganisation,
-        IsGoodDraft,
-    )
+    permission_classes = (IsDocumentInOrganisation,)
 
     def get_document(self, instance):
         return instance

--- a/api/goods/views.py
+++ b/api/goods/views.py
@@ -483,11 +483,6 @@ class GoodDocumentDetail(APIView):
         if good.organisation_id != get_request_user_organisation_id(request):
             raise PermissionDenied()
 
-        # if good.status != GoodStatus.DRAFT:
-        #    return JsonResponse(
-        #        data={"errors": "This good is already on a submitted application"}, status=status.HTTP_400_BAD_REQUEST
-        #    )
-
         good_document = get_good_document(good, doc_pk)
         serializer = GoodDocumentViewSerializer(good_document)
         return JsonResponse({"document": serializer.data})


### PR DESCRIPTION
### Aim

(slight rewording by @hnryjmes)

Currently, when a document for a good has been uploaded and the application is in draft status, the exporter is able to download and view the document. However once the application has been submitted, the good is also marked as submitted. So when the exporter goes into the product list they're unable to download and view the document. 

This PR shows that the issue can be resolved using the current API calls by removing the check for the draft status. However this would leave just a single check on that view which is that the good organisation id is equal to the request user organisation id.

Given that this check was there before we should be confident that removing the draft status check is safe, or if not, consider an alternative approach here like writing a new endpoint.

[LTD-5148](https://uktrade.atlassian.net/browse/LTD-5148)

[LTD-5148]: https://uktrade.atlassian.net/browse/LTD-5148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ