### PR TITLE
[LTD-5078] Amend by copy validation

### DIFF
--- a/api/applications/views/amendments.py
+++ b/api/applications/views/amendments.py
@@ -36,6 +36,11 @@ class CreateApplicationAmendment(CreateAPIView):
         return self.application.organisation
 
     def perform_create(self, serializer):
+        # Create a clone of the application in question and set the original application
+        # to a superseded status.  Amendment applications are new copies of the original
+        # which can be edited by exporters as if they were a completely new draft.
+        # Caseworker commentary is not copied to the amendment application but persists
+        # on the old superseded application
         self.amendment_application = self.application.create_amendment(self.request.user)
 
     @application_can_invoke_major_edit

--- a/api/applications/views/amendments.py
+++ b/api/applications/views/amendments.py
@@ -4,10 +4,12 @@ from rest_framework.generics import CreateAPIView
 from rest_framework import serializers
 from rest_framework import status
 
-from api.core.authentication import ExporterAuthentication
-from api.core.exceptions import NotFoundError
-from api.core.permissions import IsExporterInOrganisation
 from api.applications.libraries.get_applications import get_application
+from api.core.authentication import ExporterAuthentication
+from api.core.decorators import application_can_invoke_major_edit
+from api.core.exceptions import NotFoundError, BadRequestError
+from api.core.permissions import IsExporterInOrganisation
+from api.licences.models import Licence
 
 
 class AmendmentSerializer(serializers.Serializer):
@@ -29,7 +31,6 @@ class CreateApplicationAmendment(CreateAPIView):
             self.application = get_application(pk=self.kwargs["pk"])
         except (ObjectDoesNotExist, NotFoundError):
             raise Http404()
-        # TODO: More validation to prevent creating amendment of something we should not
 
     def get_organisation(self):
         return self.application.organisation
@@ -37,7 +38,14 @@ class CreateApplicationAmendment(CreateAPIView):
     def perform_create(self, serializer):
         self.amendment_application = self.application.create_amendment(self.request.user)
 
+    @application_can_invoke_major_edit
     def create(self, request, *args, **kwargs):
+        # At this stage we aren't totally sure how we should deal with applications
+        # that have licences being amended.  So raise a meaningful error when this is attempted.
+        application_has_licence = Licence.objects.filter_non_draft_licences(application=self.application).count() > 0
+        if application_has_licence:
+            raise BadRequestError({"non_field_errors": "Application has at least one licence so cannot be amended."})
+
         super().create(request, *args, **kwargs)
         return JsonResponse(
             {

--- a/api/core/decorators.py
+++ b/api/core/decorators.py
@@ -108,6 +108,17 @@ def application_is_major_editable(application_status):
     )
 
 
+@application_in_status
+def application_can_invoke_major_edit(application_status):
+    """
+    Checks if application is in a state where a  major edit can be started
+    """
+    return (
+        CaseStatusEnum.can_invoke_major_edit(application_status),
+        strings.Applications.Generic.INVALID_OPERATION_FOR_NON_DRAFT_OR_MAJOR_EDIT_CASE_ERROR,
+    )
+
+
 def authorised_to_view_application(user_type: Union[Type[GovUser], Type[ExporterUser]]) -> Callable:
     """
     Checks if the user is the correct type and if they have access to the application being requested

--- a/api/licences/managers.py
+++ b/api/licences/managers.py
@@ -22,3 +22,6 @@ class LicenceManager(models.Manager):
                 return self.get_active_licence(application)
             except self.model.DoesNotExist:
                 return None
+
+    def filter_non_draft_licences(self, application):
+        return self.filter(case=application).exclude(status=LicenceStatus.DRAFT)

--- a/api/licences/tests/test_managers.py
+++ b/api/licences/tests/test_managers.py
@@ -1,0 +1,18 @@
+from api.licences.tests.factories import StandardLicenceFactory
+from api.applications.tests.factories import StandardApplicationFactory
+from api.licences.models import Licence
+from api.licences.enums import LicenceStatus
+from test_helpers.clients import DataTestClient
+
+
+class LicenceTests(DataTestClient):
+    def test_manager_filter_non_draft_licences(self):
+        application = StandardApplicationFactory()
+        case = application.case_ptr
+        draft_licence = StandardLicenceFactory(status=LicenceStatus.DRAFT, case=case)
+        issued_licence = StandardLicenceFactory(status=LicenceStatus.ISSUED, case=case)
+        cancelled_licence = StandardLicenceFactory(status=LicenceStatus.CANCELLED, case=case)
+        assert list(Licence.objects.filter_non_draft_licences(application=application)) == [
+            issued_licence,
+            cancelled_licence,
+        ]

--- a/api/staticdata/statuses/enums.py
+++ b/api/staticdata/statuses/enums.py
@@ -203,6 +203,10 @@ class CaseStatusEnum:
         return cls._can_invoke_major_edit_statuses
 
     @classmethod
+    def can_not_invoke_major_edit_statuses(cls):
+        return list(set(cls.all()) - set(cls._can_invoke_major_edit_statuses))
+
+    @classmethod
     def can_invoke_major_edit(cls, status):
         return status in cls._can_invoke_major_edit_statuses
 


### PR DESCRIPTION
### Aim

This change adds validation to the new "create amendment" endpoint to ensure the following;
- The application to be amended is in a status that allows major edits to be invoked.
- The application to be amended has no non-draft Licence records associated to it.  If there exists an issued/cancelled/revoked/... licence for this application, the API endpoint responds with a 400 and does not allow the user to proceed.  We are anticipating that this will be quite rare and for now we will handle amending of applications which have licences by some other means.

[LTD-5078](https://uktrade.atlassian.net/browse/LTD-5078)


[LTD-5078]: https://uktrade.atlassian.net/browse/LTD-5078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ