### PR TITLE
LTD-5083: Add endpoint to allow update of quantity value fields only

### DIFF
--- a/api/applications/serializers/good.py
+++ b/api/applications/serializers/good.py
@@ -424,3 +424,13 @@ class GoodOnApplicationInternalDocumentViewSerializer(serializers.Serializer):
 
     def get_s3_key(self, instance):
         return instance.s3_key if instance.safe else "File not ready"
+
+
+class GoodOnApplicationQuantityValueSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = GoodOnApplication
+        fields = (
+            "quantity",
+            "value",
+        )

--- a/api/applications/urls.py
+++ b/api/applications/urls.py
@@ -16,6 +16,8 @@ from api.applications.views import (
     amendments,
 )
 
+from api.exporter.applications.views import ApplicationQuantityValueUpdateView
+
 app_name = "applications"
 
 urlpatterns = [
@@ -143,5 +145,11 @@ urlpatterns = [
         "<uuid:pk>/amendment/",
         amendments.CreateApplicationAmendment.as_view(),
         name="create_amendment",
+    ),
+    # Exporter specific endpoints
+    path(
+        "<uuid:pk>/good-on-application/<uuid:good_on_application_pk>/quantity-value/",
+        ApplicationQuantityValueUpdateView.as_view(),
+        name="application_goods_quantity_value",
     ),
 ]

--- a/api/exporter/applications/permissions.py
+++ b/api/exporter/applications/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework import permissions
+
+from api.staticdata.statuses.enums import CaseStatusEnum
+
+
+class IsApplicationEditable(permissions.BasePermission):
+    def has_permission(self, request, view):
+        application = view.application
+        return application.status.status in CaseStatusEnum.major_editable_statuses()

--- a/api/exporter/applications/views.py
+++ b/api/exporter/applications/views.py
@@ -1,0 +1,49 @@
+from django.http import Http404, JsonResponse
+from rest_framework import status
+from rest_framework.generics import UpdateAPIView
+
+from api.core.authentication import ExporterAuthentication
+from api.core.permissions import IsExporterInOrganisation
+from api.applications.serializers.good import GoodOnApplicationQuantityValueSerializer
+from api.applications.models import BaseApplication, GoodOnApplication
+from api.exporter.applications.permissions import IsApplicationEditable
+
+
+class BaseExporterApplication:
+    authentication_classes = (ExporterAuthentication,)
+    permission_classes = (IsExporterInOrganisation,)
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+
+        try:
+            self.application = BaseApplication.objects.get(pk=self.kwargs["pk"])
+        except BaseApplication.DoesNotExist:
+            raise Http404()
+
+    def get_organisation(self):
+        return self.application.organisation
+
+
+class ApplicationQuantityValueUpdateView(BaseExporterApplication, UpdateAPIView):
+    serializer_class = GoodOnApplicationQuantityValueSerializer
+    permission_classes = (
+        IsExporterInOrganisation,
+        IsApplicationEditable,
+    )
+
+    def patch(self, request, **kwargs):
+        good_on_application_pk = kwargs["good_on_application_pk"]
+        good_on_application = GoodOnApplication.objects.get(pk=good_on_application_pk)
+
+        data = request.data.copy()
+        serializer = self.serializer_class(instance=good_on_application, data=data, partial=True)
+        if not serializer.is_valid():
+            return JsonResponse(
+                data={"errors": serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer.save()
+
+        return JsonResponse(status=status.HTTP_200_OK, data=serializer.data)

--- a/api/exporter/applications/views.py
+++ b/api/exporter/applications/views.py
@@ -1,5 +1,4 @@
-from django.http import Http404, JsonResponse
-from rest_framework import status
+from django.http import Http404
 from rest_framework.generics import UpdateAPIView
 
 from api.core.authentication import ExporterAuthentication
@@ -26,24 +25,12 @@ class BaseExporterApplication:
 
 
 class ApplicationQuantityValueUpdateView(BaseExporterApplication, UpdateAPIView):
-    serializer_class = GoodOnApplicationQuantityValueSerializer
     permission_classes = (
         IsExporterInOrganisation,
         IsApplicationEditable,
     )
+    lookup_url_kwarg = "good_on_application_pk"
+    serializer_class = GoodOnApplicationQuantityValueSerializer
 
-    def patch(self, request, **kwargs):
-        good_on_application_pk = kwargs["good_on_application_pk"]
-        good_on_application = GoodOnApplication.objects.get(pk=good_on_application_pk)
-
-        data = request.data.copy()
-        serializer = self.serializer_class(instance=good_on_application, data=data, partial=True)
-        if not serializer.is_valid():
-            return JsonResponse(
-                data={"errors": serializer.errors},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        serializer.save()
-
-        return JsonResponse(status=status.HTTP_200_OK, data=serializer.data)
+    def get_queryset(self):
+        return GoodOnApplication.objects.filter(application_id=self.kwargs["pk"])


### PR DESCRIPTION
## Change description

Add exporter specific endpoint to allow editing of quantity/value of goods added to an application.
This endpoint is restrictive and only quantity, value can be edited.

As we are moving towards separating exporter, caseworker urls a new directory is created with the intention of grouping
relevant views under that directory.

Permission checks are moved to their own custom permission classes.

Note: This ticket is mainly about auditing quantity and value changes but this PR doesn't add audit events.
Editing of quantity value was introduced as a minor edit earlier but now we have removed minor edits completely. To perform major edits application need to be in `draft` state at which point it is not associated to any `Case`. This is a problem for audit events because they are always associated to a `Case`. So even if we add audit entries when in `draft` state they don't show up under Notes and timeline.
Hence we agreed to add this exporter specific endpoint which is an improvement and revisit auditing later after discussing with UCD.

Relevant FE PR: https://github.com/uktrade/lite-frontend/pull/2092

[LTD-5083](https://uktrade.atlassian.net/browse/LTD-5083)


[LTD-5083]: https://uktrade.atlassian.net/browse/LTD-5083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ