### PR TITLE
LTD-6228 fix permission implementation to enable get request to view case detail

### DIFF
--- a/api/f680/caseworker/tests/test_views.py
+++ b/api/f680/caseworker/tests/test_views.py
@@ -147,6 +147,21 @@ class TestF680RecommendationViewSet:
             for item in Recommendation.objects.filter(case=f680_application)
         ]
 
+    # MOD-ECJU call this endpoint when they GET Case detail so we need to check they can get a response
+    # even though they don't make recommendations and a case can be without a recommendation.
+    @freeze_time("2025-01-01 12:00:01")
+    def test_GET_recommendation_details_mod_ecju_caseworker_success(
+        self, get_hawk_client, url, team_case_advisor, team_case_advisor_headers, organisation
+    ):
+        f680_application = SubmittedF680ApplicationFactory(organisation=organisation)
+        gov_user = team_case_advisor(TeamIdEnum.MOD_ECJU)
+
+        headers = {"HTTP_GOV_USER_TOKEN": user_to_token(gov_user.baseuser_ptr)}
+        api_client, target_url = get_hawk_client("GET", url(f680_application))
+        response = api_client.get(target_url, **headers)
+
+        assert response.status_code == 200
+
     def test_GET_recommendation_raises_notfound_error(
         self, get_hawk_client, get_f680_application, team_case_advisor_headers
     ):

--- a/api/f680/caseworker/views.py
+++ b/api/f680/caseworker/views.py
@@ -16,8 +16,7 @@ from api.f680.caseworker.mixins import F680CaseworkerApplicationMixin
 
 class F680RecommendationViewSet(F680CaseworkerApplicationMixin, viewsets.ModelViewSet):
     permission_classes = [
-        permissions.CaseCanAcceptRecommendations,
-        permissions.CaseCanUserMakeRecommendations | permissions.ReadOnly,
+        permissions.CaseCanAcceptRecommendations & permissions.CaseCanUserMakeRecommendations | permissions.ReadOnly
     ]
     serializer_class = serializers.F680RecommendationSerializer
     pagination_class = None


### PR DESCRIPTION
### Aim

In a previous PR I had changed the permissions but not re-implemented them correctly.  This PR corrects that and now enables users to view read only version of the case even if they can't make a recommendation on it.

[LTD-6228](https://uktrade.atlassian.net/browse/LTD-6228)


[LTD-6228]: https://uktrade.atlassian.net/browse/LTD-6228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ