### PR TITLE
[LTD-5299] Prevent caseworkers setting superseded status

### DIFF
--- a/api/applications/caseworker/permissions.py
+++ b/api/applications/caseworker/permissions.py
@@ -21,6 +21,9 @@ class CaseStatusCaseworkerChangeable(permissions.BasePermission):
         if new_status == CaseStatusEnum.APPLICANT_EDITING:
             return False
 
+        if new_status == CaseStatusEnum.SUPERSEDED_BY_EXPORTER_EDIT:
+            return False
+
         if CaseStatusEnum.is_terminal(original_status) and not user.has_permission(GovPermissions.REOPEN_CLOSED_CASES):
             return False
 

--- a/api/applications/caseworker/tests/test_permissions.py
+++ b/api/applications/caseworker/tests/test_permissions.py
@@ -62,10 +62,11 @@ class TestChangeStatusCaseworkerChangeable(DataTestClient):
         mock_request.data = {"status": CaseStatusEnum.OGD_ADVICE}
         assert self.permission_obj.has_object_permission(mock_request, None, self.application) is True
 
-    def test_has_object_permission_new_status_applicant_editing(self):
+    @parameterized.expand([CaseStatusEnum.APPLICANT_EDITING, CaseStatusEnum.SUPERSEDED_BY_EXPORTER_EDIT])
+    def test_has_object_permission_new_status_disallowed(self, new_status):
         mock_request = mock.Mock()
         mock_request.user = self.gov_user.baseuser_ptr
-        mock_request.data = {"status": CaseStatusEnum.APPLICANT_EDITING}
+        mock_request.data = {"status": new_status}
         assert self.permission_obj.has_object_permission(mock_request, None, self.application) is False
 
     def test_has_object_permission_new_status_finalised_user_permitted(self):


### PR DESCRIPTION
### Aim

This change ensures that caseworkers are unable to set the case status to "Superseded by exporter edit" via the API.

[LTD-5299](https://uktrade.atlassian.net/browse/LTD-5299)


[LTD-5299]: https://uktrade.atlassian.net/browse/LTD-5299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ