### PR TITLE
[LTD-5428] Make CI check routing docs are up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,39 @@ jobs:
           name: Check migrations are made
           command: pipenv run ./manage.py makemigrations --check
 
+  check_routing_docs:
+    docker:
+      - <<: *image_python
+      - <<: *image_postgres
+      - <<: *image_opensearch_v1
+    working_directory: ~/lite-api
+    environment:
+      <<: *common_env_vars
+      LITE_API_ENABLE_ES: True
+    steps:
+      - setup
+      - run:
+          name: Migrate app
+          command: pipenv run ./manage.py migrate
+      - run:
+          name: Seed app
+          command: pipenv run ./manage.py seedall
+      - run:
+          name: Generate routing rules documentation
+          command: pipenv run ./manage.py generate_rules_docs
+      - run:
+          name: Check for routing documentation changes
+          command: |
+            cd lite_routing
+            CHANGED_FILES=$(git diff --name-only)
+            CHANGED_CONTENT=$(git diff)
+            if [[ "$CHANGED_FILES" == *"docs/"* ]]; then
+              echo "lite-routing docs are stale! They should be re-generated with manage.py generate_rules_docs and committed to the lite-routing repository."
+              echo "Changed files; $CHANGED_FILES"
+              echo "$CHANGED_CONTENT"
+              exit 1
+            fi
+
   check_coverage:
     working_directory: ~/lite-api
     docker:
@@ -655,8 +688,12 @@ workflows:
               - lite_routing_tests
               - requires_transactions_tests
       - check-lite-routing-sha
+      - check_routing_docs
       - e2e_tests
       - anonymised_db_dump_tests
       - anonymised_db_dump_tests_dbt_platform
       - requires_transactions_tests
       - requires_transactions_tests_dbt_platform
+  check_routing_docs:
+    jobs:
+      - check_routing_docs


### PR DESCRIPTION
### Aim

This change adds a new circle CI job to ensure that the lite_routing documentation is up to date.

This is achieved by generating the docs again in circleci (after bringing up a seeded/migrated app) and checking for differences from what we have in git for lite-routing.
If differences are observed, the check fails with an error message which shows the diff.

PRs for the lite-routing repository will get this check "for free" since the CI for that repository calls through to lite-api's CI pipeline.

**NOTE:** We should only merge this PR when the companion PR in lite-routing has merged https://github.com/uktrade/lite-routing/pull/268 AND when we are ready to update the lite-routing submodule sha.

[LTD-5428](https://uktrade.atlassian.net/browse/LTD-5428)


[LTD-5428]: https://uktrade.atlassian.net/browse/LTD-5428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ