### PR TITLE
fixed csv reader and the tests

### DIFF
--- a/api/applications/management/commands/update_good_name.py
+++ b/api/applications/management/commands/update_good_name.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         csv_file = kwargs["csv_file"]
 
-        reader = csv.DictReader(csv_file)
+        reader = csv.DictReader(csv_file, escapechar=None)
         with developer_intervention(dry_run=False) as audit_log:
             for row in reader:
                 good_id = row["good_id"]


### PR DESCRIPTION
resolved issue with escaping \

looked into adding the same to party name + address but they focus on newlines and removing the escaping causes issues there, lets revisit if we hit an issue with there being escaped characters there, perhaps a shared csv reader

[LTD-6048](https://uktrade.atlassian.net/browse/LTD-6048)


[LTD-6048]: https://uktrade.atlassian.net/browse/LTD-6048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ