### PR TITLE
Ltd 5378 licence list bug

### DIFF
--- a/api/data_workspace/v1/licence_views.py
+++ b/api/data_workspace/v1/licence_views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 from rest_framework.pagination import LimitOffsetPagination
 
 from api.core.authentication import DataWorkspaceOnlyAuthentication
-from api.data_workspace.v1.serializers import LicenceWithoutGoodsSerializer
+from api.data_workspace.v1.serializers import LicenceSerializer
 from api.licences import models
 from api.licences.serializers import view_licence as serializers
 
@@ -16,6 +16,6 @@ class GoodOnLicenceList(viewsets.ReadOnlyModelViewSet):
 
 class LicencesList(viewsets.ReadOnlyModelViewSet):
     authentication_classes = (DataWorkspaceOnlyAuthentication,)
-    serializer_class = LicenceWithoutGoodsSerializer
+    serializer_class = LicenceSerializer
     pagination_class = LimitOffsetPagination
     queryset = models.Licence.objects.all()

--- a/api/data_workspace/v1/serializers.py
+++ b/api/data_workspace/v1/serializers.py
@@ -131,7 +131,7 @@ class LicenceSerializer(serializers.ModelSerializer):
         ordering = ["created_at"]
 
     def get_application(self, instance):
-        return {"application_id": instance.case.pk}
+        return {"application_id": str(instance.case.pk)}
 
 
 class SurveyResponseSerializer(serializers.ModelSerializer):

--- a/api/data_workspace/v1/serializers.py
+++ b/api/data_workspace/v1/serializers.py
@@ -1,8 +1,10 @@
 from api.audit_trail.models import Audit
+from api.core.serializers import KeyValueChoiceField
 from api.survey.models import SurveyResponse
 from api.teams.models import Department
 from api.cases.models import CaseAssignment, EcjuQuery, DepartmentSLA
-from api.licences.serializers.view_licence import LicenceListSerializer
+from api.licences.enums import LicenceStatus
+from api.licences.models import Licence
 from api.queues.models import Queue
 from api.organisations.models import Site
 from rest_framework import serializers
@@ -113,10 +115,23 @@ class AdviceDenialReasonSerializer(serializers.Serializer):
     denialreason_id = serializers.CharField()
 
 
-class LicenceWithoutGoodsSerializer(LicenceListSerializer):
-    def get_goods(self, instance):
-        # Good are not required by reporting
-        return []
+class LicenceSerializer(serializers.ModelSerializer):
+    application = serializers.SerializerMethodField()
+    status = KeyValueChoiceField(choices=LicenceStatus.choices)
+
+    class Meta:
+        model = Licence
+        fields = (
+            "id",
+            "application",
+            "reference_code",
+            "status",
+        )
+        read_only_fields = fields
+        ordering = ["created_at"]
+
+    def get_application(self, instance):
+        return {"application_id": instance.case.pk}
 
 
 class SurveyResponseSerializer(serializers.ModelSerializer):

--- a/api/data_workspace/v1/tests/test_licence_views.py
+++ b/api/data_workspace/v1/tests/test_licence_views.py
@@ -61,7 +61,7 @@ class DataWorkspaceTests(DataTestClient):
 
     def test_licenses(self):
         url = reverse("data_workspace:v1:dw-licences-list")
-        expected_fields = ("id", "reference_code", "status", "application", "goods")
+        expected_fields = ("id", "application", "reference_code", "status")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()["results"]

--- a/api/data_workspace/v1/tests/test_licence_views.py
+++ b/api/data_workspace/v1/tests/test_licence_views.py
@@ -5,6 +5,7 @@ from api.applications.tests.factories import GoodOnApplicationFactory
 from api.cases.tests.factories import FinalAdviceFactory
 from api.cases.enums import AdviceType
 from api.goods.tests.factories import GoodFactory
+from api.licences.enums import LicenceStatus
 from api.licences.tests.factories import StandardLicenceFactory, GoodOnLicenceFactory
 from test_helpers.clients import DataTestClient
 
@@ -19,10 +20,11 @@ class DataWorkspaceTests(DataTestClient):
             is_good_controlled=True,
             control_list_entries=["ML21"],
         )
+        self.licence = StandardLicenceFactory(case=case)
         FinalAdviceFactory(user=self.gov_user, team=self.team, case=case, good=good, type=AdviceType.APPROVE)
         GoodOnLicenceFactory(
             good=GoodOnApplicationFactory(application=case, good=good),
-            licence=StandardLicenceFactory(case=case),
+            licence=self.licence,
             quantity=100,
             value=1,
         )
@@ -66,7 +68,18 @@ class DataWorkspaceTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()["results"]
         self.assertGreater(len(results), 0)
-        self.assertEqual(tuple(results[0].keys()), expected_fields)
+        self.assertEqual(
+            results[0],
+            {
+                "id": str(self.licence.pk),
+                "application": {"application_id": str(self.licence.case.pk)},
+                "reference_code": self.licence.reference_code,
+                "status": {
+                    "key": self.licence.status,
+                    "value": LicenceStatus.to_str(self.licence.status),
+                },
+            },
+        )
 
         response = self.client.options(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/data_workspace/v1/tests/test_serializers.py
+++ b/api/data_workspace/v1/tests/test_serializers.py
@@ -6,7 +6,7 @@ from api.data_workspace.v1.serializers import (
     EcjuQuerySerializer,
     AuditUpdatedCaseStatusSerializer,
     AuditUpdatedLicenceStatusSerializer,
-    LicenceWithoutGoodsSerializer,
+    LicenceSerializer,
     SiteSerializer,
 )
 from api.cases.tests.factories import EcjuQueryFactory, CaseAssignmentFactory
@@ -55,18 +55,16 @@ def test_AuditUpdatedLicenceStatusSerializer(db):
     assert set(serialized.data.keys()) == expected_fields
 
 
-def test_LicenceWithoutGoodsSerializer(db):
+def test_LicenceSerializer(db):
     licence = StandardLicenceFactory()
-    serialized = LicenceWithoutGoodsSerializer(licence)
+    serialized = LicenceSerializer(licence)
     expected_fields = {
         "id",
         "reference_code",
         "status",
         "application",
-        "goods",
     }
     assert set(serialized.data) == expected_fields
-    assert serialized.data["goods"] == []
 
 
 def test_SiteSerializer(db):

--- a/api/data_workspace/v1/tests/test_serializers.py
+++ b/api/data_workspace/v1/tests/test_serializers.py
@@ -10,6 +10,7 @@ from api.data_workspace.v1.serializers import (
     SiteSerializer,
 )
 from api.cases.tests.factories import EcjuQueryFactory, CaseAssignmentFactory
+from api.licences.enums import LicenceStatus
 from api.licences.tests.factories import StandardLicenceFactory
 from api.organisations.tests.factories import SiteFactory
 
@@ -58,13 +59,15 @@ def test_AuditUpdatedLicenceStatusSerializer(db):
 def test_LicenceSerializer(db):
     licence = StandardLicenceFactory()
     serialized = LicenceSerializer(licence)
-    expected_fields = {
-        "id",
-        "reference_code",
-        "status",
-        "application",
+    assert serialized.data == {
+        "id": str(licence.pk),
+        "application": {"application_id": str(licence.case.pk)},
+        "reference_code": licence.reference_code,
+        "status": {
+            "key": licence.status,
+            "value": LicenceStatus.to_str(licence.status),
+        },
     }
-    assert set(serialized.data) == expected_fields
 
 
 def test_SiteSerializer(db):

--- a/api/licences/views/main.py
+++ b/api/licences/views/main.py
@@ -76,6 +76,11 @@ class Licences(ListCreateAPIView):
         if active_only:
             licences = licences.exclude(case__status__in=self.non_active_states)
 
+        licences = licences.prefetch_related(
+            "goods__good__good",
+            "goods__good__control_list_entries",
+        )
+
         return licences.order_by("created_at").reverse()
 
 


### PR DESCRIPTION
### Aim

Fix licence list page when a good has been used multiple times on an application.

The issue was around advice objects being generated multiple times for the same good and one of the serializers falling over as a result.

The serializer for this page actually didn't need to load the advice at all so I've created a separate serializer that just sends what's required for the licence list page.

I've also separated out the Data Workspace serializer as well as this was also loading up information that it didn't need to.

[LTD-5378](https://uktrade.atlassian.net/browse/LTD-5378)


[LTD-5378]: https://uktrade.atlassian.net/browse/LTD-5378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ