### PR TITLE
[LTD-5712] Add exclude_flags parameter to case search view

### DIFF
--- a/api/cases/tests/test_case_search.py
+++ b/api/cases/tests/test_case_search.py
@@ -34,8 +34,6 @@ from test_helpers.clients import DataTestClient
 from api.users.enums import UserStatuses
 from api.users.models import GovUser
 from api.cases.tests import factories
-from api.cases.enums import AdviceType
-from api.staticdata.statuses.enums import CaseStatusEnum
 from api.teams.models import Team
 from api.cases.views.search.service import (
     get_case_status_list,
@@ -55,6 +53,7 @@ class FilterAndSortTests(DataTestClient):
         self.url = reverse("cases:search")
         statuses = [CaseStatusEnum.SUBMITTED, CaseStatusEnum.CLOSED, CaseStatusEnum.WITHDRAWN]
 
+        Case.objects.all().delete()
         self.application_cases = []
         for app_status in statuses:
             case = self.create_standard_application_case(
@@ -552,6 +551,57 @@ class FilterAndSortTests(DataTestClient):
 
         for case in response_data["cases"]:
             self.assertIn(flag_id, [item["id"] for item in case[flags_key]])
+
+    def test_filter_cases_exclude_flags_case_level(self):
+        # set required flags
+        application = self.application_cases[0]
+        case = Case.objects.get(id=application.id)
+        flag_id = FlagsEnum.GOODS_NOT_LISTED
+        flag = Flag.objects.get(id=flag_id)
+        case.flags.add(flag)
+
+        url = f"{self.url}?exclude_flags={flag_id}"
+
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for search_result_case in response_data["cases"]:
+            self.assertNotEqual(search_result_case["id"], str(case.id))
+
+    def test_filter_cases_exclude_flags_good_level(self):
+        # set required flags
+        application = self.application_cases[0]
+        good = application.goods.all()[0].good
+        flag_id = FlagsEnum.WASSENAAR
+        flag = Flag.objects.get(id=flag_id)
+        good.flags.add(flag)
+
+        url = f"{self.url}?exclude_flags={flag_id}"
+
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for search_result_case in response_data["cases"]:
+            self.assertNotEqual(search_result_case["id"], str(application.id))
+
+    def test_filter_cases_exclude_flags_destination_level(self):
+        # set required flags
+        application = self.application_cases[0]
+        destination = application.parties.all()[0].party
+        flag_id = FlagsEnum.MOD_DI_COUNTRY_OF_INTEREST
+        flag = Flag.objects.get(id=flag_id)
+        destination.flags.add(flag)
+
+        url = f"{self.url}?exclude_flags={flag_id}"
+
+        response = self.client.get(url, **self.gov_headers)
+        response_data = response.json()["results"]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for search_result_case in response_data["cases"]:
+            self.assertNotEqual(search_result_case["id"], str(application.id))
 
     @parameterized.expand(["permanent", "temporary"])
     def test_get_cases_filter_by_export_type(self, export_type):

--- a/api/cases/views/search/views.py
+++ b/api/cases/views/search/views.py
@@ -129,7 +129,11 @@ class CasesSearchView(generics.ListAPIView):
         )
 
     def get_filters(self, request):
-        filters = {key: value for key, value in request.GET.items() if key not in ["hidden", "queue_id", "flags"]}
+        filters = {
+            key: value
+            for key, value in request.GET.items()
+            if key not in ["hidden", "queue_id", "flags", "exclude_flags"]
+        }
 
         search_tabs = ("my_cases", "open_queries")
         selected_tab = request.GET.get("selected_tab")
@@ -143,6 +147,7 @@ class CasesSearchView(generics.ListAPIView):
                 del filters["max_total_value"]
 
         filters["flags"] = request.GET.getlist("flags", [])
+        filters["exclude_flags"] = request.GET.getlist("exclude_flags", [])
         filters["regime_entry"] = [regime for regime in request.GET.getlist("regime_entry", []) if regime]
         filters["exclude_regime_entry"] = request.GET.get("exclude_regime_entry", False)
         filters["control_list_entry"] = [cle for cle in request.GET.getlist("control_list_entry", []) if cle]


### PR DESCRIPTION
### Aim

Adds a filter to the case search view enabling callers to exclude cases which have specified flags.  Cases will be excluded if the case, any party or any good related to the case are associated with any flags in the `exclude_flags` value.

[LTD-5712](https://uktrade.atlassian.net/browse/LTD-5712)
