### PR TITLE
Add destination endpoint

### DIFF
--- a/api/data_workspace/v2/serializers.py
+++ b/api/data_workspace/v2/serializers.py
@@ -2,6 +2,7 @@ import datetime
 
 from rest_framework import serializers
 
+from api.applications.models import PartyOnApplication
 from api.cases.enums import LicenceDecisionType
 from api.cases.models import Case
 from api.staticdata.countries.models import Country
@@ -41,4 +42,21 @@ class CountrySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Country
-        fields = ("code", "name")
+        fields = (
+            "code",
+            "name",
+        )
+
+
+class DestinationSerializer(serializers.ModelSerializer):
+    application_id = serializers.UUIDField()
+    country_code = serializers.CharField(source="party.country.id")
+    type = serializers.CharField(source="party.type")
+
+    class Meta:
+        model = PartyOnApplication
+        fields = (
+            "application_id",
+            "country_code",
+            "type",
+        )

--- a/api/data_workspace/v2/tests/bdd/licences/conftest.py
+++ b/api/data_workspace/v2/tests/bdd/licences/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 
-from api.applications.tests.factories import GoodOnApplicationFactory, StandardApplicationFactory
+from api.applications.tests.factories import (
+    GoodOnApplicationFactory,
+    StandardApplicationFactory,
+    PartyOnApplicationFactory,
+)
 from api.cases.enums import AdviceType
 from api.cases.tests.factories import FinalAdviceFactory
 from api.goods.tests.factories import GoodFactory
@@ -36,6 +40,7 @@ def standard_licence():
     application = StandardApplicationFactory(
         status=CaseStatus.objects.get(status=CaseStatusEnum.FINALISED),
     )
+    party_on_application = PartyOnApplicationFactory(application=application)
     good = GoodFactory(organisation=application.organisation)
     good_on_application = GoodOnApplicationFactory(
         application=application, good=good, quantity=100.0, value=1500, unit=Units.NAR

--- a/api/data_workspace/v2/tests/bdd/licences/conftest.py
+++ b/api/data_workspace/v2/tests/bdd/licences/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from api.applications.models import PartyOnApplication
 from api.applications.tests.factories import (
     GoodOnApplicationFactory,
     StandardApplicationFactory,
@@ -75,3 +76,13 @@ def standard_case_with_final_advice(lu_case_officer):
 def standard_case_with_refused_advice(lu_case_officer, standard_case_with_final_advice):
     standard_case_with_final_advice.advice.update(type=AdviceType.REFUSE)
     return standard_case_with_final_advice
+
+
+@pytest.fixture()
+def licence_with_deleted_party(standard_licence):
+    licence = standard_licence
+    application = licence.case.baseapplication
+    old_party_on_application = PartyOnApplication.objects.get(application=application)
+    new_party_on_application = PartyOnApplicationFactory(application=application)
+    old_party_on_application.delete()
+    return licence

--- a/api/data_workspace/v2/tests/bdd/licences/conftest.py
+++ b/api/data_workspace/v2/tests/bdd/licences/conftest.py
@@ -5,6 +5,7 @@ from api.applications.tests.factories import (
     GoodOnApplicationFactory,
     StandardApplicationFactory,
     PartyOnApplicationFactory,
+    DraftStandardApplicationFactory,
 )
 from api.cases.enums import AdviceType
 from api.cases.tests.factories import FinalAdviceFactory
@@ -86,3 +87,9 @@ def licence_with_deleted_party(standard_licence):
     new_party_on_application = PartyOnApplicationFactory(application=application)
     old_party_on_application.delete()
     return licence
+
+
+@pytest.fixture()
+def draft_application():
+    draft_application = DraftStandardApplicationFactory()
+    return draft_application

--- a/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
+++ b/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
@@ -34,3 +34,38 @@ def country_code_and_type_included_in_extract(destinations):
 
     destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
     assert destination in destinations
+
+
+@given("a licence with deleted party is created", target_fixture="licence_with_deleted_party")
+def licence_with_deleted_party_created(licence_with_deleted_party):
+    assert licence_with_deleted_party.status == LicenceStatus.ISSUED
+    application = licence_with_deleted_party.case.baseapplication
+    assert PartyOnApplication.objects.filter(application=application).count() == 2
+
+
+@then("the existing party is included in the extract")
+def existing_party_included_in_extract(destinations):
+    existing_party_on_application = PartyOnApplication.objects.get(deleted_at__isnull=True)
+    application_id = existing_party_on_application.application.id
+    country_code = existing_party_on_application.party.country.id
+    party_type = existing_party_on_application.party.type
+
+    assert PartyOnApplication.objects.filter(application_id=application_id).count() == 2
+
+    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    assert destination in destinations
+    assert len(destinations) == 1
+
+
+@then("the deleted party is not included in the extract")
+def deleted_party_not_included_in_extract(destinations):
+    deleted_party_on_application = PartyOnApplication.objects.get(deleted_at__isnull=False)
+    application_id = deleted_party_on_application.application.id
+    country_code = deleted_party_on_application.party.country.id
+    party_type = deleted_party_on_application.party.type
+
+    assert PartyOnApplication.objects.filter(application_id=application_id).count() == 2
+
+    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    assert destination not in destinations
+    assert len(destinations) == 1

--- a/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
+++ b/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
@@ -1,0 +1,36 @@
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from django.urls import reverse
+
+from api.applications.models import PartyOnApplication
+from api.licences.enums import LicenceStatus
+
+scenarios("../scenarios/destinations.feature")
+
+
+@pytest.fixture()
+def destinations_list_url():
+    return reverse("data_workspace:v2:dw-destinations-list")
+
+
+@given("a standard licence is created", target_fixture="licence")
+def standard_licence_created(standard_licence):
+    assert standard_licence.status == LicenceStatus.ISSUED
+    return standard_licence
+
+
+@when("I fetch all destinations", target_fixture="destinations")
+def fetch_all_destinations(destinations_list_url, unpage_data):
+    return unpage_data(destinations_list_url)
+
+
+@then("the country code and type are included in the extract")
+def country_code_and_type_included_in_extract(destinations):
+    party_on_application = PartyOnApplication.objects.get()
+    application_id = party_on_application.application.id
+    country_code = party_on_application.party.country.id
+    party_type = party_on_application.party.type
+
+    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    assert destination in destinations

--- a/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
+++ b/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
@@ -28,7 +28,7 @@ def fetch_all_destinations(destinations_list_url, unpage_data):
 @then("the country code and type are included in the extract")
 def country_code_and_type_included_in_extract(destinations):
     party_on_application = PartyOnApplication.objects.get()
-    application_id = party_on_application.application.id
+    application_id = party_on_application.application_id
     country_code = party_on_application.party.country.id
     party_type = party_on_application.party.type
 
@@ -46,7 +46,7 @@ def licence_with_deleted_party_created(licence_with_deleted_party):
 @then("the existing party is included in the extract")
 def existing_party_included_in_extract(destinations):
     existing_party_on_application = PartyOnApplication.objects.get(deleted_at__isnull=True)
-    application_id = existing_party_on_application.application.id
+    application_id = existing_party_on_application.application_id
     country_code = existing_party_on_application.party.country.id
     party_type = existing_party_on_application.party.type
 
@@ -60,7 +60,7 @@ def existing_party_included_in_extract(destinations):
 @then("the deleted party is not included in the extract")
 def deleted_party_not_included_in_extract(destinations):
     deleted_party_on_application = PartyOnApplication.objects.get(deleted_at__isnull=False)
-    application_id = deleted_party_on_application.application.id
+    application_id = deleted_party_on_application.application_id
     country_code = deleted_party_on_application.party.country.id
     party_type = deleted_party_on_application.party.type
 

--- a/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
+++ b/api/data_workspace/v2/tests/bdd/licences/test_destinations.py
@@ -5,6 +5,8 @@ from django.urls import reverse
 
 from api.applications.models import PartyOnApplication
 from api.licences.enums import LicenceStatus
+from api.parties.enums import PartyType
+from api.staticdata.statuses.enums import CaseStatusEnum
 
 scenarios("../scenarios/destinations.feature")
 
@@ -32,7 +34,7 @@ def country_code_and_type_included_in_extract(destinations):
     country_code = party_on_application.party.country.id
     party_type = party_on_application.party.type
 
-    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    destination = {"application_id": str(application_id), "country_code": country_code, "type": party_type}
     assert destination in destinations
 
 
@@ -52,7 +54,7 @@ def existing_party_included_in_extract(destinations):
 
     assert PartyOnApplication.objects.filter(application_id=application_id).count() == 2
 
-    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    destination = {"application_id": str(application_id), "country_code": country_code, "type": party_type}
     assert destination in destinations
     assert len(destinations) == 1
 
@@ -66,6 +68,58 @@ def deleted_party_not_included_in_extract(destinations):
 
     assert PartyOnApplication.objects.filter(application_id=application_id).count() == 2
 
-    destination = {"application_id": application_id, "country_code": country_code, "type": party_type}
+    destination = {"application_id": str(application_id), "country_code": country_code, "type": party_type}
     assert destination not in destinations
+    assert len(destinations) == 1
+
+
+@given("a draft application is created")
+def draft_application_created(draft_application):
+    assert draft_application.status.status == CaseStatusEnum.DRAFT
+    return draft_application
+
+
+@then("the non-draft party is included in the extract")
+def non_draft_party_is_included_in_extract(destinations):
+    non_draft_party_on_application = PartyOnApplication.objects.get(
+        application__status__status=CaseStatusEnum.FINALISED
+    )
+    application_id = non_draft_party_on_application.application_id
+    country_code = non_draft_party_on_application.party.country.id
+    party_type = non_draft_party_on_application.party.type
+
+    destination = {"application_id": str(application_id), "country_code": country_code, "type": party_type}
+    assert destination in destinations
+    assert len(destinations) == 1
+
+
+@then("draft parties are not included in the extract")
+def draft_parties_not_included_in_extract(destinations):
+    draft_parties_on_application = PartyOnApplication.objects.filter(application__status__status=CaseStatusEnum.DRAFT)
+
+    application_id = draft_parties_on_application.first().application_id
+
+    draft_end_user = draft_parties_on_application.get(party__type=PartyType.END_USER)
+    draft_end_user_country_code = draft_end_user.party.country.id
+    draft_end_user_party_type = draft_end_user.party.type
+
+    assert PartyOnApplication.objects.filter(application_id=application_id).count() == 2
+
+    draft_end_user_destination = {
+        "application_id": str(application_id),
+        "country_code": draft_end_user_country_code,
+        "type": draft_end_user_party_type,
+    }
+    assert draft_end_user_destination not in destinations
+
+    draft_consignee = draft_parties_on_application.get(party__type=PartyType.CONSIGNEE)
+    draft_consignee_country_code = draft_consignee.party.country.id
+    draft_consignee_party_type = draft_consignee.party.type
+
+    draft_consignee_destination = {
+        "application_id": str(application_id),
+        "country_code": draft_consignee_country_code,
+        "party_type": draft_consignee_party_type,
+    }
+    assert draft_consignee_destination not in destinations
     assert len(destinations) == 1

--- a/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
+++ b/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
@@ -5,3 +5,9 @@ Scenario: Check that the country code and type are included in the extract
     Given a standard licence is created
     When I fetch all destinations
     Then the country code and type are included in the extract
+
+Scenario: Deleted parties are not included in the extract
+    Given a licence with deleted party is created
+    When I fetch all destinations
+    Then the existing party is included in the extract
+    And the deleted party is not included in the extract

--- a/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
+++ b/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
@@ -1,0 +1,7 @@
+@db
+Feature: Destinations
+
+Scenario: Check that the country code and type are included in the extract
+    Given a standard licence is created
+    When I fetch all destinations
+    Then the country code and type are included in the extract

--- a/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
+++ b/api/data_workspace/v2/tests/bdd/scenarios/destinations.feature
@@ -11,3 +11,10 @@ Scenario: Deleted parties are not included in the extract
     When I fetch all destinations
     Then the existing party is included in the extract
     And the deleted party is not included in the extract
+
+Scenario: Draft applications are not included in the extract
+    Given a standard licence is created
+    And a draft application is created
+    When I fetch all destinations
+    Then the non-draft party is included in the extract
+    And draft parties are not included in the extract

--- a/api/data_workspace/v2/urls.py
+++ b/api/data_workspace/v2/urls.py
@@ -1,8 +1,8 @@
-from api.data_workspace.v2 import views
-
 from api.data_workspace.metadata.routers import TableMetadataRouter
+from api.data_workspace.v2 import views
 
 
 router_v2 = TableMetadataRouter()
 router_v2.register(views.LicenceDecisionViewSet)
 router_v2.register(views.CountryViewSet)
+router_v2.register(views.DestinationViewSet)


### PR DESCRIPTION
The basic test is for the response data from the endpoint being in the right format as expected. There is another test for deleting a party. When a case is in non-draft state, deleting a party uses a different `.delete()` method which actually does not delete the record, but instead sets a `deleted_at` field with the current datetime. It is important that these "deleted" parties do not appear as destinations in the published data so the test checks they are not included.

[LTD-5650](https://uktrade.atlassian.net/browse/LTD-5650)

[LTD-5650]: https://uktrade.atlassian.net/browse/LTD-5650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ