### PR TITLE
Ltd 5637 fix csv save extra backslash

### DIFF
--- a/api/applications/management/commands/update_party_address.py
+++ b/api/applications/management/commands/update_party_address.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             for row in reader:
                 party_id = row["party_id"]
                 address = row["address"].replace("\\r\\n", "\r\n")
-                new_address = row["new_address"]
+                new_address = row["new_address"].replace("\\r\\n", "\r\n")
                 additional_text = row["additional_text"]
 
                 self.update_field_on_party(party_id, address, new_address, additional_text, audit_log)

--- a/api/applications/management/commands/update_party_name.py
+++ b/api/applications/management/commands/update_party_name.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             for row in reader:
                 party_id = row["party_id"]
                 name = row["name"].replace("\\r\\n", "\r\n")
-                new_name = row["new_name"]
+                new_name = row["new_name"].replace("\\r\\n", "\r\n")
                 additional_text = row["additional_text"]
 
                 self.update_field_on_party(party_id, name, new_name, additional_text)

--- a/api/applications/tests/test_update_parties_address.py
+++ b/api/applications/tests/test_update_parties_address.py
@@ -14,8 +14,9 @@ class UpdatePartyFromCSVTests(DataTestClient):
 
     def test_update_field_on_party_from_csv(self):
 
-        new_address = "56 Heathwood Road Broadstairs Kent"
+        new_address = "56 Heathwood Road\\r\\n Broadstairs Kent"
         old_address = self.standard_application.end_user.party.address
+        result = "56 Heathwood Road\r\n Broadstairs Kent"
         party_id = self.standard_application.end_user.party.id
 
         with NamedTemporaryFile(suffix=".csv", delete=True) as tmp_file:
@@ -28,7 +29,7 @@ class UpdatePartyFromCSVTests(DataTestClient):
 
             call_command("update_party_address", tmp_file.name)
             self.standard_application.refresh_from_db()
-            self.assertEqual(self.standard_application.end_user.party.address, new_address)
+            self.assertEqual(self.standard_application.end_user.party.address, result)
 
             audit = Audit.objects.get()
 
@@ -38,7 +39,7 @@ class UpdatePartyFromCSVTests(DataTestClient):
             self.assertEqual(
                 audit.payload,
                 {
-                    "address": {"new": new_address, "old": old_address},
+                    "address": {"new": result, "old": old_address},
                     "additional_text": "added by John Smith as per LTD-XXX",
                 },
             )

--- a/api/applications/tests/test_update_party_name.py
+++ b/api/applications/tests/test_update_party_name.py
@@ -14,9 +14,10 @@ class UpdatePartyFromCSVTests(DataTestClient):
 
     def test_update_field_on_party_from_csv(self):
 
-        new_name = "Bangarang 3000"
+        new_name = "Bangarang 3000\\r\\n Skrilly"
         old_name = self.standard_application.end_user.party.name
         party_id = self.standard_application.end_user.party.id
+        result = "Bangarang 3000\r\n Skrilly"
 
         with NamedTemporaryFile(suffix=".csv", delete=True) as tmp_file:
             rows = [
@@ -28,7 +29,7 @@ class UpdatePartyFromCSVTests(DataTestClient):
 
             call_command("update_party_name", tmp_file.name)
             self.standard_application.refresh_from_db()
-            self.assertEqual(self.standard_application.end_user.party.name, new_name)
+            self.assertEqual(self.standard_application.end_user.party.name, result)
 
             audit = Audit.objects.get()
 
@@ -38,7 +39,7 @@ class UpdatePartyFromCSVTests(DataTestClient):
             self.assertEqual(
                 audit.payload,
                 {
-                    "name": {"new": new_name, "old": old_name},
+                    "name": {"new": result, "old": old_name},
                     "additional_text": "added by John Smith as per LTD-XXX",
                 },
             )


### PR DESCRIPTION
### Aim

When saving and extra backslash is added to carriage returns which are common in these variables.  This fixes an issue whereby these commands took account of this on the old variable to be changed but not the new variable being introduced.

[LTD-5623](https://uktrade.atlassian.net/browse/LTD-5623)


[LTD-5623]: https://uktrade.atlassian.net/browse/LTD-5623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ