### PR TITLE
Raise exception if in debug mode when uploading documents in tests

### DIFF
--- a/api/staticdata/upload_document_for_tests/views.py
+++ b/api/staticdata/upload_document_for_tests/views.py
@@ -32,6 +32,8 @@ class UploadDocumentForTests(APIView):
         try:
             s3.upload_file(file_to_upload_abs_path, settings.AWS_STORAGE_BUCKET_NAME, s3_key)
         except Exception as e:  # noqa
+            if settings.DEBUG:
+                raise
             return JsonResponse(
                 data={"errors": "Error uploading file to S3"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )


### PR DESCRIPTION
### Aim

When in debug mode, if there is a file upload issue then raise the exception.

This should make it easier to debug exactly what failed when an upload error occurs, especially when running e2e tests in CI.
