### PR TITLE
[LTD-5991] Expose related F680 models on caseworker case detail endpoint

### DIFF
--- a/api/f680/caseworker/serializers.py
+++ b/api/f680/caseworker/serializers.py
@@ -2,23 +2,75 @@ from rest_framework import serializers
 
 from api.applications.serializers.fields import CaseStatusField
 from api.cases.models import Case
-from api.core.serializers import KeyValueChoiceField, PrimaryKeyRelatedField
+from api.core.serializers import CountrySerializerField, KeyValueChoiceField, PrimaryKeyRelatedField
 from api.organisations.exporter.serializers import RelatedOrganisationSerializer
-from api.f680.enums import RecommendationType, SecurityGrading
-from api.f680.models import F680Application, Recommendation, SecurityReleaseRequest
 from api.teams.models import Team
 from api.users.exporter.serializers import RelatedExporterUserSerializer
 from api.users.enums import UserStatuses
 from api.users.models import GovUser
 
+from api.f680.models import F680Application, Product, Recipient, Recommendation, SecurityReleaseRequest
+from api.f680 import enums
 
-class F680ApplicationSerializer(serializers.ModelSerializer):  # /PS-IGNORE
+
+class ProductSerializer(serializers.ModelSerializer):
+    security_grading = KeyValueChoiceField(choices=enums.SecurityGrading.product_choices)
+
+    class Meta:
+        model = Product
+        fields = [
+            "id",
+            "name",
+            "description",
+            "security_grading",
+            "security_grading_other",
+        ]
+
+
+class RecipientSerializer(serializers.ModelSerializer):
+    country = CountrySerializerField()
+    type = KeyValueChoiceField(choices=enums.RecipientType.choices)
+
+    class Meta:
+        model = Recipient
+        fields = [
+            "id",
+            "name",
+            "address",
+            "country",
+            "type",
+            "role",
+            "role_other",
+        ]
+
+
+class SecurityReleaseRequestSerializer(serializers.ModelSerializer):
+    recipient = RecipientSerializer()
+    product_id = serializers.UUIDField()
+    security_grading = KeyValueChoiceField(choices=enums.SecurityGrading.security_release_choices)
+
+    class Meta:
+        model = SecurityReleaseRequest
+        fields = [
+            "id",
+            "recipient",
+            "security_grading",
+            "security_grading_other",
+            "approval_types",
+            "intended_use",
+            "product_id",
+        ]
+
+
+class F680ApplicationSerializer(serializers.ModelSerializer):
     status = CaseStatusField(read_only=True)
     organisation = RelatedOrganisationSerializer(read_only=True)
     submitted_by = RelatedExporterUserSerializer(read_only=True)
+    security_release_requests = SecurityReleaseRequestSerializer(many=True)
+    product = ProductSerializer(source="get_product")
 
     class Meta:
-        model = F680Application  # /PS-IGNORE
+        model = F680Application
         fields = [
             "id",
             "application",
@@ -28,6 +80,8 @@ class F680ApplicationSerializer(serializers.ModelSerializer):  # /PS-IGNORE
             "submitted_at",
             "submitted_by",
             "name",
+            "security_release_requests",
+            "product",
         ]
         read_only_fields = ["id", "status", "reference_code", "organisation", "submitted_at", "submitted_by"]
 
@@ -36,8 +90,8 @@ class F680RecommendationSerializer(serializers.ModelSerializer):
     case = PrimaryKeyRelatedField(queryset=Case.objects.all())
     user = PrimaryKeyRelatedField(queryset=GovUser.objects.filter(status=UserStatuses.ACTIVE))
     team = PrimaryKeyRelatedField(queryset=Team.objects.all())
-    type = KeyValueChoiceField(choices=RecommendationType.choices)
-    security_grading = KeyValueChoiceField(choices=SecurityGrading.security_release_choices)
+    type = KeyValueChoiceField(choices=enums.RecommendationType.choices)
+    security_grading = KeyValueChoiceField(choices=enums.SecurityGrading.security_release_choices)
     security_grading_other = serializers.CharField(allow_blank=True, allow_null=True, required=False)
     conditions = serializers.CharField(allow_blank=True, allow_null=True)
     refusal_reasons = serializers.CharField(allow_blank=True, allow_null=True)

--- a/api/f680/managers.py
+++ b/api/f680/managers.py
@@ -3,4 +3,9 @@ from django.db import models
 
 class F680ApplicationQuerySet(models.QuerySet):
     def get_prepared_object(self, pk):
-        return self.get(pk=pk)
+        return self.prefetch_related(
+            "security_release_requests",
+            "security_release_requests__product",
+            "security_release_requests__recipient",
+            "security_release_requests__recipient__country",
+        ).get(pk=pk)

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -33,6 +33,8 @@ class F680Application(BaseApplication):  # /PS-IGNORE
         return self.get_field_value(section_fields, field_key, raise_exception=raise_exception)
 
     def get_product(self):
+        if not self.security_release_requests.count() > 0:
+            return None
         return self.security_release_requests.first().product
 
     def on_submit(self):

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -33,7 +33,7 @@ class F680Application(BaseApplication):  # /PS-IGNORE
         return self.get_field_value(section_fields, field_key, raise_exception=raise_exception)
 
     def get_product(self):
-        if not self.security_release_requests.count() > 0:
+        if self.security_release_requests.count() == 0:
             return None
         return self.security_release_requests.first().product
 

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -32,6 +32,9 @@ class F680Application(BaseApplication):  # /PS-IGNORE
         section_fields = self.application["sections"][section]["fields"]
         return self.get_field_value(section_fields, field_key, raise_exception=raise_exception)
 
+    def get_product(self):
+        return self.security_release_requests.first().product
+
     def on_submit(self):
         self.name = self.get_application_field_value("general_application_details", "name")
         self.save()


### PR DESCRIPTION
### Aim

This change exposes SecurityReleaseRequest, Product and Recipient on the case detail API endpoint for F680 applications.

[LTD-5991](https://uktrade.atlassian.net/browse/LTD-5991)


[LTD-5991]: https://uktrade.atlassian.net/browse/LTD-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ