### PR TITLE
Ensure coverage checks out correct routing submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
             sudo apt-get update
             sudo apt-get install swig libpango1.0-0 libcairo2 libpq-dev libpangocairo-1.0-0 imagemagick poppler-utils
 
-  setup:
+  git_checkout:
     steps:
       - checkout
       - run:
@@ -89,6 +89,9 @@ commands:
                   git checkout << pipeline.parameters.lite_routing_branch_name >>
                   cd ..
 
+  setup:
+    steps:
+      - git_checkout
       # Download and cache dependencies
       # ensure this step occurs *before* installing dependencies
       - restore_cache:
@@ -514,8 +517,7 @@ jobs:
     docker:
       - <<: *image_python
     steps:
-      - checkout
-      - run: git submodule sync --recursive && git submodule update --recursive --init
+      - git_checkout
       - attach_workspace:
           at: ~/lite-api/tmp
       - run: pip install coverage diff_cover


### PR DESCRIPTION
### Aim

This makes sure that the correct code is checked out when running code coverage.

When running our tests it's possible that the testing job checked out a different submodule e.g. because it's testing a specific branch of lite_routing, than what is checked out when `check_coverage` runs.

When the above happens this leads to an error in coverage because it's trying to find a code file to use to display code coverage which may not actually exist.

To resolve this we make sure that the same procedure to check out the relevant submodules is used across both the testing and code coverage jobs.

[LTD-5482](https://uktrade.atlassian.net/browse/LTD-5482)


[LTD-5482]: https://uktrade.atlassian.net/browse/LTD-5482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ