### PR TITLE
Allow quantity and value to be null when creating a good on application

### DIFF
--- a/api/applications/models.py
+++ b/api/applications/models.py
@@ -556,7 +556,6 @@ class GoodOnApplication(AbstractGoodOnApplication, Clonable):
 
     good = models.ForeignKey(Good, related_name="goods_on_application", on_delete=models.CASCADE)
 
-    # Every application except Exhibition applications contains the following data, as a result these can be null
     quantity = models.FloatField(null=True, blank=True, default=None)
     unit = models.CharField(choices=Units.choices, max_length=50, null=True, blank=True, default=None)
     value = models.DecimalField(max_digits=15, decimal_places=2, null=True, blank=True, default=None)

--- a/api/goods/serializers.py
+++ b/api/goods/serializers.py
@@ -104,7 +104,7 @@ class FirearmDetailsSerializer(serializers.ModelSerializer):
     deactivation_standard = serializers.CharField(allow_blank=True, required=False)
     deactivation_standard_other = serializers.CharField(allow_blank=True, required=False, allow_null=True)
     number_of_items = serializers.IntegerField(
-        allow_null=False,
+        allow_null=True,
         required=False,
         error_messages={"null": "Enter the number of items", "invalid": "Number of items must be valid"},
     )


### PR DESCRIPTION
### Aim

For OIELs and our "single user journey" applications there will be no quantity nor value provided as part of the application process.

This loosens the requirements for these fields.

[LTD-6030](https://uktrade.atlassian.net/browse/LTD-6030)


[LTD-6030]: https://uktrade.atlassian.net/browse/LTD-6030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ