### PR TITLE
Add hawk authentication to table metadata endpoint

### DIFF
--- a/api/data_workspace/metadata/routers.py
+++ b/api/data_workspace/metadata/routers.py
@@ -13,11 +13,14 @@ from django.urls import (
     path,
 )
 
+from api.core.authentication import DataWorkspaceOnlyAuthentication
+
 
 class TableMetadataView(APIView):
     _ignore_model_permissions = True
     schema = None  # exclude from schema
     metadata = None
+    authentication_classes = (DataWorkspaceOnlyAuthentication,)
 
     def get(self, request, *args, **kwargs):
         tables = []


### PR DESCRIPTION
### Aim

The table metadata endpoint wasn't checking HAWK authentication.

This makes that happen.

[LTD-5875](https://uktrade.atlassian.net/browse/LTD-5875)


[LTD-5875]: https://uktrade.atlassian.net/browse/LTD-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ