### PR TITLE
LTD-5223-tab-finalised

### DIFF
--- a/api/applications/managers.py
+++ b/api/applications/managers.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from model_utils.managers import InheritanceManager
 
 from api.staticdata.statuses.enums import CaseStatusEnum
@@ -10,8 +12,14 @@ class BaseApplicationManager(InheritanceManager):
         return self.get_queryset().filter(status=draft, organisation=organisation).order_by(sort_by)
 
     def submitted(self, organisation, sort_by):
+        finalised = get_case_status_by_status(CaseStatusEnum.FINALISED)
         draft = get_case_status_by_status(CaseStatusEnum.DRAFT)
-        return self.get_queryset().filter(organisation=organisation).exclude(status=draft).order_by(sort_by)
+        return (
+            self.get_queryset()
+            .filter(organisation=organisation)
+            .exclude(Q(status=draft) | Q(status=finalised))
+            .order_by(sort_by)
+        )
 
     def finalised(self, organisation, sort_by):
         finalised = get_case_status_by_status(CaseStatusEnum.FINALISED)


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5223

Removes the `finalised` applications from the `submitted` tab.