### PR TITLE
[LTD-6055] Ensure security_grading_other populated on F680 application submission

### DIFF
--- a/api/f680/conftest.py
+++ b/api/f680/conftest.py
@@ -496,10 +496,10 @@ def data_application_json(data_australia_release_id, data_france_release_id, dat
                     },
                     "other_security_classification": {
                         "key": "other_security_classification",
-                        "answer": "",
+                        "answer": "some other grading",
                         "datatype": "string",
                         "question": "Enter the security classification",
-                        "raw_answer": "",
+                        "raw_answer": "some other grading",
                     },
                     "suffix": {
                         "key": "suffix",

--- a/api/f680/exporter/serializers.py
+++ b/api/f680/exporter/serializers.py
@@ -74,6 +74,7 @@ class ProductInformationFieldsSerializer(serializers.Serializer):
     product_name = FieldSerializer()
     product_description = FieldSerializer()
     security_classification = FieldSerializer(required=False)
+    other_security_classification = FieldSerializer(required=False)
 
 
 class ProductInformationSerializer(serializers.Serializer):

--- a/api/f680/models.py
+++ b/api/f680/models.py
@@ -96,6 +96,11 @@ class F680Application(BaseApplication, Clonable):
                 if "security_classification" in product_information_fields
                 else None
             ),
+            security_grading_other=(
+                product_information_fields["other_security_classification"]["raw_answer"]
+                if "other_security_classification" in product_information_fields
+                else None
+            ),
         )
 
         # Create a Recipient and SecurityRelease for each.  In F680s caseworkers

--- a/api/f680/tests/test_models.py
+++ b/api/f680/tests/test_models.py
@@ -32,6 +32,7 @@ class TestF680Application:
         assert product.name == "some product name"
         assert product.description == "some product description"
         assert product.security_grading == "official"
+        assert product.security_grading_other == "some other grading"
         assert product.organisation == f680_application.organisation
 
         expected_security_release_count = len(data_application_json["sections"]["user_information"]["items"])


### PR DESCRIPTION
### Aim

This change ensures that `security_grading_other` is populated when an F680 application is submitted - if the corresponding field was present in application JSON.

[LTD-6055](https://uktrade.atlassian.net/browse/LTD-6055)


[LTD-6055]: https://uktrade.atlassian.net/browse/LTD-6055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ