### PR TITLE
Add new ML13c1 ControlListEntry object

### DIFF
--- a/api/staticdata/control_list_entries/migrations/0006_add_ML13c1_cle.py
+++ b/api/staticdata/control_list_entries/migrations/0006_add_ML13c1_cle.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def add_cle(apps, schema_editor):
+    ControlListEntry = apps.get_model("control_list_entries", "ControlListEntry")
+
+    parent_cle = ControlListEntry.objects.get(rating="ML13c")
+
+    ControlListEntry.objects.update_or_create(
+        rating="ML13c1", text="ML13c1", parent_id=parent_cle.id, category="UK Military List", controlled=True
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("control_list_entries", "0005_adds_5D001e"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_cle, migrations.RunPython.noop),
+    ]

--- a/api/staticdata/control_list_entries/migrations/tests/test_0006_add_ML13c1_cle.py
+++ b/api/staticdata/control_list_entries/migrations/tests/test_0006_add_ML13c1_cle.py
@@ -1,0 +1,18 @@
+import pytest
+
+from django_test_migrations.contrib.unittest_case import MigratorTestCase
+
+
+@pytest.mark.django_db()
+class TestMigration(MigratorTestCase):
+    migrate_from = ("control_list_entries", "0005_adds_5D001e")
+    migrate_to = ("control_list_entries", "0006_add_ML13c1_cle")
+
+    def test_add_cle(self):
+        ControlListEntry = self.new_state.apps.get_model("control_list_entries", "ControlListEntry")
+        parent_cle = ControlListEntry.objects.get(rating="ML13c")
+        new_cle = ControlListEntry.objects.get(rating="ML13c1")
+        assert new_cle.text == "ML13c1"
+        assert new_cle.parent_id == parent_cle.id
+        assert new_cle.category == "UK Military List"
+        assert new_cle.controlled == True


### PR DESCRIPTION
### Aim

Because of flagging rule tests in lite-routing we need to merge in the following order:

- Add ControlListEntry object using a migration in lite-api (this PR)
- Add "ML13c1" to the right set in lite-routing constants, in the same location as "ML13c" (https://github.com/uktrade/lite-routing/pull/257)
- Update lite-routing sha in lite-api to bring lite-routing changes into lite-api (to do later)

[LTD-5100](https://uktrade.atlassian.net/browse/LTD-5100)


[LTD-5100]: https://uktrade.atlassian.net/browse/LTD-5100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ