### PR TITLE
LTD-5304-managment-cmd-remove-advice 

### DIFF
--- a/api/support/management/commands/remove_case_final_advice.py
+++ b/api/support/management/commands/remove_case_final_advice.py
@@ -1,0 +1,85 @@
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from api.audit_trail.enums import AuditType
+from api.cases.enums import AdviceLevel
+from api.cases.models import Case
+from api.queues.models import Queue
+from api.audit_trail import service as audit_trail_service
+
+from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+from lite_routing.routing_rules_internal.enums import QueuesEnum
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+        Command to delete Final advice when a case is ready to finalise
+
+        When an application goes back to TAU and they change their mind we need to
+        invalidate all the final advice. This is unsed where cases are ready to proceed
+        with finial review. i.e a refusal.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--case_reference",
+            type=str,
+            nargs="?",
+            help="Reference code of the Case (eg GBSIEL/2023/0000001/P)",
+        )
+        parser.add_argument("--dry_run", help="Is it a test run?", action="store_true")
+
+    def handle(self, *args, **options):
+        case_reference = options.pop("case_reference")
+        dry_run = options.pop("dry_run")
+
+        with transaction.atomic():
+            try:
+                case = Case.objects.get(reference_code=case_reference)
+            except Case.DoesNotExist as e:
+                logger.error("Invalid Case reference %s, does not exist", case_reference)
+                raise CommandError(e)
+
+            final_advice = case.advice.filter(level=AdviceLevel.FINAL)
+
+            # Ensure final advice given by LU
+            if not final_advice.exists():
+                logger.error("Invalid Advice data, no final advice on this case")
+                raise CommandError(Exception("Invalid Advice data, no final advice on this case"))
+
+            if not dry_run:
+                # Move the Case to 'LU Post-Circulation Cases to Finalise' queue
+                # as it needs to be in this queue to finalise and issue
+                # also need to ensure the status is under final review.
+                case.queues.set(Queue.objects.filter(id=QueuesEnum.LU_POST_CIRC))
+
+                for item in final_advice:
+                    item.delete()
+
+                audit_trail_service.create_system_user_audit(
+                    verb=AuditType.DEVELOPER_INTERVENTION,
+                    target=case,
+                    payload={
+                        "additional_text": "Removed final advice.",
+                    },
+                )
+                # If the case isn't under final review update the status
+                if case.status.status != CaseStatusEnum.UNDER_FINAL_REVIEW:
+                    prev_case_status = case.status.status
+                    case.status = get_case_status_by_status(CaseStatusEnum.UNDER_FINAL_REVIEW)
+                    case.save()
+                    audit_trail_service.create_system_user_audit(
+                        verb=AuditType.UPDATED_STATUS,
+                        target=case,
+                        payload={
+                            "status": {"new": case.status.status, "old": prev_case_status},
+                            "additional_text": "",
+                        },
+                    )
+
+            logging.info("[%s] can now be finalised by LU to issue a licence", case_reference)

--- a/api/support/management/commands/tests/test_remove_case_final_advice.py
+++ b/api/support/management/commands/tests/test_remove_case_final_advice.py
@@ -1,0 +1,91 @@
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+import pytest
+
+from django.core.management import call_command, CommandError
+
+from api.applications.tests.factories import AdviceFactory, FinalAdviceOnApplicationFactory
+from api.audit_trail.enums import AuditType
+from api.audit_trail.models import Audit
+from api.cases.enums import AdviceLevel
+from api.staticdata.statuses.enums import CaseStatusEnum
+from test_helpers.clients import DataTestClient
+
+
+class RemoveCaseFinalAdviceMgmtCommandTests(DataTestClient):
+
+    def setUp(self):
+        super().setUp()
+        self.application = FinalAdviceOnApplicationFactory()
+        self.application.advice.set([AdviceFactory(level=AdviceLevel.USER)])
+
+    def test_remove_case_final_advice_command(self):
+
+        self.application.status = get_case_status_by_status(CaseStatusEnum.SUBMITTED)
+        self.application.save()
+
+        self.assertEqual(self.application.advice.filter(level=AdviceLevel.FINAL).exists(), True)
+        self.assertEqual(self.application.advice.all().count(), 2)
+
+        call_command("remove_case_final_advice", case_reference=self.application.reference_code)
+
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status.status, CaseStatusEnum.UNDER_FINAL_REVIEW)
+        self.assertEqual(self.application.advice.filter(level=AdviceLevel.FINAL).exists(), False)
+        self.assertEqual(self.application.advice.all().count(), 1)
+
+        audit_dev = Audit.objects.get(verb=AuditType.DEVELOPER_INTERVENTION)
+        self.assertEqual(audit_dev.actor, self.system_user)
+        self.assertEqual(audit_dev.target.id, self.application.id)
+
+        self.assertEqual(
+            audit_dev.payload,
+            {
+                "additional_text": "Removed final advice.",
+            },
+        )
+
+        audit = Audit.objects.get(verb=AuditType.UPDATED_STATUS)
+        self.assertEqual(audit.actor, self.system_user)
+        self.assertEqual(audit.target.id, self.application.id)
+
+        self.assertEqual(
+            audit.payload,
+            {
+                "status": {"new": self.application.status.status, "old": CaseStatusEnum.SUBMITTED},
+                "additional_text": "",
+            },
+        )
+
+    def test_remove_case_final_advice_command_status_not_updated(self):
+
+        call_command("remove_case_final_advice", case_reference=self.application.reference_code)
+
+        self.assertEqual(Audit.objects.filter(verb=AuditType.UPDATED_STATUS).exists(), False)
+
+    def test_remove_case_status_change_command_dry_run(self):
+
+        self.assertEqual(self.application.advice.filter(level=AdviceLevel.FINAL).exists(), True)
+        self.assertEqual(self.application.advice.all().count(), 2)
+
+        call_command("remove_case_final_advice", "--dry_run", case_reference=self.application.reference_code)
+
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.advice.filter(level=AdviceLevel.FINAL).exists(), True)
+        self.assertEqual(self.application.advice.all().count(), 2)
+        self.assertEqual(Audit.objects.filter(verb=AuditType.DEVELOPER_INTERVENTION).exists(), False)
+
+    def test_remove_case_final_advice_command_no_final_advise(self):
+
+        self.application.advice.filter(level=AdviceLevel.FINAL).delete()
+        with pytest.raises(CommandError):
+            call_command("remove_case_final_advice", case_reference=self.application.reference_code)
+
+    def test_remove_case_final_advice_command_missing_case_ref(self):
+
+        self.application.advice.filter(level=AdviceLevel.FINAL).delete()
+        self.assertEqual(self.application.advice.all().count(), 1)
+
+        with pytest.raises(CommandError):
+            call_command("remove_case_final_advice", case_reference="bad-ref")
+
+        self.assertEqual(self.application.advice.all().count(), 1)


### PR DESCRIPTION
A new management command which allows all finial advice to be deleted. 

This is required when TAU change their minds and have issue various final advice on a case. We need to invalidate this so the case can go back to post-circulation 