### PR TITLE
LTD-5537-Licence-document-cutting-off-details

### DIFF
--- a/api/letter_templates/templates/letter_templates/refusal.html
+++ b/api/letter_templates/templates/letter_templates/refusal.html
@@ -13,7 +13,7 @@
   <ul class="govuk-list govuk-list--bullet">
     {% for good in goods.refuse %}
       <li>
-        {{good.good.name}}
+        {{good.good.name|split_good_name_across_lines}}
       </li>
     {% endfor %}
   </ul>

--- a/api/letter_templates/templates/letter_templates/siel.html
+++ b/api/letter_templates/templates/letter_templates/siel.html
@@ -282,7 +282,7 @@
                   <table border="0">
                     <tr id="row-{{ forloop.counter}}-description-name">
                         <td><strong>Name:</strong></td>
-                        <td>{% if good.name %}{{ good.name }}{% else %}{{ good.description }}{% endif %}
+                        <td>{% if good.name %}{{ good.name|split_good_name_across_lines }}{% else %}{{ good.description|split_good_name_across_lines }}{% endif %}
                         </td>
                     </tr>
                     <tr>

--- a/api/letter_templates/templatetags/custom_tags.py
+++ b/api/letter_templates/templatetags/custom_tags.py
@@ -128,3 +128,8 @@ def remove_duplicate_provisos(goods_approved):
             provisos.add(good_item["proviso_reason"])
 
     return provisos
+
+
+@register.filter(name="split_good_name_across_lines")
+def split_good_name_across_lines(value):
+    return value.replace(",", "\n") if "," in value else value

--- a/api/letter_templates/tests/test_letter_templates.py
+++ b/api/letter_templates/tests/test_letter_templates.py
@@ -14,7 +14,7 @@ class TemplatesTestCase(TestCase):
                     ],
                 },
                 {
-                    "good": {"name": "Test Good 2"},
+                    "good": {"name": "Test Good 2, Another line"},
                     "denial_reasons": [
                         {"display_value": "1", "description": "Test Description 1"},
                         {"display_value": "2", "description": "Test Description 2"},
@@ -29,6 +29,8 @@ class TemplatesTestCase(TestCase):
         )
 
         self.assertIn("Test Good 1", rendered_template)
+
+        self.assertIn("Test Good 2\n Another line", rendered_template)
         self.assertIn("Criterion 1", rendered_template)
         self.assertIn("Test Description 1", rendered_template)
 
@@ -42,6 +44,13 @@ class TemplatesTestCase(TestCase):
                     "value": "555111",
                     "quantity": "555222",
                 },
+                {
+                    "good": {"name": "Test Good 2, Another line", "control_list_entries": ["R1a", "M7"]},
+                    "applied_for_value": "999111",
+                    "applied_for_quantity": "999222",
+                    "value": "555111",
+                    "quantity": "555222",
+                },
             ]
         }
 
@@ -50,6 +59,7 @@ class TemplatesTestCase(TestCase):
             {"goods": goods_data},
         )
 
+        self.assertIn("Test Good 2\n Another line", rendered_template)
         self.assertNotIn("999111", rendered_template)
         self.assertNotIn("999222", rendered_template)
         self.assertIn("555111", rendered_template)


### PR DESCRIPTION
### Aim

Split good name onto different lines on Licence pdf by comma to ensure full good details appear on licence pdf.

Investigated and there are 2727 out of 14574 good records which contain commas so this a lighter touch on the existing data than adding splitting across any character types although this could be introduced.


[LTD-5537](https://uktrade.atlassian.net/browse/LTD-5537)


[LTD-5537]: https://uktrade.atlassian.net/browse/LTD-5537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ