### PR TITLE
Code coverage change on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,7 +520,7 @@ jobs:
       - git_checkout
       - attach_workspace:
           at: ~/lite-api/tmp
-      - run: pip install coverage diff_cover
+      - run: pip install coverage==7.6.4 diff_cover
       - run: coverage combine tmp
       - run: coverage xml
       - run: coverage html


### PR DESCRIPTION
### Aim

Coverage has released a new version today and it's causing our `check_coverage` job to fail on CircleCI.  If we use the `config.yml `to get it to specifically install the latest working version from yesterday (7.6.4) and the jobs work okay.

[LTD-5647](https://uktrade.atlassian.net/browse/LTD-5647)


[LTD-5647]: https://uktrade.atlassian.net/browse/LTD-5647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ