### PR TITLE
Ltd 5424 tidy up email payloads

### DIFF
--- a/api/cases/notify.py
+++ b/api/cases/notify.py
@@ -78,7 +78,6 @@ def notify_exporter_licence_revoked(licence):
         {
             "user_first_name": exporter.first_name,
             "application_reference": case.reference_code,
-            "exporter_frontend_url": get_exporter_frontend_url("/"),
         },
     )
 
@@ -188,6 +187,5 @@ def notify_exporter_appeal_acknowledgement(case):
     payload = ExporterAppealAcknowledgement(
         user_first_name=exporter.first_name,
         application_reference=case.reference_code,
-        exporter_frontend_url=get_exporter_frontend_url("/"),
     )
     send_email(exporter.email, TemplateType.EXPORTER_APPEAL_ACKNOWLEDGEMENT, payload)

--- a/api/cases/tests/test_notify.py
+++ b/api/cases/tests/test_notify.py
@@ -69,7 +69,6 @@ class NotifyTests(DataTestClient):
         expected_payload = ExporterLicenceRevoked(
             user_first_name=self.exporter_user.first_name,
             application_reference=self.licence.case.reference_code,
-            exporter_frontend_url="https://exporter.lite.service.localhost.uktrade.digital/",
         )
 
         notify_exporter_licence_revoked(self.licence)
@@ -154,7 +153,6 @@ class NotifyTests(DataTestClient):
         expected_payload = ExporterAppealAcknowledgement(
             user_first_name=self.case.submitted_by.first_name,
             application_reference=self.case.reference_code,
-            exporter_frontend_url="https://exporter.lite.service.localhost.uktrade.digital/",
         )
         mock_send_email.assert_called_with(
             self.case.submitted_by.email,

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -54,7 +54,6 @@ class ExporterLicenceRefused(EmailData):
 class ExporterLicenceRevoked(EmailData):
     user_first_name: str
     application_reference: str
-    exporter_frontend_url: str
 
 
 @dataclass(frozen=True)
@@ -122,7 +121,6 @@ class ExporterInformLetter(EmailData):
 class ExporterAppealAcknowledgement(EmailData):
     user_first_name: str
     application_reference: str
-    exporter_frontend_url: str
 
 
 @dataclass(frozen=True)

--- a/gov_notify/payloads.py
+++ b/gov_notify/payloads.py
@@ -12,20 +12,6 @@ class EmailData:
 
 
 @dataclass(frozen=True)
-class EcjuCreatedEmailData(EmailData):
-    case_reference: str
-    application_reference: str
-    link: str
-
-
-@dataclass(frozen=True)
-class ApplicationStatusEmailData(EmailData):
-    case_reference: str
-    application_reference: str
-    link: str
-
-
-@dataclass(frozen=True)
 class ExporterRegistration(EmailData):
     organisation_name: str
 

--- a/gov_notify/tests/test_payloads.py
+++ b/gov_notify/tests/test_payloads.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from parameterized import parameterized
 from rest_framework.test import APITestCase
 
@@ -9,22 +7,6 @@ from gov_notify import payloads
 class DataclassTests(APITestCase):
     @parameterized.expand(
         [
-            (
-                payloads.EcjuCreatedEmailData,
-                {
-                    "case_reference": "testref",
-                    "application_reference": "testref2",
-                    "link": "testlink",
-                },
-            ),
-            (
-                payloads.ApplicationStatusEmailData,
-                {
-                    "case_reference": "testref",
-                    "application_reference": "testref2",
-                    "link": "testlink",
-                },
-            ),
             (
                 payloads.ExporterRegistration,
                 {
@@ -97,7 +79,7 @@ class DataclassTests(APITestCase):
                 payloads.CaseWorkerNewRegistration,
                 {
                     "organisation_name": "testref",
-                    "applicant_email": "test@user.com",
+                    "applicant_email": "test@user.com",  # /PS-IGNORE
                 },
             ),
         ]


### PR DESCRIPTION
### Aim

When looking to update the URLs for the public beta switch over it was hard to decipher what was a used template variable and/or a used template. This should remove both templates and template variables that aren’t being used.

[LTD-5424](https://uktrade.atlassian.net/browse/LTD-5424)


[LTD-5424]: https://uktrade.atlassian.net/browse/LTD-5424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ