### PR TITLE
[LTD-5993] Change F680 JSON contract for fields to be dict

### DIFF
--- a/api/f680/conftest.py
+++ b/api/f680/conftest.py
@@ -23,35 +23,41 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
             "approval_type": {
                 "type": "single",
                 "label": "Approval type",
-                "fields": [
-                    {
+                "fields": {
+                    "approval_choices": {
                         "key": "approval_choices",
                         "answer": ["Demonstration overseas", "Training"],
                         "datatype": "list",
                         "question": "Select the types of approvals you need",
                         "raw_answer": ["demonstration_overseas", "training"],
                     },
-                    {
+                    "demonstration_in_uk": {
                         "key": "demonstration_in_uk",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "",
                     },
-                    {
+                    "demonstration_overseas": {
                         "key": "demonstration_overseas",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain what you are demonstrating and why",
                         "raw_answer": "",
                     },
-                    {
+                    "approval_details_text": {
                         "key": "approval_details_text",
                         "answer": "csda",
                         "datatype": "string",
                         "question": "Provide details about what you're seeking approval to do",
                         "raw_answer": "csda",
                     },
+                },
+                "fields_sequence": [
+                    "approval_choices",
+                    "demonstration_in_uk",
+                    "demonstration_overseas",
+                    "approval_details_text",
                 ],
             },
             "user_information": {
@@ -59,339 +65,391 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
                 "items": [
                     {
                         "id": data_france_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "Ultimate end-user",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "ultimate-end-user",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "france name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "france name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "france address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "france address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "France",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "FR",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Official",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "official",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "cdsacsad",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "cdsacsad",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "ref",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "ref",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "france intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "france intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                     {
                         "id": data_uae_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "End user",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "end-user",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "uae name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "uae name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "uae address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "uae address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "United Arab Emirates",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "AE",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Top-Secret",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "top-secret",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "casdcdsa",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "casdcdsa",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "csd",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "csd",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "uae intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "uae intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                     {
                         "id": data_australia_release_id,
-                        "fields": [
-                            {
+                        "fields": {
+                            "entity_type": {
                                 "key": "entity_type",
                                 "answer": "Third party",
                                 "datatype": "string",
                                 "question": "Select type of entity",
                                 "raw_answer": "third-party",
                             },
-                            {
+                            "third_party_role": {
                                 "key": "third_party_role",
                                 "answer": "Consultant",
                                 "datatype": "string",
                                 "question": "Select the role of the third party",
                                 "raw_answer": "consultant",
                             },
-                            {
+                            "end_user_name": {
                                 "key": "end_user_name",
                                 "answer": "australia name",
                                 "datatype": "string",
                                 "question": "End-user name",
                                 "raw_answer": "australia name",
                             },
-                            {
+                            "address": {
                                 "key": "address",
                                 "answer": "australia address",
                                 "datatype": "string",
                                 "question": "Address",
                                 "raw_answer": "australia address",
                             },
-                            {
+                            "country": {
                                 "key": "country",
                                 "answer": "Australia",
                                 "datatype": "string",
                                 "question": "Country",
                                 "raw_answer": "AU",
                             },
-                            {
+                            "prefix": {
                                 "key": "prefix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a prefix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "security_classification": {
                                 "key": "security_classification",
                                 "answer": "Secret",
                                 "datatype": "string",
                                 "question": "Select security classification",
                                 "raw_answer": "secret",
                             },
-                            {
+                            "other_security_classification": {
                                 "key": "other_security_classification",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter the security classification",
                                 "raw_answer": "",
                             },
-                            {
+                            "suffix": {
                                 "key": "suffix",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Enter a suffix (optional)",
                                 "raw_answer": "",
                             },
-                            {
+                            "issuing_authority_name_address": {
                                 "key": "issuing_authority_name_address",
                                 "answer": "csdacdsa",
                                 "datatype": "string",
                                 "question": "Name and address of the issuing authority",
                                 "raw_answer": "csdacdsa",
                             },
-                            {
+                            "reference": {
                                 "key": "reference",
                                 "answer": "casdcdsa",
                                 "datatype": "string",
                                 "question": "Reference",
                                 "raw_answer": "casdcdsa",
                             },
-                            {
+                            "date_of_issue": {
                                 "key": "date_of_issue",
                                 "answer": "2024-01-01",
                                 "datatype": "date",
                                 "question": "Date of issue",
                                 "raw_answer": "2024-01-01",
                             },
-                            {
+                            "end_user_intended_end_use": {
                                 "key": "end_user_intended_end_use",
                                 "answer": "australia intended use",
                                 "datatype": "string",
                                 "question": "How does the end-user intend to use this product",
                                 "raw_answer": "australia intended use",
                             },
-                            {
+                            "assemble_manufacture": {
                                 "key": "assemble_manufacture",
                                 "answer": ["No"],
                                 "datatype": "list",
                                 "question": "Does this end-user need to assemble or manufacture any of the products?",
                                 "raw_answer": ["no"],
                             },
-                            {
+                            "assemble": {
                                 "key": "assemble",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what assembly is needed.",
                                 "raw_answer": "",
                             },
-                            {
+                            "manufacture": {
                                 "key": "manufacture",
                                 "answer": "",
                                 "datatype": "string",
                                 "question": "Describe what manufacture is needed. Be sure to include the manufacturer's website if they have one.",
                                 "raw_answer": "",
                             },
+                        },
+                        "fields_sequence": [
+                            "entity_type",
+                            "third_party_role",
+                            "end_user_name",
+                            "address",
+                            "country",
+                            "prefix",
+                            "security_classification",
+                            "other_security_classification",
+                            "suffix",
+                            "issuing_authority_name_address",
+                            "reference",
+                            "date_of_issue",
+                            "end_user_intended_end_use",
+                            "assemble_manufacture",
+                            "assemble",
+                            "manufacture",
                         ],
                     },
                 ],
@@ -400,161 +458,183 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
             "product_information": {
                 "type": "single",
                 "label": "Product information",
-                "fields": [
-                    {
+                "fields": {
+                    "product_name": {
                         "key": "product_name",
                         "answer": "some product name",
                         "datatype": "string",
                         "question": "Give the item a descriptive name",
                         "raw_answer": "some product name",
                     },
-                    {
+                    "product_description": {
                         "key": "product_description",
                         "answer": "some product description",
                         "datatype": "string",
                         "question": "Describe the item",
                         "raw_answer": "some product description",
                     },
-                    {
+                    "has_security_classification": {
                         "key": "has_security_classification",
                         "answer": "Yes",
                         "datatype": "boolean",
                         "question": "Has the product been given a security classifcation by a UK MOD authority?",
                         "raw_answer": True,
                     },
-                    {
+                    "prefix": {
                         "key": "prefix",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter a prefix (optional)",
                         "raw_answer": "",
                     },
-                    {
+                    "security_classification": {
                         "key": "security_classification",
                         "answer": "Official",
                         "datatype": "string",
                         "question": "Select security classification",
                         "raw_answer": "official",
                     },
-                    {
+                    "other_security_classification": {
                         "key": "other_security_classification",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter the security classification",
                         "raw_answer": "",
                     },
-                    {
+                    "suffix": {
                         "key": "suffix",
                         "answer": "",
                         "datatype": "string",
                         "question": "Enter a suffix (optional)",
                         "raw_answer": "",
                     },
-                    {
+                    "issuing_authority_name_address": {
                         "key": "issuing_authority_name_address",
                         "answer": "csadcas",
                         "datatype": "string",
                         "question": "Name and address of the issuing authority",
                         "raw_answer": "csadcas",
                     },
-                    {
+                    "reference": {
                         "key": "reference",
                         "answer": "fdfscsa",
                         "datatype": "string",
                         "question": "Reference",
                         "raw_answer": "fdfscsa",
                     },
-                    {
+                    "date_of_issue": {
                         "key": "date_of_issue",
                         "answer": "0001-01-01",
                         "datatype": "date",
                         "question": "Date of issue",
                         "raw_answer": "0001-01-01",
                     },
-                    {
+                    "is_foreign_tech_or_information_shared": {
                         "key": "is_foreign_tech_or_information_shared",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Will any foreign technology or information be shared with the item?",
                         "raw_answer": False,
                     },
-                    {
+                    "is_including_cryptography_or_security_features": {
                         "key": "is_including_cryptography_or_security_features",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Does the item include cryptography or other information security features?",
                         "raw_answer": False,
                     },
-                    {
+                    "cryptography_or_security_feature_info": {
                         "key": "cryptography_or_security_feature_info",
                         "answer": "",
                         "datatype": "string",
                         "question": "Provide full details",
                         "raw_answer": "",
                     },
-                    {
+                    "is_item_rated_under_mctr": {
                         "key": "is_item_rated_under_mctr",
                         "answer": "Yes, the product is MTCR Category 2",
                         "datatype": "string",
                         "question": "Do you believe the item is rated under the Missile Technology Control Regime (MTCR)",
                         "raw_answer": "mtcr_2",
                     },
-                    {
+                    "is_item_manpad": {
                         "key": "is_item_manpad",
                         "answer": "Don't know",
                         "datatype": "string",
                         "question": "Do you believe the item is a man-portable air defence system (MANPAD)?",
                         "raw_answer": "dont_know",
                     },
-                    {
+                    "is_mod_electronic_data_shared": {
                         "key": "is_mod_electronic_data_shared",
                         "answer": "No",
                         "datatype": "string",
                         "question": "Will any electronic warfare data owned by the Ministry of Defence (MOD) be shared with the item?",
                         "raw_answer": "no",
                     },
-                    {
+                    "funding_source": {
                         "key": "funding_source",
                         "answer": "MOD",
                         "datatype": "string",
                         "question": "Who is funding the item?",
                         "raw_answer": "mod",
                     },
-                    {
+                    "is_used_by_uk_armed_forces": {
                         "key": "is_used_by_uk_armed_forces",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Will the item be used by the UK Armed Forces?",
                         "raw_answer": False,
                     },
-                    {
+                    "used_by_uk_armed_forces_info": {
                         "key": "used_by_uk_armed_forces_info",
                         "answer": "",
                         "datatype": "string",
                         "question": "Explain how it will be used",
                         "raw_answer": "",
                     },
+                },
+                "fields_sequence": [
+                    "product_name",
+                    "product_description",
+                    "has_security_classification",
+                    "prefix",
+                    "security_classification",
+                    "other_security_classification",
+                    "suffix",
+                    "issuing_authority_name_address",
+                    "reference",
+                    "date_of_issue",
+                    "is_foreign_tech_or_information_shared",
+                    "is_including_cryptography_or_security_features",
+                    "cryptography_or_security_feature_info",
+                    "is_item_rated_under_mctr",
+                    "is_item_manpad",
+                    "is_mod_electronic_data_shared",
+                    "funding_source",
+                    "is_used_by_uk_armed_forces",
+                    "used_by_uk_armed_forces_info",
                 ],
             },
             "general_application_details": {
                 "type": "single",
                 "label": "General application details",
-                "fields": [
-                    {
+                "fields": {
+                    "name": {
                         "key": "name",
                         "answer": "casdcasd",
                         "datatype": "string",
                         "question": "Name the application",
                         "raw_answer": "some name",
                     },
-                    {
+                    "is_exceptional_circumstances": {
                         "key": "is_exceptional_circumstances",
                         "answer": "No",
                         "datatype": "boolean",
                         "question": "Do you have exceptional circumstances that mean you need F680 approval in less than 30 days?",
                         "raw_answer": False,
                     },
-                ],
+                },
+                "fields_sequence": ["name", "is_exceptional_circumstances"],
             },
         }
     }

--- a/api/f680/exporter/tests/test_views.py
+++ b/api/f680/exporter/tests/test_views.py
@@ -354,45 +354,44 @@ class TestF680ApplicationViewSet:
             (
                 {
                     "sections": {
-                        "approval_type": {"type": "multiple", "fields": []},
-                        "product_information": {"type": "single", "fields": []},
+                        "approval_type": {"type": "multiple", "fields": {}},
+                        "product_information": {"type": "single", "fields": {}},
                         "user_information": {"type": "multiple", "items": []},
-                        "general_application_details": {"type": "single", "fields": []},
+                        "general_application_details": {"type": "single", "fields": {}},
                     }
                 },
                 {
                     "errors": {
                         "sections": {
-                            "approval_type": {
-                                "type": [
-                                    ErrorDetail(string='"multiple" is not a valid choice.', code="invalid_choice"),
-                                ],
-                            },
-                            "general_application_details": {
-                                "non_field_errors": [
-                                    ErrorDetail(
-                                        string="Required fields missing from section; ['name']", code="invalid"
-                                    ),
-                                ],
-                            },
                             "product_information": {
-                                "non_field_errors": [
-                                    ErrorDetail(
-                                        string="Required fields missing from section; ['product_description', 'product_name']",
-                                        code="invalid",
-                                    ),
-                                ],
+                                "fields": {
+                                    "product_name": [ErrorDetail(string="This field is required.", code="required")],
+                                    "product_description": [
+                                        ErrorDetail(string="This field is required.", code="required")
+                                    ],
+                                }
                             },
                             "user_information": {
                                 "items": {
                                     "non_field_errors": [
                                         ErrorDetail(
                                             string="Ensure this field has at least 1 elements.", code="min_length"
-                                        ),
-                                    ],
+                                        )
+                                    ]
+                                }
+                            },
+                            "general_application_details": {
+                                "fields": {"name": [ErrorDetail(string="This field is required.", code="required")]}
+                            },
+                            "approval_type": {
+                                "type": [
+                                    ErrorDetail(string='"multiple" is not a valid choice.', code="invalid_choice")
+                                ],
+                                "fields": {
+                                    "approval_choices": [ErrorDetail(string="This field is required.", code="required")]
                                 },
                             },
-                        },
+                        }
                     }
                 },
             ),

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -1,4 +1,3 @@
-from pprint import pprint
 from django.db import transaction
 from django.utils import timezone
 
@@ -44,7 +43,6 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         #   to depend on a model method, a library utility, or something else.  We should also think about
         #   commonality with StandardApplication
         application = self.get_object()
-        pprint(application.application)
         application_serializer = SubmittedApplicationJSONSerializer(data=application.application)
         application_serializer.is_valid(raise_exception=True)
 

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -1,3 +1,4 @@
+from pprint import pprint
 from django.db import transaction
 from django.utils import timezone
 
@@ -43,6 +44,7 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         #   to depend on a model method, a library utility, or something else.  We should also think about
         #   commonality with StandardApplication
         application = self.get_object()
+        pprint(application.application)
         application_serializer = SubmittedApplicationJSONSerializer(data=application.application)
         application_serializer.is_valid(raise_exception=True)
 
@@ -54,7 +56,7 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         application.sla_days = 0
         application.submitted_by = request.user.exporteruser
         application.save()
-        application.on_submit()
+        application.on_submit(application_serializer.data)
 
         apply_flagging_rules_to_case(application)
         queues_assigned = run_routing_rules(application)

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -20,18 +20,6 @@ class F680Application(BaseApplication):  # /PS-IGNORE
 
     application = models.JSONField()
 
-    def get_field_value(self, fields, field_key, raise_exception=True):
-        for field in fields:
-            if field.get("key") == field_key:
-                return field.get("raw_answer")
-        if raise_exception:
-            raise KeyError(f"Field {field_key} not found in fields for application {self.id}")
-        return None
-
-    def get_application_field_value(self, section, field_key, raise_exception=True):
-        section_fields = self.application["sections"][section]["fields"]
-        return self.get_field_value(section_fields, field_key, raise_exception=raise_exception)
-
     def get_product(self):
         if self.security_release_requests.count() == 0:
             return None

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -37,33 +37,42 @@ class F680Application(BaseApplication):  # /PS-IGNORE
             return None
         return self.security_release_requests.first().product
 
-    def on_submit(self):
-        self.name = self.get_application_field_value("general_application_details", "name")
+    def on_submit(self, application_data):
+        self.name = application_data["sections"]["general_application_details"]["fields"]["name"]["raw_answer"]
         self.save()
 
+        product_information_fields = application_data["sections"]["product_information"]["fields"]
         # Create the Product for this application - F680s just have the one
         product = Product.objects.create(
-            name=self.get_application_field_value("product_information", "product_name"),
-            description=self.get_application_field_value("product_information", "product_description"),
+            name=application_data["sections"]["product_information"]["fields"]["product_name"]["raw_answer"],
+            description=application_data["sections"]["product_information"]["fields"]["product_description"][
+                "raw_answer"
+            ],
             organisation=self.organisation,
-            security_grading=self.get_application_field_value(
-                "product_information", "security_classification", raise_exception=False
+            security_grading=(
+                product_information_fields["security_classification"]["raw_answer"]
+                if "security_classification" in product_information_fields
+                else None
             ),
         )
 
         # Create a Recipient and SecurityRelease for each.  In F680s caseworkers
         #   will advise against SecurityRelease records
-        for item in self.application["sections"]["user_information"]["items"]:
+        for item in application_data["sections"]["user_information"]["items"]:
             item_fields = item["fields"]
 
             recipient = Recipient.objects.create(
-                name=self.get_field_value(item_fields, "end_user_name"),
-                address=self.get_field_value(item_fields, "address"),
-                country_id=self.get_field_value(item_fields, "country"),
-                type=self.get_field_value(item_fields, "entity_type"),
+                name=item_fields["end_user_name"]["raw_answer"],
+                address=item_fields["address"]["raw_answer"],
+                country_id=item_fields["country"]["raw_answer"],
+                type=item_fields["entity_type"]["raw_answer"],
                 organisation=self.organisation,
-                role=self.get_field_value(item_fields, "third_party_role", raise_exception=False),
-                role_other=self.get_field_value(item_fields, "third_party_role_other", raise_exception=False),
+                role=item_fields["third_party_role"]["raw_answer"] if "third_party_role" in item_fields else None,
+                role_other=(
+                    item_fields["third_party_role_other"]["raw_answer"]
+                    if "third_party_role_other" in item_fields
+                    else None
+                ),
             )
 
             SecurityReleaseRequest.objects.create(
@@ -71,12 +80,16 @@ class F680Application(BaseApplication):  # /PS-IGNORE
                 recipient=recipient,
                 product=product,
                 application=self,
-                security_grading=self.get_field_value(item_fields, "security_classification"),
-                intended_use=self.get_field_value(item_fields, "end_user_intended_end_use"),
-                security_grading_other=self.get_field_value(
-                    item_fields, "other_security_classification", raise_exception=False
+                security_grading=item_fields["security_classification"]["raw_answer"],
+                intended_use=item_fields["end_user_intended_end_use"]["raw_answer"],
+                security_grading_other=(
+                    item_fields["other_security_classification"]["raw_answer"]
+                    if "other_security_classification" in item_fields
+                    else None
                 ),
-                approval_types=self.get_application_field_value("approval_type", "approval_choices"),
+                approval_types=application_data["sections"]["approval_type"]["fields"]["approval_choices"][
+                    "raw_answer"
+                ],
             )
 
 


### PR DESCRIPTION
### Aim

Change the F680 application JSON contract so that `fields` is a dictionary as opposed to an array.  This allows us to have a much easier time with DRF serializer validation and additionally makes lookups much easier.

Companion frontend PR: https://github.com/uktrade/lite-frontend/pull/2419

**NOTE** On merge we will need to delete existing F680 applications on dev2 as this contract change is backwards incompatible.  We could do a data migration, but since we only have test applications on a dev environment this would be overkill.

[LTD-5993](https://uktrade.atlassian.net/browse/LTD-5993)


[LTD-5993]: https://uktrade.atlassian.net/browse/LTD-5993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ