### PR TITLE
LTD-5760 remove CRN check against rejected organisations

### DIFF
--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -504,8 +504,7 @@ class OrganisationRegistrationNumberSerializer(serializers.Serializer):
         if not self.instance:
             if (
                 Organisation.objects.filter(registration_number=value)
-                .exclude(status=OrganisationStatus.REJECTED)
-                .exclude(status=OrganisationStatus.DRAFT)
+                .exclude(status__in=[OrganisationStatus.REJECTED, OrganisationStatus.DRAFT])
                 .exists()
             ):
                 raise serializers.ValidationError("This registration number is already in use.")

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -505,6 +505,7 @@ class OrganisationRegistrationNumberSerializer(serializers.Serializer):
             if (
                 Organisation.objects.filter(registration_number=value)
                 .exclude(status=OrganisationStatus.REJECTED)
+                .exclude(status=OrganisationStatus.DRAFT)
                 .exists()
             ):
                 raise serializers.ValidationError("This registration number is already in use.")

--- a/api/organisations/serializers.py
+++ b/api/organisations/serializers.py
@@ -502,7 +502,11 @@ class OrganisationRegistrationNumberSerializer(serializers.Serializer):
     def validate_registration_number(self, value):
         # Check for uniqueness only when creating a new Organisation
         if not self.instance:
-            if Organisation.objects.filter(registration_number=value).exists():
+            if (
+                Organisation.objects.filter(registration_number=value)
+                .exclude(status=OrganisationStatus.REJECTED)
+                .exists()
+            ):
                 raise serializers.ValidationError("This registration number is already in use.")
 
         return value

--- a/api/organisations/tests/test_organisations.py
+++ b/api/organisations/tests/test_organisations.py
@@ -973,9 +973,10 @@ class ValidateRegistrationNumberTests(DataTestClient):
             response.json(), {"errors": {"registration_number": ["This registration number is already in use."]}}
         )
 
-    def test_validate_registration_number_success_if_rejected_crn_used(self):
+    @parameterized.expand([OrganisationStatus.REJECTED, OrganisationStatus.DRAFT])
+    def test_validate_registration_number_success_for_rejected_or_draft_org(self, org_status):
         self.organisation.refresh_from_db()
-        self.organisation.status = OrganisationStatus.REJECTED
+        self.organisation.status = org_status
         self.organisation.save()
         data = {"registration_number": self.organisation.registration_number}
         response = self.client.post(self.url, data, **self.exporter_headers)

--- a/api/organisations/tests/test_organisations.py
+++ b/api/organisations/tests/test_organisations.py
@@ -1,7 +1,6 @@
 import pytest
 
 from unittest import mock
-from django.conf import settings
 from faker import Faker
 from parameterized import parameterized
 
@@ -14,7 +13,6 @@ from api.audit_trail.models import Audit
 from api.core.authentication import EXPORTER_USER_TOKEN_HEADER
 from api.core.constants import Roles, GovPermissions
 from lite_content.lite_api.strings import Organisations
-from api.organisations.constants import UK_VAT_VALIDATION_REGEX, UK_EORI_VALIDATION_REGEX
 from api.organisations.enums import OrganisationType, OrganisationStatus
 from api.organisations.tests.factories import OrganisationFactory
 from api.organisations.models import Organisation
@@ -974,3 +972,12 @@ class ValidateRegistrationNumberTests(DataTestClient):
         self.assertEqual(
             response.json(), {"errors": {"registration_number": ["This registration number is already in use."]}}
         )
+
+    def test_validate_registration_number_success_if_rejected_crn_used(self):
+        self.organisation.refresh_from_db()
+        self.organisation.status = OrganisationStatus.REJECTED
+        self.organisation.save()
+        data = {"registration_number": self.organisation.registration_number}
+        response = self.client.post(self.url, data, **self.exporter_headers)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), data)


### PR DESCRIPTION
### Aim

Remove validation agains a rejected CRN when and exporter registers.

as per ticket: 'The change here is to only validate against CRNs where the registration that are either pending or approved.'

[LTD-5760](https://uktrade.atlassian.net/browse/LTD-5760)


[LTD-5760]: https://uktrade.atlassian.net/browse/LTD-5760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ