### PR TITLE
Use cursor pagination for goods endpoint

### DIFF
--- a/api/conf/pagination.py
+++ b/api/conf/pagination.py
@@ -25,3 +25,7 @@ class MaxFiftyPageSizePaginator(MaxPageNumberPagination):
     page_size = 50
     page_size_query_param = "page_size"
     max_page_size = 50
+
+
+class CreatedAtCursorPagination(pagination.CursorPagination):
+    ordering = "-created_at"

--- a/api/data_workspace/v1/good_views.py
+++ b/api/data_workspace/v1/good_views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets
 from rest_framework.pagination import LimitOffsetPagination
 
+from api.conf.pagination import CreatedAtCursorPagination
 from api.goods import models, serializers
 from api.core.authentication import DataWorkspaceOnlyAuthentication
 
@@ -8,7 +9,7 @@ from api.core.authentication import DataWorkspaceOnlyAuthentication
 class GoodListView(viewsets.ReadOnlyModelViewSet):
     authentication_classes = (DataWorkspaceOnlyAuthentication,)
     serializer_class = serializers.GoodSerializerInternalIncludingPrecedents
-    pagination_class = LimitOffsetPagination
+    pagination_class = CreatedAtCursorPagination
     queryset = models.Good.objects.all()
 
 


### PR DESCRIPTION
This is to ensure consistent results across pages

Currently it's possible that duplicates can occur as the order of the queryset isn't deterministic

[LTD-5718](https://uktrade.atlassian.net/browse/LTD-5718)


[LTD-5718]: https://uktrade.atlassian.net/browse/LTD-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ