### PR TITLE
[LTD-5908] Submit F680 application

### DIFF
--- a/api/f680/caseworker/serializers.py
+++ b/api/f680/caseworker/serializers.py
@@ -22,5 +22,6 @@ class F680ApplicationSerializer(serializers.ModelSerializer):  # /PS-IGNORE
             "organisation",
             "submitted_at",
             "submitted_by",
+            "name",
         ]
         read_only_fields = ["id", "status", "reference_code", "organisation", "submitted_at", "submitted_by"]

--- a/api/f680/exporter/filters.py
+++ b/api/f680/exporter/filters.py
@@ -1,0 +1,10 @@
+from rest_framework import filters
+
+from api.staticdata.statuses.enums import CaseStatusEnum
+from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+
+
+class DraftApplicationFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        draft_status = get_case_status_by_status(CaseStatusEnum.DRAFT)
+        return queryset.filter(status=draft_status)

--- a/api/f680/exporter/urls.py
+++ b/api/f680/exporter/urls.py
@@ -7,12 +7,17 @@ app_name = "exporter_f680"
 urlpatterns = [
     path(
         "application/",
-        F680ApplicationViewSet.as_view({"get": "list", "post": "create"}),  # /PS-IGNORE
+        F680ApplicationViewSet.as_view({"get": "list", "post": "create"}),
         name="applications",
     ),
     path(
         "application/<uuid:f680_application_id>/",
-        F680ApplicationViewSet.as_view({"get": "retrieve", "patch": "partial_update"}),  # /PS-IGNORE
+        F680ApplicationViewSet.as_view({"get": "retrieve", "patch": "partial_update"}),
         name="application",
+    ),
+    path(
+        "application/<uuid:f680_application_id>/submit/",
+        F680ApplicationViewSet.as_view({"post": "submit"}),
+        name="application_submit",
     ),
 ]

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -49,6 +49,7 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         application.sla_days = 0
         application.submitted_by = request.user.exporteruser
         application.save()
+        application.on_submit()
 
         apply_flagging_rules_to_case(application)
         queues_assigned = run_routing_rules(application)

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -17,6 +17,7 @@ from lite_routing.routing_rules_internal.routing_engine import run_routing_rules
 
 from api.f680.models import F680Application
 from api.f680.exporter.serializers import F680ApplicationSerializer
+from api.f680.exporter.filters import DraftApplicationFilter
 
 
 class F680ApplicationViewSet(viewsets.ModelViewSet):
@@ -24,7 +25,7 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
     serializer_class = F680ApplicationSerializer
     queryset = F680Application.objects.all()
     lookup_url_kwarg = "f680_application_id"
-    filter_backends = [CurrentExporterUserOrganisationFilter]
+    filter_backends = [CurrentExporterUserOrganisationFilter, DraftApplicationFilter]
 
     def get_serializer_context(self):
         serializer_context = super().get_serializer_context()

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -1,11 +1,19 @@
+from django.utils import timezone
+
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from api.cases.enums import CaseTypeEnum
+from api.cases.celery_tasks import get_application_target_sla
+from api.cases.models import CaseQueueMovement
 from api.core.authentication import ExporterAuthentication
 from api.organisations.libraries.get_organisation import get_request_user_organisation
 from api.organisations.filters import CurrentExporterUserOrganisationFilter
 from api.staticdata.statuses.enums import CaseStatusEnum
 from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
+from lite_routing.routing_rules_internal.flagging_engine import apply_flagging_rules_to_case
+from lite_routing.routing_rules_internal.routing_engine import run_routing_rules
 
 from api.f680.models import F680Application
 from api.f680.exporter.serializers import F680ApplicationSerializer
@@ -24,3 +32,30 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         serializer_context["default_status"] = get_case_status_by_status(CaseStatusEnum.DRAFT)
         serializer_context["case_type_id"] = CaseTypeEnum.F680.id
         return serializer_context
+
+    @action(detail=True)
+    def submit(self, request, **kwargs):
+        # TODO: What follows is a lean slice of applications.views.applications.ApplicationSubmission.
+        #   We should review exactly how best to structure application submission; it could be better
+        #   to depend on a model method, a library utility, or something else
+        application = self.get_object()
+
+        # TODO: some sort of validation that we have everything we need on the application -
+        #   this may duplicate frontend validation in some way so needs some consideration.
+
+        application.status = get_case_status_by_status(CaseStatusEnum.SUBMITTED)
+        application.submitted_at = timezone.now()
+        application.sla_remaining_days = get_application_target_sla(application.case_type.sub_type)
+        application.sla_days = 0
+        application.submitted_by = request.user.exporteruser
+        application.save()
+
+        apply_flagging_rules_to_case(application)
+        queues_assigned = run_routing_rules(application)
+        for queue in queues_assigned:
+            CaseQueueMovement.objects.create(
+                case=application.case_ptr, queue_id=queue, created_at=application.submitted_at
+            )
+
+        serializer = self.get_serializer(application)
+        return Response(serializer.data)

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -38,12 +38,12 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
     def submit(self, request, **kwargs):
         # TODO: What follows is a lean slice of applications.views.applications.ApplicationSubmission.
         #   We should review exactly how best to structure application submission; it could be better
-        #   to depend on a model method, a library utility, or something else
+        #   to depend on a model method, a library utility, or something else.  We should also think about
+        #   commonality with StandardApplication
         application = self.get_object()
 
         # TODO: some sort of validation that we have everything we need on the application -
         #   this may duplicate frontend validation in some way so needs some consideration.
-
         application.status = get_case_status_by_status(CaseStatusEnum.SUBMITTED)
         application.submitted_at = timezone.now()
         application.sla_remaining_days = get_application_target_sla(application.case_type.sub_type)

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -5,30 +5,18 @@ from api.applications.models import BaseApplication
 from api.f680.managers import F680ApplicationQuerySet
 
 
-class Hasher(dict):
-    # https://stackoverflow.com/a/3405143/190597
-    def __missing__(self, key):
-        value = self[key] = type(self)()
-        return value
-
-
 class F680Application(BaseApplication):  # /PS-IGNORE
     objects = F680ApplicationQuerySet.as_manager()
 
     application = models.JSONField()
 
-    @property
-    def application_dict(self):
-        if not isinstance(self.application, dict):
-            return Hasher({})
-        return Hasher(self.application)
-
     def get_application_field_value(self, section, field_key):
         # TODO: investigate wrapping up accessing fields on application JSON with some OOP
-        section_fields = self.application_dict["sections"][section]["fields"]
+        #   we should be able to solve all the chained .gets() with a decent interface
+        section_fields = self.application.get("sections", {}).get(section, {}).get("fields", [])
         for field in section_fields:
-            if field["key"] == field_key:
-                return field["raw_answer"]
+            if field.get("key") == field_key:
+                return field.get("raw_answer")
         return None
 
     def on_submit(self):

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -5,7 +5,33 @@ from api.applications.models import BaseApplication
 from api.f680.managers import F680ApplicationQuerySet
 
 
+class Hasher(dict):
+    # https://stackoverflow.com/a/3405143/190597
+    def __missing__(self, key):
+        value = self[key] = type(self)()
+        return value
+
+
 class F680Application(BaseApplication):  # /PS-IGNORE
     objects = F680ApplicationQuerySet.as_manager()
 
     application = models.JSONField()
+
+    @property
+    def application_dict(self):
+        if not isinstance(self.application, dict):
+            return Hasher({})
+        return Hasher(self.application)
+
+    def get_application_field_value(self, section, field_key):
+        # TODO: investigate wrapping up accessing fields on application JSON with some OOP
+        section_fields = self.application_dict["sections"][section]["fields"]
+        for field in section_fields:
+            if field["key"] == field_key:
+                return field["raw_answer"]
+        return None
+
+    def on_submit(self):
+        # TODO: Flesh out field promotion
+        self.name = self.get_application_field_value("general_application_details", "name")
+        self.save()

--- a/api/f680/tests/test_models.py
+++ b/api/f680/tests/test_models.py
@@ -26,17 +26,17 @@ class TestF680Application:
 
     def test_on_submit_name_present_in_application_json(self, data_application_json):
         f680_application = F680ApplicationFactory(application=data_application_json)
-        assert f680_application.name == None
+        assert f680_application.name is None
         f680_application.on_submit()
         f680_application.refresh_from_db()
         assert f680_application.name == "some name"
 
     def test_on_submit_name_missing_in_application_json(self):
         f680_application = F680ApplicationFactory()
-        assert f680_application.name == None
+        assert f680_application.name is None
         f680_application.on_submit()
         f680_application.refresh_from_db()
-        assert f680_application.name == None
+        assert f680_application.name is None
 
     def test_get_application_field_value_field_present(self, data_application_json):
         f680_application = F680ApplicationFactory(application=data_application_json)
@@ -44,8 +44,8 @@ class TestF680Application:
 
     def test_get_application_field_value_field_missing(self, data_application_json):
         f680_application = F680ApplicationFactory(application=data_application_json)
-        assert f680_application.get_application_field_value("general_application_details", "foo") == None
+        assert f680_application.get_application_field_value("general_application_details", "foo") is None
 
     def test_get_application_field_value_section_missing(self, data_application_json):
         f680_application = F680ApplicationFactory(application=data_application_json)
-        assert f680_application.get_application_field_value("bar", "name") == None
+        assert f680_application.get_application_field_value("bar", "name") is None

--- a/api/f680/tests/test_models.py
+++ b/api/f680/tests/test_models.py
@@ -1,0 +1,51 @@
+import pytest
+
+from .factories import F680ApplicationFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def data_application_json():
+    return {
+        "sections": {
+            "general_application_details": {
+                "fields": [
+                    {
+                        "key": "name",
+                        "raw_answer": "some name",
+                    }
+                ]
+            }
+        }
+    }
+
+
+class TestF680Application:
+
+    def test_on_submit_name_present_in_application_json(self, data_application_json):
+        f680_application = F680ApplicationFactory(application=data_application_json)
+        assert f680_application.name == None
+        f680_application.on_submit()
+        f680_application.refresh_from_db()
+        assert f680_application.name == "some name"
+
+    def test_on_submit_name_missing_in_application_json(self):
+        f680_application = F680ApplicationFactory()
+        assert f680_application.name == None
+        f680_application.on_submit()
+        f680_application.refresh_from_db()
+        assert f680_application.name == None
+
+    def test_get_application_field_value_field_present(self, data_application_json):
+        f680_application = F680ApplicationFactory(application=data_application_json)
+        assert f680_application.get_application_field_value("general_application_details", "name") == "some name"
+
+    def test_get_application_field_value_field_missing(self, data_application_json):
+        f680_application = F680ApplicationFactory(application=data_application_json)
+        assert f680_application.get_application_field_value("general_application_details", "foo") == None
+
+    def test_get_application_field_value_section_missing(self, data_application_json):
+        f680_application = F680ApplicationFactory(application=data_application_json)
+        assert f680_application.get_application_field_value("bar", "name") == None


### PR DESCRIPTION
### Aim

Add the capability for an exporter to submit an F680 application.
This PR also makes the exporter F680 endpoints only operate on draft applications, to avoid any chance of an exporter making an edit to a submitted application.

[LTD-5908](https://uktrade.atlassian.net/browse/LTD-5908)


[LTD-5908]: https://uktrade.atlassian.net/browse/LTD-5908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ