### PR TITLE
LTD-6085 Use mixin for outcomes and recommendation viewsets common methods

### DIFF
--- a/api/f680/caseworker/filters.py
+++ b/api/f680/caseworker/filters.py
@@ -1,6 +1,12 @@
 from rest_framework import filters
+from api.cases.enums import CaseTypeSubTypeEnum
 
 
 class CurrentCaseFilter(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         return queryset.filter(case_id=view.kwargs["pk"])
+
+
+class F680CaseFilter(filters.BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        return queryset.filter(case__case_type__sub_type=CaseTypeSubTypeEnum.F680)

--- a/api/f680/caseworker/mixins.py
+++ b/api/f680/caseworker/mixins.py
@@ -12,6 +12,7 @@ class F680CaseworkerApplicationMixin:
     filter_backends = (filters.CurrentCaseFilter, filters.F680CaseFilter)
 
     def initial(self, request, *args, **kwargs):
+        self.perform_authentication(request)
         try:
             self.application = get_application(self.kwargs["pk"])
         except (ObjectDoesNotExist, NotFoundError):

--- a/api/f680/caseworker/mixins.py
+++ b/api/f680/caseworker/mixins.py
@@ -9,15 +9,14 @@ from api.f680.caseworker import filters
 
 class F680CaseworkerApplicationMixin:
     authentication_classes = (GovAuthentication,)
-    filter_backends = (filters.CurrentCaseFilter,)
+    filter_backends = (filters.CurrentCaseFilter, filters.F680CaseFilter)
 
-    def dispatch(self, request, *args, **kwargs):
+    def initial(self, request, *args, **kwargs):
         try:
             self.application = get_application(self.kwargs["pk"])
         except (ObjectDoesNotExist, NotFoundError):
             raise Http404()
-
-        return super().dispatch(request, *args, **kwargs)
+        return super().initial(request, *args, **kwargs)
 
     def get_case(self):
         return self.application

--- a/api/f680/caseworker/mixins.py
+++ b/api/f680/caseworker/mixins.py
@@ -1,0 +1,23 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
+
+from api.core.authentication import GovAuthentication
+from api.core.exceptions import NotFoundError
+from api.applications.libraries.get_applications import get_application
+from api.f680.caseworker import filters
+
+
+class F680CaseworkerApplicationMixin:
+    authentication_classes = (GovAuthentication,)
+    filter_backends = (filters.CurrentCaseFilter,)
+
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            self.application = get_application(self.kwargs["pk"])
+        except (ObjectDoesNotExist, NotFoundError):
+            raise Http404()
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_case(self):
+        return self.application

--- a/api/f680/caseworker/urls.py
+++ b/api/f680/caseworker/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from api.f680.caseworker.views import F680RecommendationViewSet, F680OutcomeViewSet, F680OutcomeDocumenViewSet
+from api.f680.caseworker.views import F680RecommendationViewSet, F680OutcomeViewSet, F680OutcomeDocumentViewSet
 
 app_name = "caseworker_f680"
 
@@ -37,7 +37,7 @@ urlpatterns = [
     ),
     path(
         "<uuid:pk>/outcome_document/",
-        F680OutcomeDocumenViewSet.as_view(
+        F680OutcomeDocumentViewSet.as_view(
             {
                 "get": "list",
             }

--- a/api/f680/caseworker/views.py
+++ b/api/f680/caseworker/views.py
@@ -135,7 +135,7 @@ class F680OutcomeViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
         return HttpResponse(status=response.status_code)
 
 
-class F680OutcomeDocumenViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
+class F680OutcomeDocumentViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
     queryset = GeneratedCaseDocument.objects.all()
     serializer_class = serializers.OutcomeDocumentSerializer
     lookup_url_kwarg = "case_id"

--- a/api/f680/caseworker/views.py
+++ b/api/f680/caseworker/views.py
@@ -1,43 +1,27 @@
-from django.core.exceptions import ObjectDoesNotExist
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from api.cases.generated_documents.models import GeneratedCaseDocument
 from rest_framework import status, viewsets
 from rest_framework.response import Response
 
-from api.applications.libraries.get_applications import get_application
 from api.audit_trail import service as audit_trail_service
 from api.audit_trail.enums import AuditType
-from api.core.authentication import GovAuthentication
-from api.core.exceptions import NotFoundError
 
 from api.f680.models import Recommendation, SecurityReleaseOutcome
-from api.f680.caseworker import filters
 from api.f680.caseworker import permissions
 from api.f680.caseworker import serializers
 from api.f680.caseworker import read_only_serializers
 
+from .mixins import F680CaseworkerApplicationMixin
 
-class F680RecommendationViewSet(viewsets.ModelViewSet):
-    authentication_classes = (GovAuthentication,)
+
+class F680RecommendationViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
     permission_classes = [
         permissions.CaseCanAcceptRecommendations & permissions.CaseCanUserMakeRecommendations | permissions.ReadOnly
     ]
-    filter_backends = (filters.CurrentCaseFilter,)
+
     queryset = Recommendation.objects.all()
     serializer_class = serializers.F680RecommendationSerializer
     pagination_class = None
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: Review dispatch methods in LTD-6085
-        try:
-            self.application = get_application(self.kwargs["pk"])
-        except (ObjectDoesNotExist, NotFoundError):
-            raise Http404()
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_case(self):
-        return self.application
 
     def prepare_data(self, request_data):
         return [
@@ -96,26 +80,12 @@ class F680RecommendationViewSet(viewsets.ModelViewSet):
         return HttpResponse(status=status.HTTP_204_NO_CONTENT)
 
 
-class F680OutcomeViewSet(viewsets.ModelViewSet):
-    authentication_classes = (GovAuthentication,)
+class F680OutcomeViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
     permission_classes = [permissions.CaseReadyForOutcome & permissions.CanUserMakeOutcome | permissions.ReadOnly]
-    filter_backends = (filters.CurrentCaseFilter,)
     queryset = SecurityReleaseOutcome.objects.all()
     serializer_class = serializers.SecurityReleaseOutcomeSerializer
     lookup_url_kwarg = "outcome_id"
     pagination_class = None
-
-    def dispatch(self, request, *args, **kwargs):
-        # TODO: Review dispatch methods in LTD-6085
-        try:
-            self.application = get_application(self.kwargs["pk"])
-        except (ObjectDoesNotExist, NotFoundError):
-            raise Http404()
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_case(self):
-        return self.application
 
     def prepare_data(self, request_data):
         return {
@@ -165,18 +135,8 @@ class F680OutcomeViewSet(viewsets.ModelViewSet):
         return HttpResponse(status=response.status_code)
 
 
-class F680OutcomeDocumenViewSet(viewsets.ModelViewSet):
-    authentication_classes = (GovAuthentication,)
-    filter_backends = (filters.CurrentCaseFilter,)
+class F680OutcomeDocumenViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
     queryset = GeneratedCaseDocument.objects.all()
     serializer_class = serializers.OutcomeDocumentSerializer
     lookup_url_kwarg = "case_id"
     pagination_class = None
-
-    def dispatch(self, request, *args, **kwargs):
-        try:
-            self.application = get_application(self.kwargs["pk"])
-        except (ObjectDoesNotExist, NotFoundError):
-            raise Http404()
-
-        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
### Aim

There is some reusanle functionality in the F680s recommendation/outcome views so this has been pulled out into a mixin and I've also used a backend filter so that only F680 cases are filtered

[LTD-6085](https://uktrade.atlassian.net/browse/LTD-6085)

[LTD-6085]: https://uktrade.atlassian.net/browse/LTD-6085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ