### PR TITLE
Use a single manifest for licence application types

### DIFF
--- a/api/applications/application_manifest.py
+++ b/api/applications/application_manifest.py
@@ -10,21 +10,8 @@ from gov_notify.enums import TemplateType
 
 
 @application_manifest_registry.register(CaseTypeReferenceEnum.EXPORT_LICENCE)
-class ExportLicenceApplicationManifest(BaseManifest):
-    model_class = StandardApplication
-    # Warning: Caseworker and exporter currently share the same serializer which could lead
-    # to internal data unintentional being shared with the exporter
-    # TODO: Create a dedicated serializer for the exporter
-    caseworker_serializers = {"view": StandardApplicationViewSerializer}
-    exporter_serializers = {"view": StandardApplicationViewSerializer}
-    features = {
-        ApplicationFeatures.LICENCE_ISSUE: True,
-        ApplicationFeatures.ROUTE_TO_COUNTERSIGNING_QUEUES: True,
-    }
-
-
 @application_manifest_registry.register(CaseTypeReferenceEnum.SIEL)
-class StandardApplicationManifest(BaseManifest):
+class ApplicationManifest(BaseManifest):
     model_class = StandardApplication
     # Warning: Caseworker and exporter currently share the same serializer which could lead
     # to internal data unintentional being shared with the exporter

--- a/api/applications/tests/test_application_manifest.py
+++ b/api/applications/tests/test_application_manifest.py
@@ -1,7 +1,8 @@
-from api.applications.application_manifest import StandardApplicationManifest
+from api.applications.application_manifest import ApplicationManifest
 from api.cases.enums import ApplicationFeatures
 
 
 def test_has_feature():
-    manifest = StandardApplicationManifest()
+    manifest = ApplicationManifest()
     assert manifest.has_feature(ApplicationFeatures.LICENCE_ISSUE) is True
+    assert manifest.has_feature(ApplicationFeatures.ROUTE_TO_COUNTERSIGNING_QUEUES) is True

--- a/api/cases/tests/test_models.py
+++ b/api/cases/tests/test_models.py
@@ -11,8 +11,11 @@ from django.test import TransactionTestCase
 from api.audit_trail.enums import AuditType
 from api.audit_trail.models import Audit
 from api.audit_trail.serializers import AuditSerializer
-from api.applications.application_manifest import StandardApplicationManifest
-from api.applications.tests.factories import StandardApplicationFactory
+from api.applications.application_manifest import ApplicationManifest
+from api.applications.tests.factories import (
+    ExportLicenceApplicationFactory,
+    StandardApplicationFactory,
+)
 from api.cases.models import (
     BadSubStatus,
     Case,
@@ -216,7 +219,8 @@ class CaseTests(DataTestClient):
 
     @parameterized.expand(
         [
-            (StandardApplicationFactory, StandardApplicationManifest),
+            (StandardApplicationFactory, ApplicationManifest),
+            (ExportLicenceApplicationFactory, ApplicationManifest),
             (SubmittedF680ApplicationFactory, F680ApplicationManifest),
         ]
     )
@@ -229,6 +233,7 @@ class CaseTests(DataTestClient):
     @parameterized.expand(
         [
             (StandardApplicationFactory,),
+            (ExportLicenceApplicationFactory,),
             (SubmittedF680ApplicationFactory,),
         ]
     )


### PR DESCRIPTION
### Aim

Allow the Export Licence type to be pushed through the caseworker side by using a single manifest file for both Export Licence and Standard Licence.

If they diverge in the future I'll split them out again, however this is to make sure that these stay inline until that point as updates were made to the StandardApplication at one point that broke the Export Licence journey.

[LTD-6212](https://uktrade.atlassian.net/browse/LTD-6212)
