### PR TITLE
Remove, or skip, tests that are no longer maintained

### DIFF
--- a/api/queries/goods_query/tests/test_goods_queries.py
+++ b/api/queries/goods_query/tests/test_goods_queries.py
@@ -25,6 +25,7 @@ from test_helpers.clients import DataTestClient
 from api.users.models import Role
 
 
+@unittest.skip("Skipping failing tests that are no longer maintained")
 class ControlListClassificationsQueryCreateTests(DataTestClient):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
### Aim

This was missed off of a previous commit that skipped a bunch of failing tests

These tests start failing due to changes in the routing engine as it currently ignores anything that is not either a Standard application or an F680 application

This prepares for routing changes that skip these applications type

[LTD-6092](https://uktrade.atlassian.net/browse/LTD-6092)


[LTD-6092]: https://uktrade.atlassian.net/browse/LTD-6092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ