### PR TITLE
LTD-5247-new-endpoint-view-license 

### DIFF
--- a/api/licences/serializers/view_licence.py
+++ b/api/licences/serializers/view_licence.py
@@ -212,6 +212,18 @@ class LicenceSerializer(serializers.ModelSerializer):
         return {"id": document.id}
 
 
+class LicenceDetailsSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Licence
+        fields = (
+            "id",
+            "reference_code",
+            "status",
+        )
+        read_only_fields = ["id", "reference_code"]
+
+
 class LicenceWithGoodsViewSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     start_date = serializers.DateField()

--- a/api/licences/urls.py
+++ b/api/licences/urls.py
@@ -7,6 +7,7 @@ app_name = "licences"
 urlpatterns = [
     path("", main.Licences.as_view(), name="licences"),
     path("<uuid:pk>/", main.ViewLicence.as_view(), name="licence"),
+    path("licence_details/<uuid:pk>/", main.LicenceDetails.as_view(), name="licence_details"),
     path("nlrs/", main.NLRs.as_view(), name="nlrs"),
     path(
         "hmrc-integration/force-mail-push/", hmrc_integration.force_mail_push, name="hmrc_integration_force_mail_push"

--- a/api/licences/views/main.py
+++ b/api/licences/views/main.py
@@ -4,10 +4,15 @@ from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, ListAPIV
 from api.cases.enums import CaseTypeSubTypeEnum, AdviceType, AdviceLevel, CaseTypeEnum
 from api.cases.generated_documents.models import GeneratedCaseDocument
 from api.cases.models import CaseType
-from api.core.authentication import ExporterAuthentication
+from api.core.authentication import ExporterAuthentication, GovAuthentication
 from api.licences.enums import LicenceStatus
 from api.licences.models import Licence
-from api.licences.serializers.view_licence import LicenceSerializer, NLRdocumentSerializer, LicenceListSerializer
+from api.licences.serializers.view_licence import (
+    LicenceDetailsSerializer,
+    LicenceSerializer,
+    NLRdocumentSerializer,
+    LicenceListSerializer,
+)
 from api.organisations.libraries.get_organisation import get_request_user_organisation_id, get_request_user_organisation
 from api.parties.enums import PartyType
 from api.staticdata.statuses.enums import CaseStatusEnum
@@ -76,6 +81,15 @@ class ViewLicence(RetrieveAPIView):
 
     def get_queryset(self):
         return Licence.objects.filter(case__organisation_id=get_request_user_organisation_id(self.request))
+
+
+class LicenceDetails(RetrieveAPIView):
+    # This is used to retrieve the details of the license based on id. ViewLicence is mainly used on exported side to get the
+    # License(s) on the case.
+    authentication_classes = (GovAuthentication,)
+    serializer_class = LicenceDetailsSerializer
+    queryset = Licence.objects.all()
+    lookup_field = "pk"
 
 
 class NLRs(ListAPIView):


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/LTD-5247

This is to support the new feature of allowing License(s) to be updated directly from the UI. 

This is adding a new endpoint to allow govuser to retrieval the details  of a License based on id.  New Serialiser is used since it's very light weight. 

Also We will leverage this end point to allow updates to an individual License. 

Hence this will be followed by a series of PRs