### PR TITLE
LTD-5287: Include submitted_by in the application data sent to exporter

### DIFF
--- a/api/applications/serializers/generic_application.py
+++ b/api/applications/serializers/generic_application.py
@@ -45,6 +45,7 @@ class GenericApplicationListSerializer(serializers.Serializer):
     case_type = TinyCaseTypeSerializer()
     status = CaseStatusField()
     submitted_at = serializers.DateTimeField()
+    submitted_by = serializers.SerializerMethodField()
     updated_at = serializers.DateTimeField()
     reference_code = serializers.CharField()
     export_type = serializers.SerializerMethodField()
@@ -55,6 +56,9 @@ class GenericApplicationListSerializer(serializers.Serializer):
                 "key": instance.export_type,
                 "value": get_value_from_enum(instance.export_type, ApplicationExportType),
             }
+
+    def get_submitted_by(self, instance):
+        return f"{instance.submitted_by.full_name}" if instance.submitted_by else ""
 
 
 class GenericApplicationViewSerializer(serializers.ModelSerializer):

--- a/api/applications/tests/test_view_application.py
+++ b/api/applications/tests/test_view_application.py
@@ -219,6 +219,8 @@ class DraftTests(DataTestClient):
         response = self.client.get(url, **self.exporter_headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
+        application_data = response.json()["results"][0]
+        self.assertEqual(application_data["submitted_by"], self.exporter_user.full_name)
 
     def test_organisation_has_existing_applications(self):
         url = reverse("applications:existing")


### PR DESCRIPTION
## Change description

On the exporter dashboard, for archived applications we want to show 'Submitted by' column but that data is not sent atm.
Update serializer to provide this field.

Relevant FE PR: https://github.com/uktrade/lite-frontend/pull/2102

[LTD-5287](https://uktrade.atlassian.net/browse/LTD-5287)


[LTD-5287]: https://uktrade.atlassian.net/browse/LTD-5287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ