### PR TITLE
LTD-5892-improve-sanction-matching-exact-match

### DIFF
--- a/api/applications/helpers.py
+++ b/api/applications/helpers.py
@@ -158,6 +158,7 @@ def delete_uploaded_document(data):
 
 def auto_match_sanctions(application):
     parties = []
+
     if application.end_user:
         parties.append(application.end_user.party)
 
@@ -178,16 +179,16 @@ def auto_match_sanctions(application):
             pass
         else:
             for match in matches:
-                if match.meta.score > 0.5:
-                    party_on_application = application.parties.get(party=party)
-                    reference = match["reference"][0]
-                    if not party_on_application.sanction_matches.filter(elasticsearch_reference=reference).exists():
-                        SanctionMatch.objects.create(
-                            party_on_application=party_on_application,
-                            elasticsearch_reference=reference,
-                            name=match["name"],
-                            flag_uuid=match["flag_uuid"],
-                        )
+                party_on_application = application.parties.get(party=party)
+                reference = match["reference"][0]
+
+                if not party_on_application.sanction_matches.filter(elasticsearch_reference=reference).exists():
+                    SanctionMatch.objects.create(
+                        party_on_application=party_on_application,
+                        elasticsearch_reference=reference,
+                        name=match["name"],
+                        flag_uuid=match["flag_uuid"],
+                    )
 
 
 def normalize_address(value):
@@ -195,8 +196,7 @@ def normalize_address(value):
 
 
 def build_query(name):
-    # Exact order and terms
-    return Q("match_phrase", name=name)
+    return Q("term", name=name)
 
 
 def reset_appeal_deadline(application):

--- a/api/applications/helpers.py
+++ b/api/applications/helpers.py
@@ -195,7 +195,8 @@ def normalize_address(value):
 
 
 def build_query(name):
-    return Q("match", name=name)
+    # Exact order and terms
+    return Q("match_phrase", name=name)
 
 
 def reset_appeal_deadline(application):

--- a/api/applications/tests/test_helpers.py
+++ b/api/applications/tests/test_helpers.py
@@ -98,14 +98,12 @@ class AbstractAutoMatchTests:
             self.assertEqual(party_on_application.flags.count(), 0)
 
     @pytest.mark.elasticsearch
-    def test_auto_match_sanctions_match_name_similar(self):
-        """This test exposes the fact that ES tokenization etc. would mean
-        that the following names will be matched to "Jeremy Jackson". There is
-        no simple way around this.
+    def test_auto_match_sanctions_match_name_exact(self):
+        """Sanctions matching uses phrase matching
+        Any name that martches in search term will be returned
         """
         names = [
-            "Jackson, Jeremy",
-            "Jackson Jeremy",
+            "Jeremy Jackson",
             "Mr. Jeremy Jackson",
         ]
 

--- a/api/conf/settings.py
+++ b/api/conf/settings.py
@@ -405,7 +405,7 @@ SANCTION_LIST_SOURCES = env.json(
     {
         "un_sanctions_file": "https://scsanctions.un.org/resources/xml/en/consolidated.xml",
         "office_financial_sanctions_file": "https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.xml",
-        "uk_sanctions_file": "https://assets.publishing.service.gov.uk/media/6776a7d49d03f12136308d1c/UK_Sanctions_List.xml",  # /PS-IGNORE
+        "uk_sanctions_file": "https://assets.publishing.service.gov.uk/media/679b8f9eabe77b74cc146c71/UK_Sanctions_List.xml",  # /PS-IGNORE
     },
 )
 LITE_INTERNAL_NOTIFICATION_EMAILS = env.json("LITE_INTERNAL_NOTIFICATION_EMAILS", {})

--- a/api/external_data/documents.py
+++ b/api/external_data/documents.py
@@ -22,6 +22,26 @@ name_analyzer = analysis.analyzer(
     filter=["lowercase", "trim", custom_ascii_folding_filter],
 )
 
+
+name_filter = analysis.char_filter(
+    "name_filter",
+    type="pattern_replace",
+    pattern="[\\s+]|[-]|[.]|[,]|[']",
+    replacement="",
+)
+
+
+name_normalizer = analysis.normalizer(
+    "name_normalizer",
+    type="custom",
+    char_filter=[name_filter],
+    filter=[
+        "trim",
+        "lowercase",
+        "asciifolding",
+    ],
+)
+
 postcode_filter = analysis.char_filter(
     "postcode_filter",
     type="pattern_replace",
@@ -137,7 +157,7 @@ class SanctionDocumentType(Document):
 
     flag_uuid = fields.Keyword()
     reference = fields.Keyword()
-    name = fields.Text(analyzer=name_analyzer)
+    name = fields.Keyword(normalizer=name_normalizer)
     address = fields.Text(analyzer=address_analyzer)
     postcode = fields.Keyword(normalizer=postcode_normalizer)
 

--- a/api/external_data/management/commands/tests/test_ingest_sanctions.py
+++ b/api/external_data/management/commands/tests/test_ingest_sanctions.py
@@ -99,11 +99,11 @@ class PopulateSanctionsTests(DataTestClient):
                         "monthofbirth": None,
                         "name1": "Haji",
                         "name2": "Agha",
-                        "name3": None,
-                        "name4": None,
+                        "name3": "Abdul",
+                        "name4": "Manan",
                         "name5": None,
-                        "name6": "Abdul Manan",
-                        "nametitle": "Haji",
+                        "name6": None,
+                        "nametitle": "",
                         "nationalidnumber": None,
                         "nationality": None,
                         "orgtype": None,
@@ -186,27 +186,20 @@ class PopulateSanctionsTests(DataTestClient):
 
         search = Search(index=documents.SanctionDocumentType.Index.name)
 
-        results_one = search.query("match", name="RI WON HO").execute()
+        results_one = search.query("term", name="RI WON HO").execute()
         self.assertEqual(len(results_one.hits), 1)
         self.assertEqual(results_one.hits[0]["name"], "RI WON HO")
         self.assertEqual(results_one.hits[0]["flag_uuid"], "00000000-0000-0000-0000-000000000039")
         self.assertEqual(results_one.hits[0]["reference"], "6908555")
 
-        results_two = search.query("match", name="PROPAGANDA AND AGITATION DEPARTMENT").execute()
-        self.assertEqual(len(results_two.hits), 1)
-        self.assertEqual(results_two.hits[0]["name"], "PROPAGANDA AND AGITATION DEPARTMENT (PAD)")
-        self.assertEqual(results_two.hits[0]["flag_uuid"], "00000000-0000-0000-0000-000000000039")
-        self.assertEqual(results_two.hits[0]["reference"], "6908629")
+        results_two = search.query("term", name="PROPAGANDA AND AGITATION DEPARTMENT").execute()
+        self.assertEqual(len(results_two.hits), 0)
 
-        results_three = search.query("match", name="Haji Agha Abdul Manan").execute()
-        self.assertEqual(len(results_three.hits), 2)
+        results_three = search.query("term", name="Haji Agha Abdul Manan").execute()
+        self.assertEqual(len(results_three.hits), 1)
         self.assertEqual(results_three.hits[0]["name"], "Haji Agha Abdul Manan")
         self.assertEqual(results_three.hits[0]["flag_uuid"], "00000000-0000-0000-0000-000000000040")
         self.assertEqual(results_three.hits[0]["reference"], "6897")
-
-        self.assertEqual(results_three.hits[1]["name"], "HAJI KHAIRULLAH HAJI SATTAR MONEY EXCHANGE")
-        self.assertEqual(results_three.hits[1]["flag_uuid"], "00000000-0000-0000-0000-000000000041")
-        self.assertEqual(results_three.hits[1]["reference"], "1234")
 
     @pytest.mark.elasticsearch
     @mock.patch.object(ingest_sanctions, "get_un_sanctions")
@@ -476,7 +469,7 @@ class PopulateSanctionsTests(DataTestClient):
                         "lengthofvessel": None,
                         "listingtype": "UK and UN",
                         "monthofbirth": None,
-                        "name1": "Haji",
+                        "name1": "Haji Agha Abdul Manan",
                         "name2": "Agha",
                         "name3": None,
                         "name4": None,
@@ -571,7 +564,7 @@ class PopulateSanctionsTests(DataTestClient):
             "2020-12-10T00:00:00",
         )
 
-        doc = documents.SanctionDocumentType.get("ofs:28f40249140f9c08d1d0172fb834dea1")  # /PS-IGNORE
+        doc = documents.SanctionDocumentType.get("ofs:4fabaa6acac29b31d18aa0a5e7847b70")  # /PS-IGNORE
         self.assertEqual(
             doc.data.lastupdated,
             "2020-12-31T00:00:00",


### PR DESCRIPTION
    https://uktrade.atlassian.net/browse/LTD-5892

It has been agreed with the business
that sanction matches will be exact phrase search to reduce the high number of false positives.

We did explore and present a solution that matches in any order but this is preferred for now.

We should get a couple of problem cases from prod with end part signature names that causing issues. 
Create a case with the same names in that environment and present the results to business on a real case. 
