### PR TITLE
hot-fix-dbt-endesive

### DIFF
--- a/.copilot/phases/pre_build.sh
+++ b/.copilot/phases/pre_build.sh
@@ -23,3 +23,6 @@ url = $git_clone_base_url/django-db-anonymiser.git
 EOF
 
 git submodule update --init --recursive
+
+sed -i 's/\[packages\]/[packages]\nendesive = "~=1.5.9"/' Pipfile
+pipenv lock


### PR DESCRIPTION
HOT Fix for dbt-platform endesive not installed

this is required for UAT testing on PROD DBT Platform. 

This has been tested on DBT and will be tested by deployed to Support. 
No Gov-paas release is required as it has no impact.. 