### PR TITLE
[LTD-5152] Ensure that PartyOnApplication.clone creates a copy of the related Party

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -717,10 +717,14 @@ class PartyOnApplication(TimestampableModel, Clonable):
         "id",
         "application",
         "flags",
+        "party",
     ]
-    clone_mappings = {
-        "party": "party_id",
-    }
+
+    def clone(self, exclusions=None, **overrides):
+        if not overrides.get("party"):
+            cloned_party = self.party.clone()
+            overrides["party"] = cloned_party
+        return super().clone(exclusions=exclusions, **overrides)
 
 
 class DenialMatchOnApplication(TimestampableModel):

--- a/api/applications/tests/test_models.py
+++ b/api/applications/tests/test_models.py
@@ -501,6 +501,32 @@ class TestPartyOnApplication(DataTestClient):
         cloned_party_on_application = original_party_on_application.clone(application=new_application)
         assert cloned_party_on_application.id != original_party_on_application.id
         assert cloned_party_on_application.application_id == new_application.id
+        assert cloned_party_on_application.party_id != original_party_on_application.party_id
+        assert model_to_dict(cloned_party_on_application) == {
+            "id": cloned_party_on_application.id,
+            "application": new_application.id,
+            "deleted_at": original_party_on_application.deleted_at,
+            "flags": [],
+            "party": cloned_party_on_application.party_id,
+        }, """
+        The attributes on the cloned record were not as expected. If this is the result
+        of a schema migration, think carefully about whether the new fields should be
+        cloned by default or not and adjust PartyOnApplication.clone_*
+        attributes accordingly.
+        """
+
+    def test_clone_with_party_override(self):
+        original_party_on_application = PartyOnApplicationFactory(
+            deleted_at=timezone.now(),
+        )
+        original_party_on_application.flags.add(Flag.objects.first())
+        original_party_on_application.save()
+        new_application = StandardApplicationFactory()
+        cloned_party_on_application = original_party_on_application.clone(
+            application=new_application, party=original_party_on_application.party
+        )
+        assert cloned_party_on_application.id != original_party_on_application.id
+        assert cloned_party_on_application.application_id == new_application.id
         assert model_to_dict(cloned_party_on_application) == {
             "id": cloned_party_on_application.id,
             "application": new_application.id,

--- a/api/parties/tests/test_models.py
+++ b/api/parties/tests/test_models.py
@@ -1,0 +1,71 @@
+from django.forms import model_to_dict
+
+from api.flags.models import Flag
+from api.parties.tests.factories import PartyFactory
+from api.staticdata.countries.models import Country
+
+from test_helpers.clients import DataTestClient
+
+
+class TestParty(DataTestClient):
+
+    def test_clone(self):
+        original_party = PartyFactory(
+            name="some party",
+            address="123 fake st",
+            country=Country.objects.get(id="FR"),
+            website="https://www.example.com/foo",
+            signatory_name_euu="some signatory name",
+            type="end_user",
+            organisation=self.organisation,
+            role="intermediate_consignee",
+            role_other="some other role",
+            sub_type="government",
+            sub_type_other="some other sub type",
+            end_user_document_available=False,
+            end_user_document_missing_reason="some reason",
+            product_differences_note="some differences",
+            document_in_english=True,
+            document_on_letterhead=True,
+            ec3_missing_reason="some reason",
+            clearance_level="uk_official",
+            descriptors="some descriptors",
+            copy_of=PartyFactory(),
+            phone_number="12345",
+            email="some.email@example.net",  # /PS-IGNORE
+            details="some details",
+        )
+        original_party.flags.add(Flag.objects.first())
+
+        cloned_party = original_party.clone()
+        assert original_party.id != cloned_party.id
+        assert model_to_dict(cloned_party) == {
+            "name": "some party",
+            "address": "123 fake st",
+            "country": original_party.country.id,
+            "website": "https://www.example.com/foo",
+            "signatory_name_euu": "some signatory name",
+            "type": "end_user",
+            "organisation": original_party.organisation.id,
+            "role": "intermediate_consignee",
+            "role_other": "some other role",
+            "sub_type": "government",
+            "sub_type_other": "some other sub type",
+            "end_user_document_available": False,
+            "end_user_document_missing_reason": "some reason",
+            "product_differences_note": "some differences",
+            "document_in_english": True,
+            "document_on_letterhead": True,
+            "ec3_missing_reason": "some reason",
+            "clearance_level": "uk_official",
+            "descriptors": "some descriptors",
+            "copy_of": original_party.id,
+            "phone_number": "12345",
+            "email": "some.email@example.net",  # /PS-IGNORE
+            "details": "some details",
+            "flags": [],
+        }, """
+        The attributes on the cloned record were not as expected. If this is the result
+        of a schema migration, think carefully about whether the new fields should be
+        cloned by default or not and adjust Party.clone_* attributes accordingly.
+        """


### PR DESCRIPTION
### Aim

The various model clone methods are currently used in the "amend by copy" feature.  Amend by copy ensures that when a user makes a major amendment to an application a new copy of an application is created and the original application put in to a superseded state.  We need to ensure that the application itself is copied and all related model records are also copied such that no records are re-used between the amendment application and the superseded application (with the exception of `Good` - which is used across multiple different applications).

To keep in line with this thinking, we need to also ensure that the new application has a full copy of any related `Party` records.

This change ensures that the `PartyOnApplication.clone()` method will associate the cloned PartyOnApplication object with a copy of the associated Party object.  The reason for this is to maintain the restriction where a single `Party` record is used for at most one application; a given `Party` record should not be reused for multiple applications.

[LTD-5152](https://uktrade.atlassian.net/browse/LTD-5152)

[LTD-5152]: https://uktrade.atlassian.net/browse/LTD-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ