### PR TITLE
Fix a race condition when multiple amendments are made

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pipenv run pytest --circleci-parallelize --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing --ignore api/anonymised_db_dumps -k "not seeding and not elasticsearch and not performance and not migration and not db_anonymiser"
+            pipenv run pytest --circleci-parallelize --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing --ignore api/anonymised_db_dumps -k "not seeding and not elasticsearch and not performance and not migration and not db_anonymiser and not requires_transactions"
       - upload_code_coverage:
           alias: tests
 
@@ -154,7 +154,7 @@ jobs:
       - run:
           name: Run tests on Postgres 13
           command: |
-            pipenv run pytest --circleci-parallelize --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing --ignore api/anonymised_db_dumps -k "not seeding and not elasticsearch and not performance and not migration and not db_anonymiser"
+            pipenv run pytest --circleci-parallelize --cov=. --cov-report xml --cov-config=.coveragerc --ignore lite_routing --ignore api/anonymised_db_dumps -k "not seeding and not elasticsearch and not performance and not migration and not db_anonymiser and not requires_transactions"
       - upload_code_coverage:
           alias: tests_dbt_platform
 
@@ -231,6 +231,44 @@ jobs:
             pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc api/anonymised_db_dumps
       - upload_code_coverage:
           alias: anonymised_db_dump_tests_dbt_platform
+
+  requires_transactions_tests:
+    docker:
+      - <<: *image_python
+      - <<: *image_postgres
+      - <<: *image_opensearch_v1
+      - <<: *image_redis
+    working_directory: ~/lite-api
+    environment:
+      <<: *common_env_vars
+      LITE_API_ENABLE_ES: True
+    steps:
+      - setup
+      - run:
+          name: Run requiring transactions tests
+          command: |
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k requires_transactions
+      - upload_code_coverage:
+          alias: requires_transactions_tests
+
+  requires_transactions_tests_dbt_platform:
+    docker:
+      - <<: *image_python
+      - <<: *image_postgres13
+      - <<: *image_opensearch
+      - <<: *image_redis
+    working_directory: ~/lite-api
+    environment:
+      <<: *common_env_vars
+      LITE_API_ENABLE_ES: True
+    steps:
+      - setup
+      - run:
+          name: Run requiring transactions tests on Postgres 13
+          command: |
+            pipenv run pytest --cov=. --cov-report xml --cov-config=.coveragerc -k requires_transactions
+      - upload_code_coverage:
+          alias: requires_transactions_tests_dbt_platform
 
   migration_tests:
     docker:
@@ -613,7 +651,10 @@ workflows:
               - open_search_tests
               - migration_tests
               - lite_routing_tests
+              - requires_transactions_tests
       - check-lite-routing-sha
       - e2e_tests
       - anonymised_db_dump_tests
       - anonymised_db_dump_tests_dbt_platform
+      - requires_transactions_tests
+      - requires_transactions_tests_dbt_platform

--- a/api/applications/exceptions.py
+++ b/api/applications/exceptions.py
@@ -1,0 +1,2 @@
+class AmendmentError(Exception):
+    pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
 	elasticsearch: Tests that use elasticsearch
 	seeding: tests that check seed commands
 	performance: tests that check performance
+	requires_transactions: tests that require fine grained controls of transactions


### PR DESCRIPTION
### Aim

This stops a race condition where an amendment request hits our API multiple times simultaneously.

It's possible for a user to have submitted the "confirm major edit" action multiple times and we want to ensure that the request is only processed once.

To handle this we ensure that a lock is put on the application object and then check the status of the application after any simultaneous edits are being made.

To properly test this I've added a separate CI job due to this test needing to use `TransactionTestCase` and that not playing nicely with other tests.

[LTD-5392](https://uktrade.atlassian.net/browse/LTD-5392)


[LTD-5392]: https://uktrade.atlassian.net/browse/LTD-5392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ