### PR TITLE
Remove, or skip, tests are no longer maintained

### DIFF
--- a/api/queries/end_user_advisories/tests/test_create_end_user_advisories.py
+++ b/api/queries/end_user_advisories/tests/test_create_end_user_advisories.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.urls import reverse
 from parameterized import parameterized
 from rest_framework import status
@@ -7,6 +9,7 @@ from api.parties.enums import PartyType
 from test_helpers.clients import DataTestClient
 
 
+@unittest.skip("Skipping failing tests that are no longer maintained")
 class EndUserAdvisoryCreateTests(DataTestClient):
     url = reverse("queries:end_user_advisories:end_user_advisories")
 

--- a/api/queries/goods_query/tests/test_goods_queries.py
+++ b/api/queries/goods_query/tests/test_goods_queries.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from rest_framework import status
@@ -18,7 +20,6 @@ from api.queries.goods_query.helpers import get_starting_status
 from api.queries.goods_query.models import GoodsQuery
 from api.staticdata.control_list_entries.helpers import get_control_list_entry
 from api.staticdata.statuses.enums import CaseStatusEnum
-from api.staticdata.statuses.libraries.get_case_status import get_case_status_by_status
 from api.staticdata.statuses.models import CaseStatus
 from test_helpers.clients import DataTestClient
 from api.users.models import Role
@@ -78,6 +79,7 @@ class ControlListClassificationsQueryCreateTests(DataTestClient):
         self.assertEqual(GoodsQuery.objects.get().status.status, CaseStatusEnum.CLC)
 
 
+@unittest.skip("Skipping failing tests that are no longer maintained")
 class ControlListClassificationsQueryRespondTests(DataTestClient):
     def setUp(self):
         super().setUp()
@@ -205,6 +207,7 @@ class ControlListClassificationsQueryRespondTests(DataTestClient):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+@unittest.skip("Skipping failing tests that are no longer maintained")
 class PvGradingQueryCreateTests(DataTestClient):
     def test_given_an_unsure_pv_graded_good_exists_when_creating_pv_grading_query_then_201_created_is_returned(self):
         pv_graded_good = GoodFactory(
@@ -281,6 +284,7 @@ class PvGradingQueryCreateTests(DataTestClient):
         self.assertEqual(GoodsQuery.objects.count(), 0)
 
 
+@unittest.skip("Skipping failing tests that are no longer maintained")
 class CombinedPvGradingAndClcQuery(DataTestClient):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
### Aim

These tests start failing due to changes in the routing engine as it currently ignores anything that is either a Standard application or an F680 application

This prepares for routing changes that skip these application types

[LTD-6092](https://uktrade.atlassian.net/browse/LTD-6092)


[LTD-6092]: https://uktrade.atlassian.net/browse/LTD-6092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ