### PR TITLE
LTD-5892-improve-sanction-matching-exact 

### DIFF
--- a/api/applications/helpers.py
+++ b/api/applications/helpers.py
@@ -195,7 +195,8 @@ def normalize_address(value):
 
 
 def build_query(name):
-    return Q("match", name=name)
+    # Exact order and terms
+    query = Q("match_phrase", name=name)
 
 
 def reset_appeal_deadline(application):

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -405,7 +405,7 @@ SANCTION_LIST_SOURCES = env.json(
     {
         "un_sanctions_file": "https://scsanctions.un.org/resources/xml/en/consolidated.xml",
         "office_financial_sanctions_file": "https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.xml",
-        "uk_sanctions_file": "https://assets.publishing.service.gov.uk/media/6776a7d49d03f12136308d1c/UK_Sanctions_List.xml",  # /PS-IGNORE
+        "uk_sanctions_file": "https://assets.publishing.service.gov.uk/media/679b8f9eabe77b74cc146c71/UK_Sanctions_List.xml",  # /PS-IGNORE
     },
 )
 LITE_INTERNAL_NOTIFICATION_EMAILS = env.json("LITE_INTERNAL_NOTIFICATION_EMAILS", {})


### PR DESCRIPTION

https://uktrade.atlassian.net/browse/LTD-5892

It has been agreed with the business
that sanction matches will be exact phrase search to reduce the high number of false positives.

We did explore and present a solution that matches in any order but this is preferred for now.