### PR TITLE
LTD-5801 Make product and end user sections required

### DIFF
--- a/api/applications/creators.py
+++ b/api/applications/creators.py
@@ -276,7 +276,8 @@ def _validate_standard_licence(draft, errors):
 
 
 def _validate_f680(draft, errors):
-    # placeholder as we don't want anything required in the tasklist currently
+    errors = _validate_end_user(draft, errors, is_mandatory=True)
+    errors = _validate_goods(draft, errors, is_mandatory=True)
     return errors
 
 


### PR DESCRIPTION
### Aim

Uses existing validation functions to make `end_user` and product/goods section of application required by api.  This passes validation error to frontend to be presented to the user.

[LTD-5801](https://uktrade.atlassian.net/browse/LTD-5801)


[LTD-5801]: https://uktrade.atlassian.net/browse/LTD-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ