### PR TITLE
[LTD-6160] Ensure search API GET endpoint returns only active case types

### DIFF
--- a/api/cases/enums.py
+++ b/api/cases/enums.py
@@ -52,10 +52,15 @@ class CaseTypeReferenceEnum:
     STANDARD_LICENCES = [SIEL, SICL, SITL]
     OPEN_LICENCES = [OIEL, OICL, OGEL, OGTCL, OGTL]
     MOD_LICENCES = [F680, EXHC, GIFT]
+    ACTIVE_CASE_TYPES = [SIEL, F680]
 
     @classmethod
     def as_list(cls):
         return [{"key": choice[0], "value": choice[1]} for choice in cls.choices]
+
+    @classmethod
+    def get_active_choices(cls):
+        return [{"key": choice[0], "value": choice[1]} for choice in cls.choices if choice[0] in cls.ACTIVE_CASE_TYPES]
 
     @classmethod
     def get_text(cls, status):

--- a/api/cases/views/search/service.py
+++ b/api/cases/views/search/service.py
@@ -15,7 +15,7 @@ from api.staticdata.countries.serializers import CountrySerializer
 
 from api.applications.models import PartyOnApplication, GoodOnApplication, DenialMatchOnApplication
 from api.audit_trail.models import Audit
-from api.cases.enums import CaseTypeEnum, AdviceType
+from api.cases.enums import CaseTypeReferenceEnum, AdviceType
 from api.cases import serializers as cases_serializers
 from api.applications.serializers.advice import AdviceSearchViewSerializer
 from api.cases.models import Case, EcjuQuery, Advice
@@ -38,7 +38,7 @@ def get_case_sub_status_list() -> List[Dict]:
 
 
 def get_case_type_type_list() -> List[Dict]:
-    return CaseTypeEnum.case_types_to_representation()
+    return CaseTypeReferenceEnum.get_active_choices()
 
 
 def get_gov_users_list():


### PR DESCRIPTION
### Aim

For companion PR making sure users can filter by case type on the queue view.

[LTD-6160](https://uktrade.atlassian.net/browse/LTD-6160)


[LTD-6160]: https://uktrade.atlassian.net/browse/LTD-6160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ