### PR TITLE
Remove routing docs checking job from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,6 +694,3 @@ workflows:
       - anonymised_db_dump_tests_dbt_platform
       - requires_transactions_tests
       - requires_transactions_tests_dbt_platform
-  check_routing_docs:
-    jobs:
-      - check_routing_docs


### PR DESCRIPTION
### Aim

Removing this redundant top level job from the circleci config should fix an incompatibility which lite-routing has calling circleci on lite-api.