### PR TITLE
[Bugfix] LTD-6068 allow foi_reason to be blank

### DIFF
--- a/api/f680/exporter/serializers.py
+++ b/api/f680/exporter/serializers.py
@@ -103,7 +103,7 @@ class SectionSerializer(serializers.Serializer):
 
 class FoiDeclarationSerializer(serializers.Serializer):
     agreed_to_foi = serializers.BooleanField()
-    foi_reason = serializers.CharField(max_length=200, required=False)
+    foi_reason = serializers.CharField(max_length=200, required=False, allow_blank=True)
 
 
 class SubmittedApplicationJSONSerializer(serializers.Serializer):

--- a/api/f680/exporter/views.py
+++ b/api/f680/exporter/views.py
@@ -55,7 +55,7 @@ class F680ApplicationViewSet(viewsets.ModelViewSet):
         application.sla_days = 0
         application.submitted_by = request.user.exporteruser
         application.agreed_to_foi = application_declaration_serializer.data["agreed_to_foi"]
-        application.foi_reason = application_declaration_serializer.data["foi_reason"]
+        application.foi_reason = application_declaration_serializer.data.get("foi_reason", "")
 
         application.save()
         application.on_submit(application_json_serializer.data)


### PR DESCRIPTION
### Aim

When selecting yes on declaration you get an error `{'errors': {'foi_reason': ['This field may not be blank.']}}` so set allowed_blank to True and now this error will not appear.

[LTD-6068](https://uktrade.atlassian.net/browse/LTD-6068)


[LTD-6068]: https://uktrade.atlassian.net/browse/LTD-6068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ