### PR TITLE
Remove lite-api test for expected count of CLEs

### DIFF
--- a/api/staticdata/management/commands/tests/test_commands.py
+++ b/api/staticdata/management/commands/tests/test_commands.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 
-from django.conf import settings
 from tempfile import NamedTemporaryFile
 
 from api.cases.enums import CaseTypeEnum
@@ -9,7 +8,6 @@ from api.cases.models import CaseType
 from api.core.constants import GovPermissions, ExporterPermissions
 from api.conf.settings import BASE_DIR
 from api.letter_templates.models import LetterTemplate
-from api.staticdata.control_list_entries.models import ControlListEntry
 from api.staticdata.countries.models import Country
 from api.cases.enums import AdviceType
 from api.staticdata.decisions.models import Decision
@@ -20,7 +18,6 @@ from api.staticdata.management.commands import (
     seedlayouts,
     seedcasestatuses,
     seedcasetypes,
-    seedcontrollistentries,
     seedcountries,
     seeddenialreasons,
     seedlettertemplates,
@@ -28,7 +25,6 @@ from api.staticdata.management.commands import (
     seedfinaldecisions,
 )
 from api.staticdata.statuses.models import CaseStatus, CaseStatusCaseType
-from api.teams.models import Team
 from api.users.models import Permission
 
 
@@ -57,11 +53,6 @@ class SeedingTests(SeedCommandTest):
                     counter += 1
 
         self.assertEqual(CaseStatusCaseType.objects.all().count(), counter)
-
-    @pytest.mark.seeding
-    def test_seed_control_list_entries(self):
-        self.seed_command(seedcontrollistentries.Command)
-        self.assertEqual(ControlListEntry.objects.count(), 2943)
 
     @pytest.mark.seeding
     def test_seed_countries(self):


### PR DESCRIPTION
### Aim

We are currently in the process of changing CLEs in LITE including adding many new CLEs. To do this we need to write migrations that create ControlListEntry objects in lite-api for each CLE. Previously we decided that any new migrations affecting routing should be written in the lite-routing repo and not in lite-api.

There is an existing seeding test in lite-api that checks the count of CLEs is as expected. Although this was written to ensure the seeding command was successful, it has been changed many times as new CLEs have been added through migrations. It is now just checking the count of CLEs is a particular number but this is not related to the count of CLEs added through the seeding command.

After discussion it was suggested that we probably don't want this test anymore, as it's not checking anything useful about the seeding command or about the CLEs in general. It also makes it more difficult to add CLEs via migrations in lite-routing as the test will fail when the new CLE is added in lite-routing. Removing the test allows us to have a process where we can add CLE objects in two steps: first, add the CLE through a migration in lite-routing, and second, bring in that lite-routing change into lite-api via a sha update.

[LTD-5149](https://uktrade.atlassian.net/browse/LTD-5149)


[LTD-5149]: https://uktrade.atlassian.net/browse/LTD-5149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ