### PR TITLE
Add parallelism to migration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,7 @@ jobs:
     environment:
       <<: *common_env_vars
       LITE_API_ENABLE_ES: True
+    parallelism: 5
     steps:
       - setup
       - run:
@@ -299,6 +300,7 @@ jobs:
     environment:
       <<: *common_env_vars
       LITE_API_ENABLE_ES: True
+    parallelism: 5
     steps:
       - setup
       - run:


### PR DESCRIPTION
### Aim

The migrations tests have now become the longest running part of our API CI suite.

Running these in parallel now reduces the total time spent running.
