### PR TITLE
LTD-5290 added role_other to query

### DIFF
--- a/api/applications/views/parties.py
+++ b/api/applications/views/parties.py
@@ -20,6 +20,7 @@ from api.parties.models import Party
 from api.parties.serializers import PartySerializer
 from api.users.models import ExporterUser
 from api.staticdata.statuses.enums import CaseStatusEnum
+from django.db.models import Q
 
 
 class ApplicationPartyView(APIView):
@@ -127,7 +128,11 @@ class ApplicationPartyView(APIView):
         )
 
         if "type" in request.GET:
-            application_parties = application_parties.filter(party__type=request.GET["type"])
+            query = Q(party__type=request.GET["type"])
+            if "role_other" in request.GET:
+                query |= Q(party__role_other=request.GET["role_other"])
+
+            application_parties = application_parties.filter(query)
 
         parties_data = PartySerializer([p.party for p in application_parties], many=True).data
 


### PR DESCRIPTION
**Exporter User** wanted to see a Ultimate end user that was added as a third party, the type of this UEU became third_party instead of ultimate end user and so the exporter wasn't able to remove the third party from the case.

[LTD-5290](https://uktrade.atlassian.net/browse/LTD-5290)


[LTD-5290]: https://uktrade.atlassian.net/browse/LTD-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ