### PR TITLE
Make audit move pipeline more efficient

### DIFF
--- a/api/data_workspace/urls.py
+++ b/api/data_workspace/urls.py
@@ -3,15 +3,11 @@ from django.urls import (
     path,
 )
 
-from api.data_workspace.v0.urls import router_v0
-from api.data_workspace.v1.urls import router_v1
-from api.data_workspace.v2.urls import router_v2
-
 
 app_name = "data_workspace"
 
 urlpatterns = [
-    path("v0/", include((router_v0.urls, "data_workspace_v0"), namespace="v0")),
-    path("v1/", include((router_v1.urls, "data_workspace_v1"), namespace="v1")),
-    path("v2/", include((router_v2.urls, "data_workspace_v2"), namespace="v2")),
+    path("v0/", include(("api.data_workspace.v0.urls", "data_workspace_v0"), namespace="v0")),
+    path("v1/", include(("api.data_workspace.v1.urls", "data_workspace_v1"), namespace="v1")),
+    path("v2/", include(("api.data_workspace.v2.urls", "data_workspace_v2"), namespace="v2")),
 ]

--- a/api/data_workspace/v0/urls.py
+++ b/api/data_workspace/v0/urls.py
@@ -9,3 +9,5 @@ router_v0.register(
     licence_views.LicencesListDW,
     basename="dw-licences-only",
 )
+
+urlpatterns = router_v0.urls

--- a/api/data_workspace/v1/audit_views.py
+++ b/api/data_workspace/v1/audit_views.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from rest_framework import viewsets
 from rest_framework.pagination import LimitOffsetPagination
 
@@ -15,22 +16,52 @@ from api.data_workspace.v1.serializers import (
 )
 
 
-class AuditMoveCaseListView(viewsets.ReadOnlyModelViewSet):
-    """Expose 'move case' audit events to data workspace."""
+class AuditMoveCaseRawQuerySet:
+    # This is pretty horrible but it solves a problem in the "simplest way"
+    # Originally this was just Audit.objects.raw which then gets sent through
+    # DRFs gubbins to get a paginated queryset.
+    #
+    # The problem here is that by default the raw queryset is going to bring
+    # back the entire resultset to get both the count and the paginated results.
+    #
+    # In the case for this endpoint we're looping through 10,000s of rows,
+    # which was then transforming all of those rows into actual Audit objects
+    # putting them in a list and then doing len() and [0:25] on those lists.
+    #
+    # This was all hugely inefficient and wasteful.
+    #
+    # This horrible queryset allows us to just provide the paginator with what
+    # it needs quickly and efficiently.
+    #
+    # This could have been achieved by overriding a whole bunch in the APIView
+    # itself but that would have taken a lot more code and in this case we get
+    # to keep using what DRF wants to do internally.
 
-    authentication_classes = (DataWorkspaceOnlyAuthentication,)
-    serializer_class = AuditMoveCaseSerializer
-    pagination_class = LimitOffsetPagination
-
-    def get_queryset(self):
+    def count(self):
         content_type = ContentType.objects.get_for_model(Case)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                with audit_move_case as (
+                    select *,
+                    case when jsonb_typeof(payload->'queues') = 'array'
+                    then payload->'queues'
+                    else jsonb_build_array(payload->'queues')
+                    end as queues
+                    from audit_trail_audit
+                    where verb = %(verb)s
+                    and (action_object_content_type_id = %(action_type)s
+                    or target_content_type_id = %(target_type)s)
+                    order by created_at
+                )
+                select count(*) from audit_move_case cross join jsonb_array_elements(queues)""",
+                {"verb": AuditType.MOVE_CASE, "action_type": content_type.pk, "target_type": content_type.pk},
+            )
+            row = cursor.fetchone()
+        return row[0]
 
-        # This returns a queryset of audit records for the "move case" audit event.
-        # For each record, it exposes the nested "queues" JSON property as a top
-        # level column called "queue" and splits into multiple rows when "queues"
-        # contains multiple entries.
-        # It also deals with the fact that the value of "queues" is sometimes an
-        # array of queue names but sometimes a single string.
+    def __getitem__(self, slice):
+        content_type = ContentType.objects.get_for_model(Case)
         return Audit.objects.raw(
             """
             with audit_move_case as (
@@ -45,10 +76,25 @@ class AuditMoveCaseListView(viewsets.ReadOnlyModelViewSet):
                 or target_content_type_id = %(target_type)s)
               order by created_at
             )
-            select *, value->>0 as "queue" from audit_move_case cross join jsonb_array_elements(queues)
+            select *, value->>0 as "queue" from audit_move_case cross join jsonb_array_elements(queues) LIMIT %(limit)s OFFSET %(offset)s
             """,
-            {"verb": AuditType.MOVE_CASE, "action_type": content_type.pk, "target_type": content_type.pk},
+            {
+                "verb": AuditType.MOVE_CASE,
+                "action_type": content_type.pk,
+                "target_type": content_type.pk,
+                "offset": slice.start,
+                "limit": slice.stop - slice.start,
+            },
         )
+
+
+class AuditMoveCaseListView(viewsets.ReadOnlyModelViewSet):
+    """Expose 'move case' audit events to data workspace."""
+
+    authentication_classes = (DataWorkspaceOnlyAuthentication,)
+    serializer_class = AuditMoveCaseSerializer
+    pagination_class = LimitOffsetPagination
+    queryset = AuditMoveCaseRawQuerySet()
 
 
 class AuditUpdatedCaseStatusListView(viewsets.ReadOnlyModelViewSet):

--- a/api/data_workspace/v1/urls.py
+++ b/api/data_workspace/v1/urls.py
@@ -92,3 +92,5 @@ router_v1.register(
 router_v1.register("survey-response", views.SurveyResponseListView, basename="dw-survey-reponse")
 router_v1.register("address", address_views.AddressView, basename="dw-address")
 router_v1.register("site", organisations_views.SiteView, basename="dw-site")
+
+urlpatterns = router_v1.urls

--- a/api/data_workspace/v2/urls.py
+++ b/api/data_workspace/v2/urls.py
@@ -13,3 +13,5 @@ router_v2.register(views.UnitViewSet)
 router_v2.register(views.FootnoteViewSet)
 router_v2.register(views.AssessmentViewSet)
 router_v2.register(views.LicenceRefusalCriteriaViewSet)
+
+urlpatterns = router_v2.urls


### PR DESCRIPTION
### Aim

This makes the audit move case endpoint more efficient.

There's quite a lengthy comment in the code as to why I'm doing it like this but essentially this is the quickest route to getting this endpoint efficient and we can spend more time in the future making it work with the new CaseQueueMovement table.

[LTD-5887](https://uktrade.atlassian.net/browse/LTD-5887)


[LTD-5887]: https://uktrade.atlassian.net/browse/LTD-5887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ