### PR TITLE
Add opensearch dashboards as a developer tool

### DIFF
--- a/Dockerfile.opensearch-dashboards
+++ b/Dockerfile.opensearch-dashboards
@@ -1,0 +1,3 @@
+FROM opensearchproject/opensearch-dashboards:2.14.0
+RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
+COPY --chown=opensearch-dashboards:opensearch-dashboards opensearch_dashboards.yml /usr/share/opensearch-dashboards/config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,16 @@ services:
     networks:
       - lite
 
+  opensearch-dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile.opensearch-dashboards
+    container_name: opensearch-dashboard
+    ports:
+      - 5601:5601
+    networks:
+      - lite
+
   redis:
     image: "redis:5-alpine"
     container_name: redis

--- a/opensearch_dashboards.yml
+++ b/opensearch_dashboards.yml
@@ -1,0 +1,4 @@
+---
+server.name: opensearch-dashboards
+server.host: "0.0.0.0"
+opensearch.hosts: http://opensearch:9200


### PR DESCRIPTION
### Aim

Add opensearch dashboards as a developer tool to be able to view and test indexed data locally.
