### PR TITLE
Remove unused model criteria function method

### DIFF
--- a/api/workflow/routing_rules/models.py
+++ b/api/workflow/routing_rules/models.py
@@ -16,7 +16,6 @@ from api.staticdata.statuses.models import CaseStatus
 from api.teams.models import Team
 from api.users.models import GovUser
 from api.workflow.routing_rules.enum import RoutingRulesAdditionalFields
-from lite_routing.routing_rules_internal.routing_rules_criteria import run_criteria_function
 
 
 class RoutingRuleManager(models.Manager):
@@ -113,11 +112,6 @@ class RoutingRule(TimestampableModel):
             self.active,
             self.country_id,  # country code
         )
-
-    def is_python_criteria_satisfied(self, case):
-        if not self.is_python_criteria:
-            raise NotImplementedError(f"is_python_criteria_satisfied was run for non-python rule {self.id}")
-        return run_criteria_function(self.id, case)
 
     natural_key.dependencies = ["teams.Team", "queues.Queue", "users.GovUser", "countries.Country"]
 

--- a/api/workflow/routing_rules/tests/test_models.py
+++ b/api/workflow/routing_rules/tests/test_models.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.conf import settings
 from parameterized import parameterized
 
@@ -7,37 +5,12 @@ from api.cases.models import CaseType, CaseStatus
 from api.cases.tests.factories import CaseFactory
 from api.flags.models import Flag, FlaggingRule
 from api.workflow.routing_rules.models import RoutingRule, RoutingHistory
-from api.teams.models import Team
 from api.queues.models import Queue
 from api.staticdata.statuses.models import CaseStatus
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.users.models import BaseUser
 from api.users.enums import SystemUser
 from test_helpers.clients import DataTestClient
-
-
-class RoutingRuleCreationTests(DataTestClient):
-    def test_is_python_criteria_satisfied_non_python_rule(self):
-        rule = RoutingRule.objects.create(
-            team=Team.objects.first(),
-            queue=Queue.objects.first(),
-            status=CaseStatus.objects.first(),
-            tier=2,
-        )
-        self.assertRaises(NotImplementedError, rule.is_python_criteria_satisfied, unittest.mock.Mock())
-
-    @unittest.mock.patch("api.workflow.routing_rules.models.run_criteria_function")
-    def test_is_python_criteria_satisfied_calls_criteria_function(self, mocked_run_criteria_function):
-        mocked_run_criteria_function.return_value = True
-        rule = RoutingRule.objects.create(
-            team=Team.objects.first(),
-            queue=Queue.objects.first(),
-            status=CaseStatus.objects.first(),
-            tier=2,
-            is_python_criteria=True,
-        )
-        assert rule.is_python_criteria_satisfied(unittest.mock.Mock()) == True
-        assert mocked_run_criteria_function.called
 
 
 class RoutingHistoryCreationTests(DataTestClient):


### PR DESCRIPTION
### Aim

Remove unused model method to run criteria function now routing rules are no longer DB driven.

[LTD-5598](https://uktrade.atlassian.net/browse/LTD-5598)


[LTD-5598]: https://uktrade.atlassian.net/browse/LTD-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ