### PR TITLE
[LTD-5105] Amend by copy document copying

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -354,10 +354,9 @@ class StandardApplication(BaseApplication, Clonable):
     def clone(self, exclusions=None, **overrides):
         cloned_application = super().clone(exclusions=exclusions, **overrides)
 
-        # TODO: Figure out whether it is desirable to clone ApplicationDocument records
-        # application_documents = ApplicationDocument.objects.filter(application=self)
-        # for application_document in application_documents:
-        #    application_document.clone(application=cloned_application)
+        application_documents = ApplicationDocument.objects.filter(application=self)
+        for application_document in application_documents:
+            application_document.clone(application=cloned_application)
 
         site_on_applications = SiteOnApplication.objects.filter(application=self)
         for site_on_application in site_on_applications:

--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -354,7 +354,7 @@ class StandardApplication(BaseApplication, Clonable):
     def clone(self, exclusions=None, **overrides):
         cloned_application = super().clone(exclusions=exclusions, **overrides)
 
-        application_documents = ApplicationDocument.objects.filter(application=self)
+        application_documents = ApplicationDocument.objects.filter(application=self, safe=True)
         for application_document in application_documents:
             application_document.clone(application=cloned_application)
 
@@ -595,14 +595,15 @@ class GoodOnApplication(AbstractGoodOnApplication, Clonable):
             cloned_good_on_application.firearm_details = self.firearm_details.clone()
             cloned_good_on_application.save()
 
-        good_on_application_documents = GoodOnApplicationDocument.objects.filter(good_on_application=self)
+        good_on_application_documents = GoodOnApplicationDocument.objects.filter(good_on_application=self, safe=True)
         for good_on_application_document in good_on_application_documents:
             good_on_application_document.clone(
                 good_on_application=cloned_good_on_application, application=overrides["application"]
             )
 
         good_on_application_internal_documents = GoodOnApplicationInternalDocument.objects.filter(
-            good_on_application=self
+            good_on_application=self,
+            safe=True,
         )
         for good_on_application_internal_document in good_on_application_internal_documents:
             good_on_application_internal_document.clone(good_on_application=cloned_good_on_application)

--- a/api/applications/tests/test_models.py
+++ b/api/applications/tests/test_models.py
@@ -8,6 +8,7 @@ from api.audit_trail.models import Audit
 from api.cases.models import CaseType, Queue
 from api.flags.models import Flag
 from api.applications.models import (
+    ApplicationDocument,
     GoodOnApplication,
     GoodOnApplicationDocument,
     GoodOnApplicationInternalDocument,
@@ -173,6 +174,7 @@ class TestStandardApplication(DataTestClient):
         original_site_on_application = SiteOnApplicationFactory(application=original_application)
         original_good_on_application = GoodOnApplicationFactory(application=original_application)
         original_party_on_application = PartyOnApplicationFactory(application=original_application)
+        original_application_document = ApplicationDocumentFactory(application=original_application)
         cloned_application = original_application.clone()
 
         assert cloned_application.id != original_application.id
@@ -243,6 +245,7 @@ class TestStandardApplication(DataTestClient):
         assert SiteOnApplication.objects.filter(application=cloned_application).count() == 1
         assert GoodOnApplication.objects.filter(application=cloned_application).count() == 1
         assert PartyOnApplication.objects.filter(application=cloned_application).count() == 1
+        assert ApplicationDocument.objects.filter(application=cloned_application).count() == 1
 
 
 class TestApplicationDocument(DataTestClient):

--- a/api/applications/tests/test_models.py
+++ b/api/applications/tests/test_models.py
@@ -174,7 +174,12 @@ class TestStandardApplication(DataTestClient):
         original_site_on_application = SiteOnApplicationFactory(application=original_application)
         original_good_on_application = GoodOnApplicationFactory(application=original_application)
         original_party_on_application = PartyOnApplicationFactory(application=original_application)
-        original_application_document = ApplicationDocumentFactory(application=original_application)
+        original_application_safe_document = ApplicationDocumentFactory(
+            application=original_application, s3_key="some safe key", safe=True
+        )
+        original_application_unsafe_document = ApplicationDocumentFactory(
+            application=original_application, s3_key="some unsafe key", safe=False
+        )
         cloned_application = original_application.clone()
 
         assert cloned_application.id != original_application.id
@@ -245,7 +250,9 @@ class TestStandardApplication(DataTestClient):
         assert SiteOnApplication.objects.filter(application=cloned_application).count() == 1
         assert GoodOnApplication.objects.filter(application=cloned_application).count() == 1
         assert PartyOnApplication.objects.filter(application=cloned_application).count() == 1
-        assert ApplicationDocument.objects.filter(application=cloned_application).count() == 1
+        assert list(
+            ApplicationDocument.objects.filter(application=cloned_application).values_list("s3_key", flat=True)
+        ) == ["some safe key"]
 
 
 class TestApplicationDocument(DataTestClient):
@@ -357,16 +364,34 @@ class TestGoodOnApplication(DataTestClient):
         original_good_on_application_internal_document = GoodOnApplicationInternalDocumentFactory(
             document_title="some title",
             name="some name",
-            s3_key="doc.xlsx",
+            s3_key="safe.xlsx",
             safe=True,
+            size=100,
+            good_on_application=original_good_on_application,
+        )
+        original_good_on_application_internal_document_unsafe = GoodOnApplicationInternalDocumentFactory(
+            document_title="some title",
+            name="some name",
+            s3_key="unsafe.xlsx",
+            safe=False,
             size=100,
             good_on_application=original_good_on_application,
         )
         original_good_on_application_document = GoodOnApplicationDocumentFactory(
             document_type="some type",
             name="some name",
-            s3_key="doc.xlsx",
+            s3_key="safe.xlsx",
             safe=True,
+            size=100,
+            good_on_application=original_good_on_application,
+            good=original_good_on_application.good,
+            application=original_good_on_application.application,
+        )
+        original_good_on_application_document_unsafe = GoodOnApplicationDocumentFactory(
+            document_type="some type",
+            name="some name",
+            s3_key="unsafe.xlsx",
+            safe=False,
             size=100,
             good_on_application=original_good_on_application,
             good=original_good_on_application.good,
@@ -415,11 +440,16 @@ class TestGoodOnApplication(DataTestClient):
         cloned by default or not and adjust GoodOnApplication.clone_* attributes accordingly.
         """
         # Defer checking of related models' clone() methods to specific unit tests
-        assert (
-            GoodOnApplicationInternalDocument.objects.filter(good_on_application=cloned_good_on_application).count()
-            == 1
-        )
-        assert GoodOnApplicationDocument.objects.filter(good_on_application=cloned_good_on_application).count() == 1
+        assert list(
+            GoodOnApplicationInternalDocument.objects.filter(
+                good_on_application=cloned_good_on_application
+            ).values_list("s3_key", flat=True)
+        ) == ["safe.xlsx"]
+        assert list(
+            GoodOnApplicationDocument.objects.filter(good_on_application=cloned_good_on_application).values_list(
+                "s3_key", flat=True
+            )
+        ) == ["safe.xlsx"]
 
 
 class TestGoodOnApplicationDocument(DataTestClient):

--- a/api/documents/models.py
+++ b/api/documents/models.py
@@ -11,6 +11,7 @@ from api.documents.libraries import s3_operations, av_operations
 class Document(TimestampableModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=1000, null=False, blank=False)
+    # s3_key is not unique.  We can have many different Document records pointing to the same file in S3
     s3_key = models.CharField(max_length=1000, null=False, blank=False, default=None)
     size = models.IntegerField(null=True, blank=True)
     virus_scanned_at = models.DateTimeField(null=True, blank=True)

--- a/api/parties/models.py
+++ b/api/parties/models.py
@@ -98,10 +98,21 @@ class Party(TimestampableModel, Clonable):
         cloned_party = super().clone(exclusions=exclusions, **overrides)
         cloned_party.copy_of = self
         cloned_party.save()
+
+        party_documents = PartyDocument.objects.filter(party=self)
+        for party_document in party_documents:
+            party_document.clone(party=cloned_party)
+
         return cloned_party
 
 
-class PartyDocument(Document):
+class PartyDocument(Document, Clonable):
     party = models.ForeignKey(Party, on_delete=models.CASCADE)
     type = models.TextField(choices=PartyDocumentType.choices, default=PartyDocumentType.SUPPORTING_DOCUMENT)
     description = models.TextField(blank=True, default="")
+
+    clone_exclusions = [
+        "id",
+        "party",
+        "document_ptr",
+    ]

--- a/api/parties/models.py
+++ b/api/parties/models.py
@@ -99,7 +99,7 @@ class Party(TimestampableModel, Clonable):
         cloned_party.copy_of = self
         cloned_party.save()
 
-        party_documents = PartyDocument.objects.filter(party=self)
+        party_documents = PartyDocument.objects.filter(party=self, safe=True)
         for party_document in party_documents:
             party_document.clone(party=cloned_party)
 

--- a/api/parties/tests/test_models.py
+++ b/api/parties/tests/test_models.py
@@ -38,7 +38,10 @@ class TestParty(DataTestClient):
             details="some details",
         )
         original_party.flags.add(Flag.objects.first())
-        original_party_document = PartyDocumentFactory(party=original_party, s3_key="some key")
+        original_party_safe_document = PartyDocumentFactory(party=original_party, s3_key="some safe key", safe=True)
+        original_party_unsafe_document = PartyDocumentFactory(
+            party=original_party, s3_key="some unsafe key", safe=False
+        )
 
         cloned_party = original_party.clone()
         assert original_party.id != cloned_party.id
@@ -72,7 +75,9 @@ class TestParty(DataTestClient):
         of a schema migration, think carefully about whether the new fields should be
         cloned by default or not and adjust Party.clone_* attributes accordingly.
         """
-        assert PartyDocument.objects.filter(party=cloned_party).count() == 1
+        assert list(PartyDocument.objects.filter(party=cloned_party).values_list("s3_key", flat=True)) == [
+            "some safe key"
+        ]
 
 
 class TestPartyDocument(DataTestClient):


### PR DESCRIPTION
### Aim

This PR ensures that documents are cloned appropriately during the "amend by copy" flow.

In particular this;
- Ensures that `PartyDocument` records are copied instead of shared between cloned `Party` records.
- Ensures that `ApplicationDocument` records are also cloned when an application is cloned.  This will cover firearm dealer certificates, section 5 certificates, supporting documents etc.

[LTD-5105](https://uktrade.atlassian.net/browse/LTD-5105)


[LTD-5105]: https://uktrade.atlassian.net/browse/LTD-5105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ