### PR TITLE
Handle users clicking "finalise" multiple times

### DIFF
--- a/api/cases/models.py
+++ b/api/cases/models.py
@@ -388,6 +388,15 @@ class Case(TimestampableModel):
         from api.cases.libraries.finalise import remove_flags_on_finalisation, remove_flags_from_audit_trail
         from api.licences.models import Licence
 
+        original_case = Case.objects.select_for_update().get(pk=self.pk)
+        original_case.refresh_from_db()
+        if original_case.status.status == CaseStatusEnum.FINALISED:
+            try:
+                licence = Licence.objects.get(case=self)
+            except Licence.DoesNotExist:
+                return ""
+            return licence.id
+
         try:
             licence = Licence.objects.get_draft_licence(self)
         except Licence.DoesNotExist:

--- a/api/data_workspace/v2/tests/bdd/conftest.py
+++ b/api/data_workspace/v2/tests/bdd/conftest.py
@@ -681,6 +681,16 @@ def issue_licence(api_client, lu_case_officer, gov_headers, siel_template):
 
 
 @pytest.fixture()
+def reopen_application(
+    caseworker_change_status,
+):
+    def _reopen_application(application):
+        caseworker_change_status(application, CaseStatusEnum.REOPENED_FOR_CHANGES)
+
+    return _reopen_application
+
+
+@pytest.fixture()
 def refuse_application(
     api_client,
     lu_case_officer,
@@ -772,6 +782,16 @@ def when_the_application_is_issued_at(
     return issued_application
 
 
+@when(parsers.parse("the application is re-opened at {timestamp}"))
+def when_the_application_is_reopened_at(
+    submitted_standard_application,
+    reopen_application,
+    timestamp,
+):
+    with freeze_time(timestamp):
+        reopen_application(submitted_standard_application)
+
+
 @when(parsers.parse("the application is refused at {timestamp}"), target_fixture="refused_application")
 def when_the_application_is_refused_at(
     submitted_standard_application,
@@ -792,6 +812,7 @@ def when_the_application_is_refused_at(
 
     submitted_standard_application.refresh_from_db()
     refused_application = submitted_standard_application
+
     return refused_application
 
 

--- a/api/data_workspace/v2/tests/bdd/scenarios/licence_decisions.feature
+++ b/api/data_workspace/v2/tests/bdd/scenarios/licence_decisions.feature
@@ -79,15 +79,16 @@ Scenario: Licence issued after an appeal and re-issued again
         | f0bc0c1e-c9c5-4a90-b4c8-81a7f3cbe1e7 | 03fb08eb-1564-4b68-9336-3ca8906543f9 | issued_on_appeal  | 2024-11-29T10:20:09   | 27b79b32-1ce8-45a3-b7eb-18947bed2fcb |
 
 
-# [ISSUED, REVOKED]
+# [ISSUED, REFUSED]
 Scenario: Licence is issued and refused case
     Given a draft standard application with attributes:
         | name | value                                |
         | id   | 03fb08eb-1564-4b68-9336-3ca8906543f9 |
     When the application is submitted at 2024-10-01T11:20:15
     And the application is issued at 2024-11-22T13:35:15
-    And the application is refused at 2024-11-22T13:35:15
+    And the application is re-opened at 2024-11-22T14:01:12
+    And the application is refused at 2024-11-22T15:22:10
     Then the `licence_decisions` table has the following rows:
         | id                                   | application_id                       | decision     | decision_made_at      | licence_id                            |
         | ebd27511-7be3-4e5c-9ce9-872ad22811a1 | 03fb08eb-1564-4b68-9336-3ca8906543f9 | issued       | 2024-11-22T13:35:15   | 1b2f95c3-9cd2-4dee-b134-a79786f78c06  |
-        | 4ea4261f-03f2-4baf-8784-5ec4b352d358 | 03fb08eb-1564-4b68-9336-3ca8906543f9 | refused      | 2024-11-22T13:35:15   | None                                  |
+        | 4ea4261f-03f2-4baf-8784-5ec4b352d358 | 03fb08eb-1564-4b68-9336-3ca8906543f9 | refused      | 2024-11-22T15:22:10   | None                                  |

--- a/api/staticdata/statuses/factories.py
+++ b/api/staticdata/statuses/factories.py
@@ -1,7 +1,10 @@
 import factory
 
 from api.staticdata.statuses.enums import CaseStatusEnum
-from api.staticdata.statuses.models import CaseStatus
+from api.staticdata.statuses.models import (
+    CaseStatus,
+    CaseSubStatus,
+)
 
 
 class CaseStatusFactory(factory.django.DjangoModelFactory):
@@ -10,3 +13,10 @@ class CaseStatusFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = CaseStatus
+        django_get_or_create = ("status",)
+
+
+class CaseSubStatusFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CaseSubStatus
+        django_get_or_create = ("id",)


### PR DESCRIPTION
### Aim

This fixes an issue where a user may click the "finalisation" stage multiple times and this was creating unnecessary duplicate objects as a result and affecting Official Statistics data.

This now puts in place a lock and an extra check to make sure that any extra clicks don't duplicate data.

[LTD-6102](https://uktrade.atlassian.net/browse/LTD-6102)


[LTD-6102]: https://uktrade.atlassian.net/browse/LTD-6102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ