### PR TITLE
Get the relevant case type value for an enum type

### DIFF
--- a/api/cases/enums.py
+++ b/api/cases/enums.py
@@ -79,6 +79,10 @@ class CaseTypeTypeEnum:
     def as_list(cls):
         return [{"key": choice[0], "value": choice[1]} for choice in cls.choices]
 
+    @classmethod
+    def get_case_type(cls, case_type):
+        return case_type.type
+
 
 class CaseTypeSubTypeEnum:
     STANDARD = "standard"
@@ -133,6 +137,10 @@ class CaseTypeSubTypeEnum:
         Useful for licence duration
         """
         return application_type in CaseTypeSubTypeEnum.mod
+
+    @classmethod
+    def get_case_type(cls, case_type):
+        return case_type.sub_type
 
 
 class CaseTypeEnum:
@@ -257,6 +265,11 @@ class CaseTypeEnum:
     MOD_LICENCE_IDS = [F680.id, EXHIBITION.id, GIFTING.id]
     LICENCE_IDS = OPEN_GENERAL_LICENCE_IDS + STANDARD_LICENCE_IDS + OPEN_LICENCE_IDS + MOD_LICENCE_IDS
 
+    choices = [
+        (SIEL.id, SIEL.reference),
+        (F680.id, F680.reference),
+    ]
+
     @classmethod
     def case_types_to_representation(cls):
         return CaseTypeReferenceEnum.as_list()
@@ -293,6 +306,10 @@ class CaseTypeEnum:
     @classmethod
     def trade_control_case_type_ids(cls):
         return [cls.SICL.id, cls.OICL.id]
+
+    @classmethod
+    def get_case_type(cls, case_type):
+        return case_type.pk
 
 
 class AdviceType:

--- a/api/cases/tests/factories.py
+++ b/api/cases/tests/factories.py
@@ -84,6 +84,8 @@ class CaseSIELFactory(CaseFactory):
 
 
 class CaseTypeFactory(factory.django.DjangoModelFactory):
+    reference = factory.Faker("lexify", text="??????")
+
     class Meta:
         model = CaseType
 

--- a/api/cases/tests/test_enums.py
+++ b/api/cases/tests/test_enums.py
@@ -1,0 +1,28 @@
+import pytest
+import uuid
+
+from api.cases.enums import (
+    CaseTypeEnum,
+    CaseTypeSubTypeEnum,
+    CaseTypeTypeEnum,
+)
+from api.cases.tests.factories import CaseTypeFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_case_type_type_enum_get_case_type():
+    case_type = CaseTypeFactory(type="test_case_type")
+    assert CaseTypeTypeEnum.get_case_type(case_type) == "test_case_type"
+
+
+def test_case_type_sub_type_enum_get_case_type():
+    case_type = CaseTypeFactory(sub_type="test_case_sub_type")
+    assert CaseTypeSubTypeEnum.get_case_type(case_type) == "test_case_sub_type"
+
+
+def test_case_type_case_type_enum_get_case_type():
+    pk = uuid.uuid4()
+    case_type = CaseTypeFactory(id=pk)
+    assert CaseTypeEnum.get_case_type(case_type) == pk


### PR DESCRIPTION
### Aim

Get the case type identifier from the specific enum class from the case type object.

This is in preparation for routing changes where routing rules can be defined at different levels of the case type hierarchy.

[LTD-5979](https://uktrade.atlassian.net/browse/LTD-5979)


[LTD-5979]: https://uktrade.atlassian.net/browse/LTD-5979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ