### PR TITLE
[LTD-5946] F680 generate approval document

### DIFF
--- a/api/cases/application_manifest.py
+++ b/api/cases/application_manifest.py
@@ -1,6 +1,6 @@
 from api.applications.models import StandardApplication
 from api.applications.serializers.standard_application import StandardApplicationViewSerializer
-from api.cases.enums import CaseTypeSubTypeEnum
+from api.cases.enums import CaseTypeSubTypeEnum, ApplicationFeatures
 from api.f680.models import F680Application
 from api.f680.caseworker.serializers import F680ApplicationSerializer
 
@@ -8,16 +8,22 @@ from api.f680.caseworker.serializers import F680ApplicationSerializer
 class BaseManifest:
     caseworker_serializers = {}
     model_class = None
+    features = {}
+
+    def has_feature(self, feature):
+        return self.features.get(feature, False)
 
 
 class StandardApplicationManifest(BaseManifest):
     model_class = StandardApplication
     caseworker_serializers = {"view": StandardApplicationViewSerializer}
+    features = {ApplicationFeatures.LICENCE_ISSUE: True}
 
 
 class F680ApplicationManifest(BaseManifest):
     model_class = F680Application
     caseworker_serializers = {"view": F680ApplicationSerializer}
+    features = {ApplicationFeatures.LICENCE_ISSUE: False}
 
 
 # TODO: Make it so that each application django app defines/registers its own

--- a/api/cases/enums.py
+++ b/api/cases/enums.py
@@ -446,3 +446,7 @@ class LicenceDecisionType:
     @classmethod
     def advice_type_to_decision(cls, advice_type):
         return cls.decision_map[advice_type]
+
+
+class ApplicationFeatures:
+    LICENCE_ISSUE = "licence_issue"

--- a/api/cases/generated_documents/helpers.py
+++ b/api/cases/generated_documents/helpers.py
@@ -6,7 +6,7 @@ from weasyprint.fonts import FontConfiguration
 from rest_framework.exceptions import ParseError, ValidationError
 
 from api.staticdata.statuses.enums import CaseStatusEnum
-from api.cases.enums import CaseDocumentState, AdviceType
+from api.cases.enums import CaseDocumentState, AdviceType, ApplicationFeatures
 from api.cases.libraries.get_case import get_case
 from api.cases.models import CaseDocument
 from api.core.exceptions import NotFoundError
@@ -105,8 +105,12 @@ def get_decision_type(advice_type, template):
 
 
 def get_draft_licence(case, advice_type):
-    licence = None
+    # TODO: This helper may be better located on the Case object
+    application_manifest = case.get_application_manifest()
+    if not application_manifest.has_feature(ApplicationFeatures.LICENCE_ISSUE):
+        return None
 
+    licence = None
     # this is the case of regenerating document which can happen after
     # finalising the Case so there won't be any draft licences in this case
     if case.status.status == CaseStatusEnum.FINALISED:

--- a/api/cases/generated_documents/tests/test_helpers.py
+++ b/api/cases/generated_documents/tests/test_helpers.py
@@ -1,0 +1,45 @@
+import pytest
+
+from rest_framework.exceptions import ParseError
+
+from api.cases.generated_documents.helpers import get_draft_licence
+from api.cases.enums import AdviceType
+from api.applications.tests.factories import StandardApplicationFactory
+from api.licences.tests.factories import StandardLicenceFactory
+from api.f680.tests.factories import SubmittedF680ApplicationFactory
+from api.staticdata.statuses.models import CaseStatus
+from api.staticdata.statuses.enums import CaseStatusEnum
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_draft_licence_f680_application_returns_none():
+    application = SubmittedF680ApplicationFactory()
+    assert get_draft_licence(application.case_ptr, AdviceType.APPROVE) is None
+
+
+def test_get_draft_licence_standard_application_case_finalised_returns_none():
+    finalised_status = CaseStatus.objects.get(status=CaseStatusEnum.FINALISED)
+    application = StandardApplicationFactory(status=finalised_status)
+    assert get_draft_licence(application.case_ptr, AdviceType.APPROVE) is None
+
+
+def test_get_draft_licence_standard_application_draft_exists_success():
+    final_review_status = CaseStatus.objects.get(status=CaseStatusEnum.UNDER_FINAL_REVIEW)
+    application = StandardApplicationFactory(status=final_review_status)
+    draft_licence = StandardLicenceFactory(case=application.case_ptr)
+    assert get_draft_licence(application.case_ptr, AdviceType.APPROVE) == draft_licence
+
+
+def test_get_draft_licence_standard_application_refusal_advice_returns_none():
+    final_review_status = CaseStatus.objects.get(status=CaseStatusEnum.UNDER_FINAL_REVIEW)
+    application = StandardApplicationFactory(status=final_review_status)
+    assert get_draft_licence(application.case_ptr, AdviceType.REFUSE) is None
+
+
+def test_get_draft_licence_standard_application_draft_missing_raises_error():
+    final_review_status = CaseStatus.objects.get(status=CaseStatusEnum.UNDER_FINAL_REVIEW)
+    application = StandardApplicationFactory(status=final_review_status)
+    with pytest.raises(ParseError):
+        get_draft_licence(application.case_ptr, AdviceType.APPROVE)

--- a/api/cases/tests/test_application_manifest.py
+++ b/api/cases/tests/test_application_manifest.py
@@ -1,7 +1,13 @@
 import pytest
 from unittest import mock
 
-from api.cases.application_manifest import ManifestRegistry
+from api.cases.enums import ApplicationFeatures
+from api.cases.application_manifest import (
+    ManifestRegistry,
+    BaseManifest,
+    F680ApplicationManifest,
+    StandardApplicationManifest,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -25,3 +31,27 @@ class TestManifestRegistry:
         registry = ManifestRegistry()
         with pytest.raises(KeyError):
             registry.get_manifest("some_application_type")
+
+
+class TestBaseManifest:
+
+    def test_has_feature(self):
+        manifest = BaseManifest()
+        manifest.features = {"my-feature": True, "my-other-feature": False}
+        assert manifest.has_feature("my-feature")
+        assert manifest.has_feature("my-other-feature") is False
+        assert manifest.has_feature("my-unknown-feature") is False
+
+
+class TestStandardApplicationManifest:
+
+    def test_has_feature(self):
+        manifest = StandardApplicationManifest()
+        assert manifest.has_feature(ApplicationFeatures.LICENCE_ISSUE) is True
+
+
+class TestF680ApplicationManifest:
+
+    def test_has_feature(self):
+        manifest = F680ApplicationManifest()
+        assert manifest.has_feature(ApplicationFeatures.LICENCE_ISSUE) is False

--- a/api/letter_templates/context_generator.py
+++ b/api/letter_templates/context_generator.py
@@ -590,6 +590,18 @@ class ComplianceSiteCaseSerializer(serializers.ModelSerializer):
         return ret
 
 
+class F680Serializer(serializers.ModelSerializer):
+    class Meta:
+        model = Case
+        fields = ["application"]
+
+    application = serializers.SerializerMethodField()
+
+    def get_application(self, obj):
+        # Expose the application JSON to the template
+        return obj.get_application().application
+
+
 class ComplianceSiteLicenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Case
@@ -742,6 +754,8 @@ def get_document_context(case, addressee=None):
     }
 
 
+# TODO: This mapping/serializers business feels nuts - we should just generate a context
+#   dict in a function instead
 SERIALIZER_MAPPING = {
     CaseTypeSubTypeEnum.STANDARD: FlattenedStandardApplicationSerializer,
     CaseTypeSubTypeEnum.EUA: EndUserAdvisoryQuerySerializer,
@@ -749,6 +763,7 @@ SERIALIZER_MAPPING = {
     CaseTypeSubTypeEnum.COMP_SITE: FlattenedComplianceSiteWithVisitReportsSerializer,
     CaseTypeSubTypeEnum.EUA: EndUserAdvisoryQueryCaseSerializer,
     CaseTypeSubTypeEnum.COMP_VISIT: ComplianceVisitSerializer,
+    CaseTypeSubTypeEnum.F680: F680Serializer,
 }
 
 

--- a/api/letter_templates/templates/letter_templates/f680_approval.html
+++ b/api/letter_templates/templates/letter_templates/f680_approval.html
@@ -9,6 +9,25 @@
 {% block body %}
 
   <div class="govuk-body">We Have Approved Your F680 Application</div>
+  <p>{{user_content}}</p>
   <h2 class="govuk-heading-l">Strategic Export Licensing Criteria</h3>
+  {% for section_key, section in details.application.sections.items %}
+    <h3>{{section.label}}</h3>
+    {% if section.type == "single" %}
+        {% for field in section.fields %}
+            {% if field.answer %}
+            <p>{{field.question}}: {{field.answer}}</p>
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% for item in section.items %}
+            {% for field in item.fields %}
+                {% if field.answer %}
+                <p>{{field.question}}: {{field.answer}}</p>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+  {% endfor %}
 
 {% endblock %}

--- a/api/letter_templates/tests/test_context_generation.py
+++ b/api/letter_templates/tests/test_context_generation.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from api.applications.enums import ApplicationExportType, ApplicationExportLicenceOfficialType
 from api.applications.models import ExternalLocationOnApplication, GoodOnApplication
 from api.applications.tests.factories import GoodOnApplicationFactory
+from api.f680.tests.factories import SubmittedF680ApplicationFactory
 from api.cases.enums import AdviceType
 from api.licences.tests.factories import StandardLicenceFactory
 from api.letter_templates.context_generator import EcjuQuerySerializer
@@ -690,6 +691,13 @@ class DocumentContextGenerationTests(DataTestClient):
         self._assert_case_type_details(context["case_type"], case)
         self._assert_base_application_details(context["details"], case)
         self._assert_standard_application_details(context["details"], case)
+
+    def test_generate_context_with_f680_details(self):
+        application = SubmittedF680ApplicationFactory(application={"some": "json"})
+        case = application.case_ptr
+
+        context = get_document_context(case)
+        assert context["details"] == {"application": {"some": "json"}}
 
     def test_generate_context_with_end_user_advisory_query_details(self):
         case = self.create_end_user_advisory(note="abc", reasoning="def", organisation=self.organisation)


### PR DESCRIPTION
### Aim
This change ensures that we are able to generate an approval document for F680s.

- The approval document generation endpoint assumed that approval documents would have a draft licence.  As far as we know, we will not have a licence object for F680s so this has been made conditional with a new `get_feature()` method on the application manifest.
- The template for the F680 approval document was also enhanced so that we show more application details.

[LTD-5946](https://uktrade.atlassian.net/browse/LTD-5946)


[LTD-5946]: https://uktrade.atlassian.net/browse/LTD-5946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ