### PR TITLE
Add separate serializer for exporter licence details

### DIFF
--- a/api/licences/serializers/view_licence.py
+++ b/api/licences/serializers/view_licence.py
@@ -431,3 +431,56 @@ class LicenceListSerializer(serializers.ModelSerializer):
         )
         read_only_fields = fields
         ordering = ["created_at"]
+
+
+class GoodOnLicenceExporterLicenceViewSerializer(serializers.ModelSerializer):
+    applied_for_quantity = serializers.FloatField(source="good.quantity")
+    assessed_control_list_entries = ControlListEntrySerializer(source="good.control_list_entries", many=True)
+    control_list_entries = ControlListEntrySerializer(source="good.good.control_list_entries", many=True)
+    description = serializers.CharField(source="good.good.description")
+    name = serializers.CharField(source="good.good.name")
+    licenced_quantity = serializers.FloatField(source="quantity")
+    licenced_value = serializers.FloatField(source="value")
+    units = KeyValueChoiceField(source="good.unit", choices=Units.choices)
+    usage = serializers.FloatField()
+
+    class Meta:
+        model = GoodOnLicence
+        fields = (
+            "id",
+            "applied_for_quantity",
+            "assessed_control_list_entries",
+            "control_list_entries",
+            "description",
+            "licenced_quantity",
+            "licenced_value",
+            "name",
+            "units",
+            "usage",
+        )
+        read_only_fields = fields
+
+
+class ExporterLicenceViewSerializer(serializers.ModelSerializer):
+    application = ApplicationLicenceSerializer(source="case.baseapplication")
+    document = serializers.SerializerMethodField()
+    status = KeyValueChoiceField(choices=LicenceStatus.choices)
+    goods = GoodOnLicenceExporterLicenceViewSerializer(many=True)
+
+    class Meta:
+        model = Licence
+        fields = (
+            "id",
+            "application",
+            "document",
+            "duration",
+            "goods",
+            "reference_code",
+            "start_date",
+            "status",
+        )
+        read_only_fields = fields
+
+    def get_document(self, instance):
+        document = GeneratedCaseDocument.objects.get(licence=instance)
+        return {"id": document.id}

--- a/api/licences/tests/test_get_licence.py
+++ b/api/licences/tests/test_get_licence.py
@@ -67,31 +67,87 @@ class GetLicenceTests(DataTestClient):
         self.assertEqual(response_data["goods_on_licence"][0]["advice"]["proviso"], good_advice.proviso)
 
     def test_get_licence_exporter_view(self):
-        applications = [
-            self.create_standard_application_case(self.organisation),
-        ]
+        application = self.create_standard_application_case(self.organisation)
+
         template = self.create_letter_template(
             case_types=[
                 CaseTypeEnum.SIEL.id,
             ]
         )
-        licences = {
-            application: StandardLicenceFactory(case=application, status=LicenceStatus.ISSUED)
-            for application in applications
-        }
-        documents = {
-            application: self.create_generated_case_document(application, template, licence=licences[application])
-            for application in applications
-        }
 
-        for application, licence in licences.items():
-            url = reverse("licences:licence", kwargs={"pk": str(licence.id)})
-            response = self.client.get(url, **self.exporter_headers)
-            response_data = response.json()
+        licence = StandardLicenceFactory(case=application, status=LicenceStatus.ISSUED)
+        document = self.create_generated_case_document(application, template, licence=licence)
 
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertEqual(response_data["application"]["id"], str(application.id))
-            self.assertEqual(response_data["reference_code"], str(licence.reference_code))
-            self.assertEqual(response_data["duration"], licence.duration)
-            self.assertEqual(response_data["start_date"], licence.start_date.strftime("%Y-%m-%d"))
-            self.assertEqual(response_data["document"]["id"], str(documents[application].id))
+        good = GoodFactory(
+            is_good_controlled=True,
+            organisation=application.organisation,
+            control_list_entries=["ML1a", "ML2b"],
+        )
+        good_on_application = GoodOnApplicationFactory(
+            application=application,
+            control_list_entries=["ML5a", "ML5b"],
+            good=good,
+            quantity=100.0,
+            value=1500,
+            unit=Units.KGM,
+        )
+        good_on_licence = GoodOnLicenceFactory(
+            good=good_on_application,
+            quantity=good_on_application.quantity,
+            usage=20.0,
+            value=good_on_application.value,
+            licence=licence,
+        )
+
+        url = reverse("licences:licence", kwargs={"pk": str(licence.id)})
+        response = self.client.get(url, **self.exporter_headers)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_data["application"]["id"], str(application.id))
+        self.assertEqual(
+            response_data["application"]["case_type"],
+            {
+                "sub_type": {
+                    "key": "standard",
+                    "value": "Standard Licence",
+                },
+            },
+        )
+        self.assertEqual(response_data["document"], {"id": str(document.id)})
+        self.assertEqual(response_data["duration"], licence.duration)
+        self.assertEqual(
+            response_data["goods"],
+            [
+                {
+                    "applied_for_quantity": 100.0,
+                    "assessed_control_list_entries": [
+                        {
+                            "id": str(cle.pk),
+                            "rating": cle.rating,
+                            "text": cle.text,
+                        }
+                        for cle in good_on_application.control_list_entries.all()
+                    ],
+                    "control_list_entries": [
+                        {
+                            "id": str(cle.pk),
+                            "rating": cle.rating,
+                            "text": cle.text,
+                        }
+                        for cle in good.control_list_entries.all()
+                    ],
+                    "description": good.description,
+                    "id": str(good_on_licence.id),
+                    "licenced_quantity": good_on_licence.quantity,
+                    "licenced_value": good_on_licence.value,
+                    "name": good.name,
+                    "units": {"key": "KGM", "value": "Kilograms"},
+                    "usage": good_on_licence.usage,
+                }
+            ],
+        )
+        self.assertEqual(response_data["id"], str(licence.pk))
+        self.assertEqual(response_data["reference_code"], licence.reference_code)
+        self.assertEqual(response_data["start_date"], licence.start_date.strftime("%Y-%m-%d"))
+        self.assertEqual(response_data["status"], {"key": "issued", "value": "Issued"})

--- a/api/licences/views/main.py
+++ b/api/licences/views/main.py
@@ -12,8 +12,8 @@ from api.core.decorators import authorised_govuser_roles, licence_is_editable
 from api.licences.enums import LicenceStatus
 from api.licences.models import Licence
 from api.licences.serializers.view_licence import (
+    ExporterLicenceViewSerializer,
     LicenceDetailsSerializer,
-    LicenceSerializer,
     NLRdocumentSerializer,
     LicenceListSerializer,
 )
@@ -86,7 +86,7 @@ class Licences(ListCreateAPIView):
 
 class ViewLicence(RetrieveAPIView):
     authentication_classes = (ExporterAuthentication,)
-    serializer_class = LicenceSerializer
+    serializer_class = ExporterLicenceViewSerializer
 
     def get_queryset(self):
         return Licence.objects.filter(case__organisation_id=get_request_user_organisation_id(self.request))


### PR DESCRIPTION
### Aim

This creates a separate serializer for the exporter licence detail endpoint. This stops an issue with the original `get_advice` method that would fail given more than one advice object for a good on a licence.

Having an independent serializer here means that we are only sending the relevant and required information for the view on the frontend that doesn't require advice.

[LTD-5454](https://uktrade.atlassian.net/browse/LTD-5454)


[LTD-5454]: https://uktrade.atlassian.net/browse/LTD-5454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ