### PR TITLE
Set unique email address for base user

### DIFF
--- a/api/organisations/caseworker/views/tests/test_users.py
+++ b/api/organisations/caseworker/views/tests/test_users.py
@@ -30,7 +30,7 @@ class TestAddExporterUserToOrganisation(DataTestClient):
         )
         self.data = {
             "role": Roles.EXPORTER_ADMINISTRATOR_ROLE_ID,
-            "email": self.faker.email(),
+            "email": self.faker.unique.email(),
             "sites": [self.organisation.primary_site.id],
             "phone_number": "+441234567895",
         }

--- a/api/users/tests/factories.py
+++ b/api/users/tests/factories.py
@@ -1,7 +1,5 @@
 import factory
 
-from faker import Faker
-
 
 from api.organisations.tests.factories import OrganisationFactory
 from api.users import models
@@ -9,13 +7,13 @@ from api.users.enums import UserType, UserStatuses
 from api.users.models import Role, UserOrganisationRelationship
 from api.teams.tests.factories import TeamFactory
 
-faker = Faker()
+from test_helpers.faker import faker
 
 
 class BaseUserFactory(factory.django.DjangoModelFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    email = factory.LazyAttribute(lambda n: faker.email())
+    email = factory.LazyAttribute(lambda n: faker.unique.email())
 
     class Meta:
         model = models.BaseUser

--- a/test_helpers/clients.py
+++ b/test_helpers/clients.py
@@ -8,7 +8,6 @@ from typing import Tuple
 import django.utils.timezone
 from django.db import connection
 from django.test import override_settings
-from faker import Faker
 from rest_framework.test import APITestCase, URLPatternsTestCase, APIClient
 import pytest
 
@@ -84,6 +83,7 @@ from api.staticdata.urls import urlpatterns as static_urlpatterns
 from api.teams.models import Team
 from api.users.tests.factories import GovUserFactory
 from test_helpers import colours
+from test_helpers.faker import faker
 from api.users.enums import SystemUser, UserType
 from api.users.libraries.user_to_token import user_to_token
 from api.users.models import ExporterUser, UserOrganisationRelationship, BaseUser, GovUser, Role
@@ -94,11 +94,6 @@ from api.workflow.routing_rules.models import RoutingRule
 
 class Static:
     seeded = False
-
-
-# Instantiating this once so that we have a single instance across all tests allowing us to use things like .unique
-# and we can guarantee that we will always have unique values even if we use things like `setUpClass`.
-faker = Faker()
 
 
 class DataTestClient(APITestCase, URLPatternsTestCase):

--- a/test_helpers/faker.py
+++ b/test_helpers/faker.py
@@ -1,0 +1,6 @@
+from faker import Faker
+
+
+# Instantiating this once so that we have a single instance across all tests allowing us to use things like .unique
+# and we can guarantee that we will always have unique values even if we use things like `setUpClass`.
+faker = Faker()

--- a/test_helpers/helpers.py
+++ b/test_helpers/helpers.py
@@ -2,17 +2,15 @@ import sys
 
 from importlib import import_module, reload
 
-from faker import Faker
-
 from django.conf import settings
 from django.urls import clear_url_caches
+
+from test_helpers.faker import faker
 
 from api.core.constants import Roles
 from api.flags.enums import SystemFlags
 from api.staticdata.countries.models import Country
 from api.users.models import ExporterUser, UserOrganisationRelationship
-
-faker = Faker()
 
 
 def generate_key_value_pair(key, choices):
@@ -37,7 +35,7 @@ def create_exporter_users(organisation, quantity=1, role_id=Roles.EXPORTER_EXPOR
     users = []
 
     for i in range(quantity):
-        user, created = ExporterUser.objects.get_or_create(email=faker.email())
+        user, created = ExporterUser.objects.get_or_create(email=faker.unique.email())
         if created:
             user.first_name = faker.first_name()
             user.last_name = faker.last_name()


### PR DESCRIPTION
### Aim

Ensure a unique email address is used across all tests.

This should stop tests failing on an intermittent `IntegrityError`.
