### PR TITLE
Add setting for routing documents location

### DIFF
--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -614,3 +614,5 @@ else:
     LOGGING.update({"formatters": {"simple": {"format": "{asctime} {levelname} {message}", "style": "{"}}})
     LOGGING["handlers"].update({"stdout": {"class": "logging.StreamHandler", "formatter": "simple"}})
     LOGGING.update({"root": {"handlers": ["stdout"], "level": env("LOG_LEVEL").upper()}})
+
+ROUTING_DOCS_DIRECTORY = os.path.join(BASE_DIR, "..", "lite_routing", "docs")


### PR DESCRIPTION
### Aim

This adds a setting that will be used by the generate rules documents management command.

[LTD-5521](https://uktrade.atlassian.net/browse/LTD-5521)


[LTD-5521]: https://uktrade.atlassian.net/browse/LTD-5521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ